### PR TITLE
Fix updating policies and descriptions on the App resource

### DIFF
--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -272,7 +272,7 @@ func (r *AppResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	var updateAppRequest *shared.UpdateAppRequest
 	app := data.ToUpdateSDKType()
-	updateMask := "displayName,monthlyCostUsd"
+	updateMask := "displayName,monthlyCostUsd,description,grantPolicyId,revokePolicyId,certifyPolicyId"
 	updateAppRequest = &shared.UpdateAppRequest{
 		App:        app,
 		UpdateMask: &updateMask,


### PR DESCRIPTION
This PR adds the missing fields to the app resource update mask to allow for editing the app policies and description in the provider. 