### PR TITLE
App and Policy data sources are now gettable by name case insensitively

### DIFF
--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -9,7 +9,7 @@ description: |-
 
 App DataSource
 
-The App datasource allows you to retrieve an App instance by `display_name` (case sensitive), or `id` in ConductorOne.
+The App datasource allows you to retrieve an App instance by `display_name` (case insensitive), or `id` in ConductorOne.
 
 ## Example Usage
 

--- a/docs/data-sources/policy.md
+++ b/docs/data-sources/policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Policy DataSource
 
-The Policy datasource allows you to retrieve a Policy instance by `display_name` (case sensitive), or `id` in ConductorOne.
+The Policy datasource allows you to retrieve a Policy instance by `display_name` (case insensitive), or `id` in ConductorOne.
 
 ## Example Usage
 

--- a/templates/data-sources/app.md.tmpl
+++ b/templates/data-sources/app.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-The App datasource allows you to retrieve an App instance by `display_name` (case sensitive), or `id` in ConductorOne.
+The App datasource allows you to retrieve an App instance by `display_name` (case insensitive), or `id` in ConductorOne.
 
 ## Example Usage
 

--- a/templates/data-sources/policy.md.tmpl
+++ b/templates/data-sources/policy.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-The Policy datasource allows you to retrieve a Policy instance by `display_name` (case sensitive), or `id` in ConductorOne.
+The Policy datasource allows you to retrieve a Policy instance by `display_name` (case insensitive), or `id` in ConductorOne.
 
 ## Example Usage
 


### PR DESCRIPTION
This PR changes the documentation to state that you can get Apps and Policies by name case insensitively now. 