### PR TITLE
Fix warning by declaring and setting variable on the same line

### DIFF
--- a/internal/provider/integration_asana_resource.go
+++ b/internal/provider/integration_asana_resource.go
@@ -322,8 +322,7 @@ func (r *IntegrationAsanaResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_aws_resource.go
+++ b/internal/provider/integration_aws_resource.go
@@ -357,8 +357,7 @@ func (r *IntegrationAwsResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_azure_ad_resource.go
+++ b/internal/provider/integration_azure_ad_resource.go
@@ -316,8 +316,7 @@ func (r *IntegrationAzureAdResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_bamboo_hr_resource.go
+++ b/internal/provider/integration_bamboo_hr_resource.go
@@ -327,8 +327,7 @@ func (r *IntegrationBambooHrResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_baton_resource.go
+++ b/internal/provider/integration_baton_resource.go
@@ -241,8 +241,7 @@ func (r *IntegrationBatonResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_buildkite_resource.go
+++ b/internal/provider/integration_buildkite_resource.go
@@ -327,8 +327,7 @@ func (r *IntegrationBuildkiteResource) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_cloudamqp_resource.go
+++ b/internal/provider/integration_cloudamqp_resource.go
@@ -322,8 +322,7 @@ func (r *IntegrationCloudamqpResource) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_cloudflare_resource.go
+++ b/internal/provider/integration_cloudflare_resource.go
@@ -327,8 +327,7 @@ func (r *IntegrationCloudflareResource) Delete(ctx context.Context, req resource
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_cloudflare_zero_trust_resource.go
+++ b/internal/provider/integration_cloudflare_zero_trust_resource.go
@@ -327,8 +327,7 @@ func (r *IntegrationCloudflareZeroTrustResource) Delete(ctx context.Context, req
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_confluence_resource.go
+++ b/internal/provider/integration_confluence_resource.go
@@ -332,8 +332,7 @@ func (r *IntegrationConfluenceResource) Delete(ctx context.Context, req resource
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_coupa_resource.go
+++ b/internal/provider/integration_coupa_resource.go
@@ -332,8 +332,7 @@ func (r *IntegrationCoupaResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_datadog_resource.go
+++ b/internal/provider/integration_datadog_resource.go
@@ -333,8 +333,7 @@ func (r *IntegrationDatadogResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_docusign_resource.go
+++ b/internal/provider/integration_docusign_resource.go
@@ -321,8 +321,7 @@ func (r *IntegrationDocusignResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_duo_resource.go
+++ b/internal/provider/integration_duo_resource.go
@@ -334,8 +334,7 @@ func (r *IntegrationDuoResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_expensify_resource.go
+++ b/internal/provider/integration_expensify_resource.go
@@ -328,8 +328,7 @@ func (r *IntegrationExpensifyResource) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_github_enterprise_resource.go
+++ b/internal/provider/integration_github_enterprise_resource.go
@@ -327,8 +327,7 @@ func (r *IntegrationGithubEnterpriseResource) Delete(ctx context.Context, req re
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_github_resource.go
+++ b/internal/provider/integration_github_resource.go
@@ -327,8 +327,7 @@ func (r *IntegrationGithubResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_gitlab_resource.go
+++ b/internal/provider/integration_gitlab_resource.go
@@ -327,8 +327,7 @@ func (r *IntegrationGitlabResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_google_cloud_platform_resource.go
+++ b/internal/provider/integration_google_cloud_platform_resource.go
@@ -322,8 +322,7 @@ func (r *IntegrationGoogleCloudPlatformResource) Delete(ctx context.Context, req
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_google_identity_platform_resource.go
+++ b/internal/provider/integration_google_identity_platform_resource.go
@@ -332,8 +332,7 @@ func (r *IntegrationGoogleIdentityPlatformResource) Delete(ctx context.Context, 
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_google_workspace_resource.go
+++ b/internal/provider/integration_google_workspace_resource.go
@@ -337,8 +337,7 @@ func (r *IntegrationGoogleWorkspaceResource) Delete(ctx context.Context, req res
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_gusto_resource.go
+++ b/internal/provider/integration_gusto_resource.go
@@ -321,8 +321,7 @@ func (r *IntegrationGustoResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_jira_cloud_resource.go
+++ b/internal/provider/integration_jira_cloud_resource.go
@@ -332,8 +332,7 @@ func (r *IntegrationJiraCloudResource) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_jumpcloud_resource.go
+++ b/internal/provider/integration_jumpcloud_resource.go
@@ -322,8 +322,7 @@ func (r *IntegrationJumpcloudResource) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_linear_resource.go
+++ b/internal/provider/integration_linear_resource.go
@@ -322,8 +322,7 @@ func (r *IntegrationLinearResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_netsuite_resource.go
+++ b/internal/provider/integration_netsuite_resource.go
@@ -343,8 +343,7 @@ func (r *IntegrationNetsuiteResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_okta_resource.go
+++ b/internal/provider/integration_okta_resource.go
@@ -337,8 +337,7 @@ func (r *IntegrationOktaResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_onelogin_resource.go
+++ b/internal/provider/integration_onelogin_resource.go
@@ -332,8 +332,7 @@ func (r *IntegrationOneloginResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_opsgenie_resource.go
+++ b/internal/provider/integration_opsgenie_resource.go
@@ -322,8 +322,7 @@ func (r *IntegrationOpsgenieResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_panther_resource.go
+++ b/internal/provider/integration_panther_resource.go
@@ -328,8 +328,7 @@ func (r *IntegrationPantherResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_ramp_resource.go
+++ b/internal/provider/integration_ramp_resource.go
@@ -316,8 +316,7 @@ func (r *IntegrationRampResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_salesforce_resource.go
+++ b/internal/provider/integration_salesforce_resource.go
@@ -327,8 +327,7 @@ func (r *IntegrationSalesforceResource) Delete(ctx context.Context, req resource
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_sendgrid_resource.go
+++ b/internal/provider/integration_sendgrid_resource.go
@@ -322,8 +322,7 @@ func (r *IntegrationSendgridResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_sentry_resource.go
+++ b/internal/provider/integration_sentry_resource.go
@@ -328,8 +328,7 @@ func (r *IntegrationSentryResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_slack_resource.go
+++ b/internal/provider/integration_slack_resource.go
@@ -322,8 +322,7 @@ func (r *IntegrationSlackResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_snowflake_resource.go
+++ b/internal/provider/integration_snowflake_resource.go
@@ -337,8 +337,7 @@ func (r *IntegrationSnowflakeResource) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_tailscale_resource.go
+++ b/internal/provider/integration_tailscale_resource.go
@@ -328,8 +328,7 @@ func (r *IntegrationTailscaleResource) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_twingate_resource.go
+++ b/internal/provider/integration_twingate_resource.go
@@ -328,8 +328,7 @@ func (r *IntegrationTwingateResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_ukg_resource.go
+++ b/internal/provider/integration_ukg_resource.go
@@ -338,8 +338,7 @@ func (r *IntegrationUkgResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{

--- a/internal/provider/integration_zendesk_resource.go
+++ b/internal/provider/integration_zendesk_resource.go
@@ -333,8 +333,7 @@ func (r *IntegrationZendeskResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	var connectorServiceDeleteRequest *shared.ConnectorServiceDeleteRequest
-	connectorServiceDeleteRequest = &shared.ConnectorServiceDeleteRequest{}
+	connectorServiceDeleteRequest := &shared.ConnectorServiceDeleteRequest{}
 	appID := data.AppID.ValueString()
 	id := data.ID.ValueString()
 	request := operations.C1APIAppV1ConnectorServiceDeleteRequest{


### PR DESCRIPTION
This PR changes to declaring and setting the variable on a single line, instead of declaring the variable on one line and setting it on the next line. 