### PR TITLE
Replaced panic with helpful error

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -109,7 +109,8 @@ func (p *ConductoroneProvider) Configure(ctx context.Context, req provider.Confi
 		ClientSecret: ClientSecret,
 	}, opts...)
 	if err != nil {
-		panic(err)
+		resp.Diagnostics.AddError("Failed to create SDK Client", err.Error())
+		return
 	}
 
 	resp.DataSourceData = client


### PR DESCRIPTION
When you add an error to the resp.Diaganostic it stops execution, this should be an improvement to panicking  