### PR TITLE
Adds deleted_at field to catalog resource

### DIFF
--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -47,6 +47,7 @@ resource "conductorone_catalog" "test_catalog" {
 - `created_at` (String)
 - `created_by_user_id` (String) The createdByUserId field.
 - `created_by_user_path` (String) The createdByUserPath field.
+- `deleted_at` (String)
 - `expanded` (Attributes List) The expanded field. (see [below for nested schema](#nestedatt--expanded))
 - `id` (String) The id field.
 - `request_catalog_expand_mask` (Attributes) The RequestCatalogExpandMask message. (see [below for nested schema](#nestedatt--request_catalog_expand_mask))

--- a/internal/provider/catalog_resource_sdk.go
+++ b/internal/provider/catalog_resource_sdk.go
@@ -542,6 +542,11 @@ func (r *CatalogResourceModel) RefreshFromGetResponse(resp *shared.RequestCatalo
 	} else {
 		r.VisibleToEveryone = types.BoolNull()
 	}
+	if resp.DeletedAt != nil {
+		r.DeletedAt = types.StringValue(resp.UpdatedAt.Format(time.RFC3339))
+	} else {
+		r.DeletedAt = types.StringNull()
+	}
 }
 
 func (r *CatalogResourceModel) RefreshFromCreateResponse(resp *shared.RequestCatalog) {

--- a/internal/sdk/pkg/models/shared/requestcatalog.go
+++ b/internal/sdk/pkg/models/shared/requestcatalog.go
@@ -15,6 +15,7 @@ type RequestCatalog struct {
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 	// The createdByUserId field.
 	CreatedByUserID *string `json:"createdByUserId,omitempty"`
+	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 	// The description field.
 	Description *string `json:"description,omitempty"`
 	// The displayName field.

--- a/internal/sdk/pkg/models/shared/requestcatalog.go
+++ b/internal/sdk/pkg/models/shared/requestcatalog.go
@@ -14,8 +14,8 @@ type RequestCatalog struct {
 	AppIds    []string   `json:"appIds,omitempty"`
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 	// The createdByUserId field.
-	CreatedByUserID *string `json:"createdByUserId,omitempty"`
-	DeletedAt *time.Time `json:"deletedAt,omitempty"`
+	CreatedByUserID *string    `json:"createdByUserId,omitempty"`
+	DeletedAt       *time.Time `json:"deletedAt,omitempty"`
 	// The description field.
 	Description *string `json:"description,omitempty"`
 	// The displayName field.


### PR DESCRIPTION
This adds the `deleted_at` field to the catalog resource, which lets us properly handle detecting when a request catalog has been deleted.