### PR TITLE
More provider cleanup

### DIFF
--- a/examples/resources/conductorone_catalog/catalog.tf
+++ b/examples/resources/conductorone_catalog/catalog.tf
@@ -1,9 +1,6 @@
 resource "conductorone_catalog" "test_catalog" {
-  display_name = "terraform created catalog"
-  description  = "terraform test"
-  owner_ids = [
-    data.conductorone_user.my_user.id
-  ]
+  display_name        = "terraform created catalog"
+  description         = "terraform test"
   visible_to_everyone = "false"
   published           = "true"
 }

--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -122,7 +122,8 @@ func (r *AppResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Description: `The monthlyCostUsd field.`,
 			},
 			"owners": schema.ListAttribute{
-				Required:    true,
+				Computed:    true,
+				Optional:    true,
 				ElementType: types.StringType,
 				Description: `The owners field.`,
 			},

--- a/internal/provider/catalog_requestable_entries_resource.go
+++ b/internal/provider/catalog_requestable_entries_resource.go
@@ -3,16 +3,18 @@
 package provider
 
 import (
-	"context"
-	"fmt"
 	"conductorone/internal/sdk"
 	"conductorone/internal/sdk/pkg/models/operations"
+	"context"
+	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -49,26 +51,29 @@ func (r *CatalogRequestableEntriesResource) Schema(ctx context.Context, req reso
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
 				},
-				Optional: true,
+				Required: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"app_id": schema.StringAttribute{
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},
-							Optional:    true,
+							Required: true,
 							Description: `The appId field.`,
 						},
 						"id": schema.StringAttribute{
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},
-							Optional:    true,
+							Required: true,
 							Description: `The id field.`,
 						},
 					},
 				},
 				Description: `The appEntitlements field.`,
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
 			},
 			"catalog_id": schema.StringAttribute{
 				PlanModifiers: []planmodifier.String{

--- a/internal/provider/catalog_resource.go
+++ b/internal/provider/catalog_resource.go
@@ -44,7 +44,6 @@ type CatalogResourceModel struct {
 	DisplayName              types.String                                         `tfsdk:"display_name"`
 	Expanded                 []RequestCatalogManagementServiceGetResponseExpanded `tfsdk:"expanded"`
 	ID                       types.String                                         `tfsdk:"id"`
-	OwnerIds                 []types.String                                       `tfsdk:"owner_ids"`
 	Published                types.Bool                                           `tfsdk:"published"`
 	RequestCatalogExpandMask *RequestCatalogExpandMask                            `tfsdk:"request_catalog_expand_mask"`
 	UpdatedAt                types.String                                         `tfsdk:"updated_at"`
@@ -260,11 +259,6 @@ func (r *CatalogResource) Schema(ctx context.Context, req resource.SchemaRequest
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: `The id field.`,
-			},
-			"owner_ids": schema.ListAttribute{
-				Optional:    true,
-				ElementType: types.StringType,
-				Description: `The ownerIds field.`,
 			},
 			"published": schema.BoolAttribute{
 				Computed:    true,

--- a/internal/provider/catalog_resource_sdk.go
+++ b/internal/provider/catalog_resource_sdk.go
@@ -31,10 +31,6 @@ func (r *CatalogResourceModel) ToCreateSDKType() *shared.RequestCatalogManagemen
 	} else {
 		displayName = nil
 	}
-	ownerIds := make([]string, 0)
-	for _, ownerIdsItem := range r.OwnerIds {
-		ownerIds = append(ownerIds, ownerIdsItem.ValueString())
-	}
 	published := new(bool)
 	if !r.Published.IsUnknown() && !r.Published.IsNull() {
 		*published = r.Published.ValueBool()
@@ -51,7 +47,6 @@ func (r *CatalogResourceModel) ToCreateSDKType() *shared.RequestCatalogManagemen
 		RequestCatalogExpandMask: requestCatalogExpandMask,
 		Description:              description,
 		DisplayName:              displayName,
-		OwnerIds:                 ownerIds,
 		Published:                published,
 		VisibleToEveryone:        visibleToEveryone,
 	}

--- a/internal/provider/catalog_visibility_bindings_resource.go
+++ b/internal/provider/catalog_visibility_bindings_resource.go
@@ -3,16 +3,18 @@
 package provider
 
 import (
-	"context"
-	"fmt"
 	"conductorone/internal/sdk"
 	"conductorone/internal/sdk/pkg/models/operations"
+	"context"
+	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -49,26 +51,29 @@ func (r *CatalogVisibilityBindingsResource) Schema(ctx context.Context, req reso
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
 				},
-				Optional: true,
+				Required: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"app_id": schema.StringAttribute{
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},
-							Optional:    true,
+							Required: true,
 							Description: `The appId field.`,
 						},
 						"id": schema.StringAttribute{
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},
-							Optional:    true,
+							Required: true,
 							Description: `The id field.`,
 						},
 					},
 				},
 				Description: `The accessEntitlements field.`,
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
 			},
 			"catalog_id": schema.StringAttribute{
 				PlanModifiers: []planmodifier.String{

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -74,8 +74,7 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Description: `The description field.`,
 			},
 			"display_name": schema.StringAttribute{
-				Computed:    true,
-				Optional:    true,
+				Required: true,
 				Description: `The displayName field.`,
 			},
 			"id": schema.StringAttribute{


### PR DESCRIPTION
- Sets all fields to required for catalog entitlement bindings
- Adds a validator to ensure that a catalog binding includes at least a single entitlement
- Sets display name to required for policies
- Changes owners to optional for apps