### PR TITLE
Updated with new go SDK oauth

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ provider "conductorone" {
 ### Optional
 
 - `server_url` (String) Server URL (defaults to https://{tenantDomain}.conductor.one)
+- `tenant_domain` (String) Tenant Domain (derived from client_id if not provided)
 
 ## Limitations
 

--- a/internal/sdk/extra_sdk_options.go
+++ b/internal/sdk/extra_sdk_options.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -11,61 +13,21 @@ import (
 	"conductorone/internal/sdk/uhttp"
 )
 
+const c1TenantDomain = ".conductor.one"
 const ClientIdGolangSDK = "2RCzHlak5q7CY14SdBc8HoZEJRf"
 
-type normalizeTenantResp struct {
-	useWithServer bool
-	useWithTenant bool
-
-	ServerURL string
-	Tenant    string
-}
-
-func normalizeTenant(input string) (*normalizeTenantResp, error) {
-	input = strings.ToLower(input)
-
-	var err error
-	u := &url.URL{}
-	if !strings.Contains(input, "//") {
-		if !strings.Contains(input, ".") {
-			input += ".conductor.one"
-		}
-		u.Host = input
-	} else {
-		u, err = url.Parse(input)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	normalize := &normalizeTenantResp{}
-
-	parts := strings.Split(u.Host, ".")
-	if len(parts) == 3 && parts[1] == "conductor" && parts[2] == "one" {
-		normalize.useWithTenant = true
-		normalize.Tenant = parts[0]
-
-		return normalize, nil
-	}
-
-	u.Scheme = "https"
-	normalize.useWithServer = true
-	normalize.ServerURL = u.String()
-	return normalize, nil
-}
-
 func WithTenant(input string) (SDKOption, error) {
-	resp, err := normalizeTenant(input)
+	resp, err := NormalizeTenant(input)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.useWithTenant {
-		return WithTenantDomain(resp.Tenant), nil
+	if resp.UseWithTenant() {
+		return WithTenantDomain(resp.Tenant()), nil
 	}
 
-	if resp.useWithServer {
-		return WithServerURL(resp.ServerURL), nil
+	if resp.UseWithServer() {
+		return WithServerURL(resp.ServerURL()), nil
 	}
 
 	return func(api *ConductoroneAPI) {}, nil
@@ -73,23 +35,15 @@ func WithTenant(input string) (SDKOption, error) {
 
 type CustomSDKOption func(*CustomOptions)
 
-//func WithClient(client HTTPClient) SDKOption {
-//	return func(sdk *ConductoroneAPI) {
-//		sdk.sdkConfiguration.DefaultClient = client
-//	}
-//}
-
 func WithTenantCustom(input string) (CustomSDKOption, error) {
-	resp, err := normalizeTenant(input)
+	resp, err := NormalizeTenant(input)
 	if err != nil {
 		return nil, err
 	}
 
 	return func(sdk *CustomOptions) {
-		sdk.useWithServer = resp.useWithServer
-		sdk.useWithTenant = resp.useWithTenant
-		sdk.ServerURL = resp.ServerURL
-		sdk.Tenant = resp.Tenant
+		sdk.serverURL = resp.ServerURL()
+		sdk.tenant = resp.Tenant()
 	}, nil
 }
 
@@ -110,28 +64,86 @@ func WithTLSConfig(tlsConfig *tls.Config) CustomSDKOption {
 	}
 }
 
+type ClientConfig struct {
+	// These are mutually exclusive
+	serverURL string
+	tenant    string
+}
+
+func (c ClientConfig) UseWithServer() bool {
+	return c.serverURL != ""
+}
+
+func (c ClientConfig) UseWithTenant() bool {
+	return c.tenant != ""
+}
+
+func (c ClientConfig) SetTenant(tenant string) error {
+	if c.UseWithServer() {
+		return errors.New("cannot set tenant, tenant and serverURL are mutually exclusive")
+	}
+	c.tenant = tenant
+	return nil
+}
+
+func (c ClientConfig) SetServerURL(serverURL string) error {
+	if c.UseWithTenant() {
+		return errors.New("cannot set serverURL, tenant and serverURL are mutually exclusive")
+	}
+	c.serverURL = serverURL
+	return nil
+}
+
+func (c ClientConfig) Tenant() string {
+	return c.tenant
+}
+
+// ServerURL returns the server URL.
+func (c ClientConfig) ServerURL() string {
+	return c.serverURL
+}
+
+// GetServerURL returns the server URL. If serverURL is empty (""), it constructs the server URL using the tenant. However, if the tenant is also empty, then it will return an empty string.
+func (c ClientConfig) GetServerURL() string {
+	if c.UseWithServer() {
+		return c.serverURL
+	}
+	if c.UseWithTenant() {
+		u := &url.URL{}
+		tenant := strings.ToLower(c.Tenant())
+		u.Host = tenant + c1TenantDomain
+		u.Scheme = "https"
+		return u.String()
+	}
+	return ""
+}
+
 type CustomOptions struct {
-	useWithServer bool
-	useWithTenant bool
+	ClientConfig
 
-	ServerURL string
-	Tenant    string
-
-	logger    *zap.Logger
-	tlsConfig *tls.Config
+	withClient *http.Client
+	logger     *zap.Logger
+	tlsConfig  *tls.Config
 
 	userAgent string
 }
 
 func NewWithCredentials(ctx context.Context, cred *ClientCredentials, opts ...CustomSDKOption) (*ConductoroneAPI, error) {
-	tokenSource, err := NewC1TokenSource(ctx, cred.ClientID, cred.ClientSecret)
-	if err != nil {
-		return nil, err
-	}
-
 	options := &CustomOptions{}
 	for _, opt := range opts {
 		opt(options)
+	}
+	if options.GetServerURL() == "" {
+		resp, err := ParseClientID(cred.ClientID)
+		if err != nil {
+			return nil, err
+		}
+		options.ClientConfig = *resp
+	}
+
+	tokenSource, err := NewTokenSource(ctx, cred.ClientID, cred.ClientSecret, options.GetServerURL())
+	if err != nil {
+		return nil, err
 	}
 
 	if options.userAgent == "" {
@@ -150,13 +162,74 @@ func NewWithCredentials(ctx context.Context, cred *ClientCredentials, opts ...Cu
 	}
 
 	sdkOpts := []SDKOption{}
-	if options.useWithServer {
-		sdkOpts = append(sdkOpts, WithServerURL(options.ServerURL))
+	if options.UseWithServer() {
+		sdkOpts = append(sdkOpts, WithServerURL(options.ServerURL()))
 	}
-	if options.useWithTenant {
-		sdkOpts = append(sdkOpts, WithTenantDomain(options.Tenant))
+	if options.UseWithTenant() {
+		sdkOpts = append(sdkOpts, WithTenantDomain(options.Tenant()))
 	}
 	sdkOpts = append(sdkOpts, WithClient(uclient))
 
 	return New(sdkOpts...), nil
+}
+
+func NormalizeTenant(input string) (*ClientConfig, error) {
+	input = strings.ToLower(input)
+
+	var err error
+	u := &url.URL{}
+	if !strings.Contains(input, "://") {
+		if !strings.Contains(input, ".") {
+			input += c1TenantDomain
+		}
+		u.Host = input
+	} else {
+		u, err = url.Parse(input)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	normalize := &ClientConfig{}
+
+	parts := strings.Split(u.Host, ".")
+	if len(parts) == 3 && parts[1] == "conductor" && parts[2] == "one" {
+		err := normalize.SetTenant(parts[0])
+		if err != nil {
+			return nil, err
+		}
+		return normalize, nil
+	}
+
+	u.Scheme = "https"
+	err = normalize.SetServerURL(u.String())
+	if err != nil {
+		return nil, err
+	}
+	return normalize, nil
+}
+
+func ParseClientID(input string) (*ClientConfig, error) {
+	// split the input into 2 parts by @
+	items := strings.SplitN(input, "@", 2)
+	if len(items) != 2 {
+		return nil, ErrInvalidClientID
+	}
+
+	// split the right part into 2 parts by /
+	items = strings.SplitN(items[1], "/", 2)
+	if len(items) != 2 {
+		return nil, ErrInvalidClientID
+	}
+
+	resp, err := NormalizeTenant(items[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.GetServerURL() == "" {
+		return nil, ErrInvalidClientID
+	}
+
+	return resp, nil
 }

--- a/internal/sdk/extra_sdk_options.go
+++ b/internal/sdk/extra_sdk_options.go
@@ -120,6 +120,7 @@ func (c *ClientConfig) GetServerURL() string {
 type CustomOptions struct {
 	*ClientConfig
 
+	// nolint:unused
 	withClient *http.Client
 	logger     *zap.Logger
 	tlsConfig  *tls.Config

--- a/internal/sdk/extra_sdk_options.go
+++ b/internal/sdk/extra_sdk_options.go
@@ -121,6 +121,7 @@ func (c ClientConfig) GetServerURL() string {
 type CustomOptions struct {
 	ClientConfig
 
+	// nolint:unused
 	withClient *http.Client
 	logger     *zap.Logger
 	tlsConfig  *tls.Config

--- a/internal/sdk/extra_sdk_options_test.go
+++ b/internal/sdk/extra_sdk_options_test.go
@@ -4,71 +4,79 @@ import (
 	"testing"
 )
 
-func TestNormalizeTenantInput(t *testing.T) {
+type ClientConfigTest struct {
+	name               string
+	input              string
+	wantedURL          string
+	wantedTenantDomain string
+	tenantOnly         bool
+	wantErr            bool
+}
 
-	tests := []struct {
-		name               string
-		input              string
-		wantedURL          string
-		wantedTenantDomain string
-		wantErr            bool
-	}{
-		{
-			name:               "base",
-			input:              "insulator.conductor.one",
-			wantedURL:          "",
-			wantedTenantDomain: "insulator",
-			wantErr:            false,
-		},
-		{
-			name:               "tenantOnly",
-			input:              "insulator",
-			wantedURL:          "",
-			wantedTenantDomain: "insulator",
-			wantErr:            false,
-		},
-		{
-			name:               "baseWithHTTP",
-			input:              "https://insulator.conductor.one",
-			wantedURL:          "",
-			wantedTenantDomain: "insulator",
-			wantErr:            false,
-		},
-		{
-			name:               "differentUrlWithHTTP",
-			input:              "https://insulator.a.different.com",
-			wantedURL:          "https://insulator.a.different.com",
-			wantedTenantDomain: "invalid-example", // Doesn't match {tenant}.conductor.one, so the go sdk default is not changed
-			wantErr:            false,
-		},
-		{
-			name:               "differentUrlWithHTTP",
-			input:              "insulator.a.different.com",
-			wantedURL:          "https://insulator.a.different.com",
-			wantedTenantDomain: "invalid-example", // Doesn't match {tenant}.conductor.one, so the go sdk default is not changed
-			wantErr:            false,
-		},
-		{
-			name:               "differentURL",
-			input:              "insulator.a.different.com",
-			wantedURL:          "https://insulator.a.different.com",
-			wantedTenantDomain: "invalid-example", // Doesn't match {tenant}.conductor.one, so the go sdk default is not changed
-			wantErr:            false,
-		},
+func TestParseClientID(t *testing.T) {
+	tests := []ClientConfigTest{
+		{name: "base", input: "foobar@insulator.conductor.one/pcc", wantedURL: "https://insulator.conductor.one", wantedTenantDomain: "insulator", wantErr: false, tenantOnly: true},
+		{name: "dev", input: "foobar@c1dev.anthony.dev.ductone.com/pcc", wantedURL: "https://c1dev.anthony.dev.ductone.com", wantedTenantDomain: "", wantErr: false, tenantOnly: false},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := WithTenant(tt.input)
+			got, err := ParseClientID(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseClientID returned err = '%v', but expected error: '%v'", err, tt.wantErr)
+			}
+			testClientConfig(t, tt, got)
+		})
+	}
+}
+
+func TestCustomTenantOptions(t *testing.T) {
+	tests := []ClientConfigTest{
+		{name: "base", input: "insulator.conductor.one", wantedURL: "https://insulator.conductor.one", wantedTenantDomain: "insulator", wantErr: false, tenantOnly: true},
+		{name: "tenantOnly", input: "insulator", wantedURL: "https://insulator.conductor.one", wantedTenantDomain: "insulator", wantErr: false, tenantOnly: true},
+		{name: "baseWithHTTP", input: "https://insulator.conductor.one", wantedURL: "https://insulator.conductor.one", wantedTenantDomain: "insulator", wantErr: false, tenantOnly: true},
+		{name: "differentURL", input: "https://insulator.a.different.com", wantedURL: "https://insulator.a.different.com", wantedTenantDomain: "", wantErr: false, tenantOnly: false},
+		{name: "differentBase", input: "insulator.a.different.com", wantedURL: "https://insulator.a.different.com", wantedTenantDomain: "", wantErr: false, tenantOnly: false},
+		{name: "devURL", input: "https://c1dev.anthony.dev.ductone.com:2443", wantedURL: "https://c1dev.anthony.dev.ductone.com:2443", wantedTenantDomain: "", wantErr: false, tenantOnly: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := WithTenantCustom(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("WithTenant returned err = '%v', but expected error: '%v'", err, tt.wantErr)
 			}
-			client := New(got)
-			if client.sdkConfiguration.ServerURL != tt.wantedURL {
-				t.Errorf("ServerURL Got = '%v', want '%v'", client.sdkConfiguration.ServerURL, tt.wantedURL)
-			}
-			if client.sdkConfiguration.ServerDefaults[0]["tenantDomain"] != tt.wantedTenantDomain {
-				t.Errorf("TenantDomain Got = '%v', want '%v'", client.sdkConfiguration.ServerDefaults[0]["tenantDomain"], tt.wantedTenantDomain)
-			}
+			customOptions := &CustomOptions{}
+			got(customOptions)
+			testClientConfig(t, tt, &customOptions.ClientConfig)
 		})
+	}
+}
+
+func testClientConfig(t *testing.T, tt ClientConfigTest, got *ClientConfig) {
+	if got.UseWithServer() == got.UseWithTenant() {
+		t.Error("useWithServer and useWithTenant should not be the same")
+	}
+	if got.UseWithTenant() != tt.tenantOnly {
+		t.Errorf("useWithTenant Got = '%v', want '%v'", got.UseWithTenant(), tt.tenantOnly)
+	}
+	if got.UseWithServer() {
+		if got.ServerURL() != tt.wantedURL {
+			t.Errorf("ServerURL Got = '%v', want '%v'", got.ServerURL(), tt.wantedURL)
+		}
+		if got.Tenant() != tt.wantedTenantDomain {
+			t.Errorf("Tenant Got = '%v', want '%v'", got.Tenant(), "")
+		}
+	}
+	if got.UseWithTenant() {
+		if got.Tenant() != tt.wantedTenantDomain {
+			t.Errorf("Tenant Got = '%v', want '%v'", got.Tenant(), tt.wantedTenantDomain)
+		}
+		if got.ServerURL() != "" {
+			t.Errorf("ServerURL Got = '%v', want '%v'", got.ServerURL(), "")
+		}
+		if got.GetServerURL() != tt.wantedURL {
+			t.Errorf("GetServerURL Got = '%v', want '%v'", got.GetServerURL(), tt.wantedURL)
+		}
 	}
 }

--- a/internal/sdk/extra_sdk_options_test.go
+++ b/internal/sdk/extra_sdk_options_test.go
@@ -48,7 +48,7 @@ func TestCustomTenantOptions(t *testing.T) {
 			}
 			customOptions := &CustomOptions{}
 			got(customOptions)
-			testClientConfig(t, tt, &customOptions.ClientConfig)
+			testClientConfig(t, tt, customOptions.ClientConfig)
 		})
 	}
 }

--- a/internal/sdk/token_source.go
+++ b/internal/sdk/token_source.go
@@ -184,7 +184,8 @@ func NewTokenSource(ctx context.Context, clientID string, clientSecret string, t
 		ctx:          ctx,
 		clientID:     clientID,
 		clientSecret: secret,
-		tokenHost:    strings.TrimLeft(tokenHost, "https://"),
-		httpClient:   httpClient,
+		// nolint:staticcheck
+		tokenHost:  strings.TrimLeft(tokenHost, "https://"),
+		httpClient: httpClient,
 	}), nil
 }

--- a/internal/sdk/token_source.go
+++ b/internal/sdk/token_source.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -43,26 +42,11 @@ type c1Token struct {
 }
 
 type c1TokenSource struct {
+	ctx          context.Context
 	clientID     string
 	clientSecret *jose.JSONWebKey
 	tokenHost    string
 	httpClient   *http.Client
-}
-
-func parseClientID(input string) (string, error) {
-	// split the input into 2 parts by @
-	items := strings.SplitN(input, "@", 2)
-	if len(items) != 2 {
-		return "", ErrInvalidClientID
-	}
-
-	// split the right part into 2 parts by /
-	items = strings.SplitN(items[1], "/", 2)
-	if len(items) != 2 {
-		return "", ErrInvalidClientID
-	}
-
-	return items[0], nil
 }
 
 func parseSecret(input []byte) (*jose.JSONWebKey, error) {
@@ -148,17 +132,13 @@ func (c *c1TokenSource) Token() (*oauth2.Token, error) {
 		"client_assertion":      []string{s},
 	}
 
-	tokenHost := c.tokenHost
-	if envHost, ok := os.LookupEnv("CONE_API_ENDPOINT"); ok {
-		tokenHost = envHost
-	}
 	tokenUrl := url.URL{
 		Scheme: "https",
-		Host:   tokenHost,
+		Host:   c.tokenHost,
 		Path:   "auth/v1/token",
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, tokenUrl.String(), strings.NewReader(body.Encode()))
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, tokenUrl.String(), strings.NewReader(body.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -190,12 +170,7 @@ func (c *c1TokenSource) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
-func NewC1TokenSource(ctx context.Context, clientID string, clientSecret string) (oauth2.TokenSource, error) {
-	tokenHost, err := parseClientID(clientID)
-	if err != nil {
-		return nil, err
-	}
-
+func NewTokenSource(ctx context.Context, clientID string, clientSecret string, tokenHost string) (oauth2.TokenSource, error) {
 	secret, err := parseSecret([]byte(clientSecret))
 	if err != nil {
 		return nil, err
@@ -206,9 +181,10 @@ func NewC1TokenSource(ctx context.Context, clientID string, clientSecret string)
 		return nil, err
 	}
 	return oauth2.ReuseTokenSource(nil, &c1TokenSource{
+		ctx:          ctx,
 		clientID:     clientID,
 		clientSecret: secret,
-		tokenHost:    tokenHost,
+		tokenHost:    strings.TrimLeft(tokenHost, "https://"),
 		httpClient:   httpClient,
 	}), nil
 }

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/all.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/all.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package providervalidator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+// All returns a validator which ensures that any configured attribute value
+// validates against all the given validators.
+//
+// Use of All is only necessary when used in conjunction with Any or AnyWithAllWarnings
+// as the Validators field automatically applies a logical AND.
+func All(validators ...provider.ConfigValidator) provider.ConfigValidator {
+	return allValidator{
+		validators: validators,
+	}
+}
+
+var _ provider.ConfigValidator = allValidator{}
+
+// allValidator implements the validator.
+type allValidator struct {
+	validators []provider.ConfigValidator
+}
+
+// Description describes the validation in plain text formatting.
+func (v allValidator) Description(ctx context.Context) string {
+	var descriptions []string
+
+	for _, subValidator := range v.validators {
+		descriptions = append(descriptions, subValidator.Description(ctx))
+	}
+
+	return fmt.Sprintf("Value must satisfy all of the validations: %s", strings.Join(descriptions, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v allValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateProvider performs the validation.
+func (v allValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
+	for _, subValidator := range v.validators {
+		validateResp := &provider.ValidateConfigResponse{}
+
+		subValidator.ValidateProvider(ctx, req, validateResp)
+
+		resp.Diagnostics.Append(validateResp.Diagnostics...)
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/any.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/any.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package providervalidator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+// Any returns a validator which ensures that any configured attribute value
+// passes at least one of the given validators.
+//
+// To prevent practitioner confusion should non-passing validators have
+// conflicting logic, only warnings from the passing validator are returned.
+// Use AnyWithAllWarnings() to return warnings from non-passing validators
+// as well.
+func Any(validators ...provider.ConfigValidator) provider.ConfigValidator {
+	return anyValidator{
+		validators: validators,
+	}
+}
+
+var _ provider.ConfigValidator = anyValidator{}
+
+// anyValidator implements the validator.
+type anyValidator struct {
+	validators []provider.ConfigValidator
+}
+
+// Description describes the validation in plain text formatting.
+func (v anyValidator) Description(ctx context.Context) string {
+	var descriptions []string
+
+	for _, subValidator := range v.validators {
+		descriptions = append(descriptions, subValidator.Description(ctx))
+	}
+
+	return fmt.Sprintf("Value must satisfy at least one of the validations: %s", strings.Join(descriptions, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v anyValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateProvider performs the validation.
+func (v anyValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
+	for _, subValidator := range v.validators {
+		validateResp := &provider.ValidateConfigResponse{}
+
+		subValidator.ValidateProvider(ctx, req, validateResp)
+
+		if !validateResp.Diagnostics.HasError() {
+			resp.Diagnostics = validateResp.Diagnostics
+
+			return
+		}
+
+		resp.Diagnostics.Append(validateResp.Diagnostics...)
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/any_with_all_warnings.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/any_with_all_warnings.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package providervalidator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+// AnyWithAllWarnings returns a validator which ensures that any configured
+// attribute value passes at least one of the given validators. This validator
+// returns all warnings, including failed validators.
+//
+// Use Any() to return warnings only from the passing validator.
+func AnyWithAllWarnings(validators ...provider.ConfigValidator) provider.ConfigValidator {
+	return anyWithAllWarningsValidator{
+		validators: validators,
+	}
+}
+
+var _ provider.ConfigValidator = anyWithAllWarningsValidator{}
+
+// anyWithAllWarningsValidator implements the validator.
+type anyWithAllWarningsValidator struct {
+	validators []provider.ConfigValidator
+}
+
+// Description describes the validation in plain text formatting.
+func (v anyWithAllWarningsValidator) Description(ctx context.Context) string {
+	var descriptions []string
+
+	for _, subValidator := range v.validators {
+		descriptions = append(descriptions, subValidator.Description(ctx))
+	}
+
+	return fmt.Sprintf("Value must satisfy at least one of the validations: %s", strings.Join(descriptions, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v anyWithAllWarningsValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateProvider performs the validation.
+func (v anyWithAllWarningsValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
+	anyValid := false
+
+	for _, subValidator := range v.validators {
+		validateResp := &provider.ValidateConfigResponse{}
+
+		subValidator.ValidateProvider(ctx, req, validateResp)
+
+		if !validateResp.Diagnostics.HasError() {
+			anyValid = true
+		}
+
+		resp.Diagnostics.Append(validateResp.Diagnostics...)
+	}
+
+	if anyValid {
+		resp.Diagnostics = resp.Diagnostics.Warnings()
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/at_least_one_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/at_least_one_of.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package providervalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/configvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+// AtLeastOneOf checks that a set of path.Expression has at least one non-null
+// or unknown value.
+func AtLeastOneOf(expressions ...path.Expression) provider.ConfigValidator {
+	return &configvalidator.AtLeastOneOfValidator{
+		PathExpressions: expressions,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/conflicting.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/conflicting.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package providervalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/configvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+// Conflicting checks that a set of path.Expression, are not configured
+// simultaneously.
+func Conflicting(expressions ...path.Expression) provider.ConfigValidator {
+	return &configvalidator.ConflictingValidator{
+		PathExpressions: expressions,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/doc.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package providervalidator provides validators to express relationships
+// between multiple attributes of a provider. For example, checking that
+// multiple attributes are not configured at the same time.
+//
+// These validators are implemented outside the schema, which may be easier to
+// implement in provider code generation situations or suit provider code
+// preferences differently than those in the schemavalidator package. Those
+// validators start on a starting attribute, where relationships can be
+// expressed as absolute paths to others or relative to the starting attribute.
+package providervalidator

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/exactly_one_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/exactly_one_of.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package providervalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/configvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+// ExactlyOneOf checks that a set of path.Expression does not have more than
+// one known value.
+func ExactlyOneOf(expressions ...path.Expression) provider.ConfigValidator {
+	return &configvalidator.ExactlyOneOfValidator{
+		PathExpressions: expressions,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/required_together.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/providervalidator/required_together.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package providervalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/configvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+)
+
+// RequiredTogether checks that a set of path.Expression either has all known
+// or all null values.
+func RequiredTogether(expressions ...path.Expression) provider.ConfigValidator {
+	return &configvalidator.RequiredTogetherValidator{
+		PathExpressions: expressions,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,6 +77,7 @@ github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag
 github.com/hashicorp/terraform-plugin-framework-validators/internal/configvalidator
 github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator
 github.com/hashicorp/terraform-plugin-framework-validators/listvalidator
+github.com/hashicorp/terraform-plugin-framework-validators/providervalidator
 github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator
 github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
 # github.com/hashicorp/terraform-plugin-go v0.18.0


### PR DESCRIPTION
After updating the go sdk I added the changes to the terraform provider, also added the option to authenticate with the tenant_domain

Old Panic PR: https://github.com/ConductorOne/terraform-provider-conductorone/pull/47
Go SDK PR: https://github.com/ConductorOne/conductorone-sdk-go/pull/53
