### PR TITLE
Fixes a bug with setting duration on an entitlement

### DIFF
--- a/docs/resources/app_entitlement.md
+++ b/docs/resources/app_entitlement.md
@@ -29,9 +29,8 @@ resource "conductorone_app_entitlement" "okta_test_admin" {
       ]
     }
   }
-  max_grant_duration = {
-    duration_grant = "3600s"
-  }
+
+  duration_grant      = "3600s"
   risk_level_value_id = conductorone_risk_level.test_risk_level.id
   compliance_framework_value_ids = [
     data.conductorone_compliance_framework.soc2.id

--- a/examples/resources/conductorone_app_entitlement/app_entitlement.tf
+++ b/examples/resources/conductorone_app_entitlement/app_entitlement.tf
@@ -10,9 +10,8 @@ resource "conductorone_app_entitlement" "okta_test_admin" {
       ]
     }
   }
-  max_grant_duration = {
-    duration_grant = "3600s"
-  }
+
+  duration_grant      = "3600s"
   risk_level_value_id = conductorone_risk_level.test_risk_level.id
   compliance_framework_value_ids = [
     data.conductorone_compliance_framework.soc2.id

--- a/internal/provider/app_entitlement_resource.go
+++ b/internal/provider/app_entitlement_resource.go
@@ -277,6 +277,7 @@ func (r *AppEntitlementResource) Create(ctx context.Context, req resource.Create
 		AppID:                       appID,
 		ID:                          id,
 	}
+
 	res, err := r.client.AppEntitlements.Update(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
@@ -379,6 +380,18 @@ func (r *AppEntitlementResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
+	// TODO(mstanbCO): Need a better pattern for stuff like this
+	// These two fields are a oneof in the API, so we need to ensure that only one is set before making the request.
+	if currentAppEntitlement.DurationGrant != nil {
+		if appEntitlement.DurationUnset != nil {
+			appEntitlement.DurationGrant = nil
+		}
+	} else if currentAppEntitlement.DurationUnset != nil {
+		if appEntitlement.DurationGrant != nil {
+			appEntitlement.DurationUnset = nil
+		}
+	}
+
 	// If no value was specified for the ProvisionPolicy, use the current value.
 	if appEntitlement.ProvisionPolicy == nil {
 		appEntitlement.ProvisionPolicy = currentAppEntitlement.ProvisionPolicy
@@ -393,6 +406,7 @@ func (r *AppEntitlementResource) Update(ctx context.Context, req resource.Update
 		AppID:                       appID,
 		ID:                          id,
 	}
+
 	res, err := r.client.AppEntitlements.Update(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())


### PR DESCRIPTION
This PR fixes an issue where we have a oneof in our API with two valid values to choose from, but in our request we were incorrectly trying to set both.