### PR TITLE
Fixes an issue with how we were trimming urls

### DIFF
--- a/internal/sdk/token_source.go
+++ b/internal/sdk/token_source.go
@@ -182,8 +182,7 @@ func NewTokenSource(ctx context.Context, clientID string, clientSecret string, t
 	return oauth2.ReuseTokenSource(nil, &c1TokenSource{
 		clientID:     clientID,
 		clientSecret: secret,
-		// nolint:staticcheck
-		tokenHost:  strings.TrimLeft(tokenHost, "https://"),
-		httpClient: httpClient,
+		tokenHost:    strings.TrimPrefix(tokenHost, "https://"),
+		httpClient:   httpClient,
 	}), nil
 }


### PR DESCRIPTION
We were using strings.TrimLeft() when we should have been using strings.TrimPrefix()