### PR TITLE
Fix app_entitlement example, and catalog update request body fields

### DIFF
--- a/docs/resources/app_entitlement.md
+++ b/docs/resources/app_entitlement.md
@@ -24,7 +24,9 @@ resource "conductorone_app_entitlement" "okta_test_admin" {
   provision_policy = {
     manual_provision = {
       instructions = "Please contact the IT department to request this entitlement."
-      user_ids     = data.conductorone_user.my_user.id
+      user_ids = [
+        data.conductorone_user.my_user.id
+      ]
     }
   }
 }

--- a/examples/resources/conductorone_app_entitlement/app_entitlement.tf
+++ b/examples/resources/conductorone_app_entitlement/app_entitlement.tf
@@ -5,7 +5,9 @@ resource "conductorone_app_entitlement" "okta_test_admin" {
   provision_policy = {
     manual_provision = {
       instructions = "Please contact the IT department to request this entitlement."
-      user_ids     = data.conductorone_user.my_user.id
+      user_ids = [
+        data.conductorone_user.my_user.id
+      ]
     }
   }
 }

--- a/internal/provider/app_entitlement_resource_sdk.go
+++ b/internal/provider/app_entitlement_resource_sdk.go
@@ -373,6 +373,11 @@ func (r *AppEntitlementResourceModel) RefreshFromGetResponse(resp *shared.AppEnt
 	} else {
 		r.SystemBuiltin = types.BoolNull()
 	}
+	if resp.UpdatedAt != nil {
+		r.UpdatedAt = types.StringValue(resp.UpdatedAt.Format(time.RFC3339))
+	} else {
+		r.UpdatedAt = types.StringNull()
+	}
 }
 
 func (r *AppEntitlementResourceModel) RefreshFromCreateResponse(resp *shared.AppEntitlement) {

--- a/internal/provider/catalog_resource_sdk.go
+++ b/internal/provider/catalog_resource_sdk.go
@@ -297,12 +297,6 @@ func (r *CatalogResourceModel) ToUpdateSDKType() *shared.RequestCatalog {
 	} else {
 		published = nil
 	}
-	updatedAt1 := new(time.Time)
-	if !r.UpdatedAt.IsUnknown() && !r.UpdatedAt.IsNull() {
-		*updatedAt1, _ = time.Parse(time.RFC3339Nano, r.UpdatedAt.ValueString())
-	} else {
-		updatedAt1 = nil
-	}
 	visibleToEveryone := new(bool)
 	if !r.VisibleToEveryone.IsUnknown() && !r.VisibleToEveryone.IsNull() {
 		*visibleToEveryone = r.VisibleToEveryone.ValueBool()
@@ -318,7 +312,6 @@ func (r *CatalogResourceModel) ToUpdateSDKType() *shared.RequestCatalog {
 		DisplayName:        displayName1,
 		ID:                 id1,
 		Published:          published,
-		UpdatedAt:          updatedAt1,
 		VisibleToEveryone:  visibleToEveryone,
 	}
 	return &out


### PR DESCRIPTION
This fixes the app_entitlement example from being improperly formatted, and also removes the `updated_at` field from being set in the request_catalog resource request body.