### PR TITLE
66 provider crashed during apply

### DIFF
--- a/docs/data-sources/app_entitlement.md
+++ b/docs/data-sources/app_entitlement.md
@@ -88,6 +88,7 @@ Read-Only:
 
 - `app_id` (String) The appId field.
 - `entitlement_id` (String) The entitlementId field.
+- `implicit` (Boolean) If true, a binding will be automatically created from the entitlement of the parent app.
 
 
 <a id="nestedatt--provision_policy--manual_provision"></a>

--- a/docs/resources/app_entitlement.md
+++ b/docs/resources/app_entitlement.md
@@ -101,6 +101,7 @@ Optional:
 
 - `app_id` (String) The appId field.
 - `entitlement_id` (String) The entitlementId field.
+- `implicit` (Boolean) If true, a binding will be automatically created from the entitlement of the parent app.
 
 
 <a id="nestedatt--provision_policy--manual_provision"></a>

--- a/internal/provider/app_entitlement_data_source.go
+++ b/internal/provider/app_entitlement_data_source.go
@@ -157,6 +157,10 @@ func (r *AppEntitlementDataSource) Schema(ctx context.Context, req datasource.Sc
 								Computed:    true,
 								Description: `The entitlementId field.`,
 							},
+							"implicit": schema.BoolAttribute{
+								Computed:    true,
+								Description: `If true, a binding will be automatically created from the entitlement of the parent app.`,
+							},
 						},
 						Description: `The DelegatedProvision message.`,
 					},

--- a/internal/provider/app_entitlement_data_source_sdk.go
+++ b/internal/provider/app_entitlement_data_source_sdk.go
@@ -92,20 +92,10 @@ func (r *AppEntitlementDataSourceModel) RefreshFromGetResponse(resp *shared.AppE
 		r.ProvisionPolicy = nil
 	} else {
 		r.ProvisionPolicy = &ProvisionPolicy{}
-		if r.ProvisionPolicy.ConnectorProvision == nil {
+		if resp.ProvisionPolicy.ConnectorProvision != nil {
 			r.ProvisionPolicy.ConnectorProvision = &ConnectorProvision{}
 		}
-		if resp.ProvisionPolicy.ConnectorProvision == nil {
-			r.ProvisionPolicy.ConnectorProvision = nil
-		} else {
-			r.ProvisionPolicy.ConnectorProvision = &ConnectorProvision{}
-		}
-		if r.ProvisionPolicy.DelegatedProvision == nil {
-			r.ProvisionPolicy.DelegatedProvision = &DelegatedProvision{}
-		}
-		if resp.ProvisionPolicy.DelegatedProvision == nil {
-			r.ProvisionPolicy.DelegatedProvision = nil
-		} else {
+		if r.ProvisionPolicy.DelegatedProvision != nil {
 			r.ProvisionPolicy.DelegatedProvision = &DelegatedProvision{}
 			if resp.ProvisionPolicy.DelegatedProvision.AppID != nil {
 				r.ProvisionPolicy.DelegatedProvision.AppID = types.StringValue(*resp.ProvisionPolicy.DelegatedProvision.AppID)
@@ -117,13 +107,13 @@ func (r *AppEntitlementDataSourceModel) RefreshFromGetResponse(resp *shared.AppE
 			} else {
 				r.ProvisionPolicy.DelegatedProvision.EntitlementID = types.StringNull()
 			}
+			if resp.ProvisionPolicy.DelegatedProvision.Implicit != nil {
+				r.ProvisionPolicy.DelegatedProvision.Implicit = types.BoolValue(*resp.ProvisionPolicy.DelegatedProvision.Implicit)
+			} else {
+				r.ProvisionPolicy.DelegatedProvision.Implicit = types.BoolNull()
+			}
 		}
-		if r.ProvisionPolicy.ManualProvision == nil {
-			r.ProvisionPolicy.ManualProvision = &ManualProvision{}
-		}
-		if resp.ProvisionPolicy.ManualProvision == nil {
-			r.ProvisionPolicy.ManualProvision = nil
-		} else {
+		if r.ProvisionPolicy.ManualProvision != nil {
 			r.ProvisionPolicy.ManualProvision = &ManualProvision{}
 			if resp.ProvisionPolicy.ManualProvision.Instructions != nil {
 				r.ProvisionPolicy.ManualProvision.Instructions = types.StringValue(*resp.ProvisionPolicy.ManualProvision.Instructions)

--- a/internal/provider/app_entitlement_resource.go
+++ b/internal/provider/app_entitlement_resource.go
@@ -264,6 +264,9 @@ func (r *AppEntitlementResource) Create(ctx context.Context, req resource.Create
 		UnhandledNullAsEmpty:    true,
 		UnhandledUnknownAsEmpty: true,
 	})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	appEntitlement := data.ToUpdateSDKType()
 

--- a/internal/provider/app_entitlement_resource.go
+++ b/internal/provider/app_entitlement_resource.go
@@ -160,35 +160,48 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 			// TODO: this is a oneof
 			"provision_policy": schema.SingleNestedAttribute{
 				Optional: true,
+				Computed: true,
 				Attributes: map[string]schema.Attribute{
 					"connector_provision": schema.SingleNestedAttribute{
 						Optional:    true,
+						Computed:    true,
 						Attributes:  map[string]schema.Attribute{},
 						Description: `The ConnectorProvision message.`,
 					},
 					"delegated_provision": schema.SingleNestedAttribute{
 						Optional: true,
+						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"app_id": schema.StringAttribute{
 								Optional:    true,
+								Computed:    true,
 								Description: `The appId field.`,
 							},
 							"entitlement_id": schema.StringAttribute{
 								Optional:    true,
+								Computed:    true,
 								Description: `The entitlementId field.`,
+							},
+							"implicit": schema.BoolAttribute{
+								Optional:    true,
+								Computed:    true,
+								Description: `If true, a binding will be automatically created from the entitlement of the parent app.`,
 							},
 						},
 						Description: `The DelegatedProvision message.`,
 					},
 					"manual_provision": schema.SingleNestedAttribute{
 						Optional: true,
+						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"instructions": schema.StringAttribute{
 								Optional:    true,
+								Computed:    true,
 								Description: `The instructions field.`,
 							},
 							"user_ids": schema.ListAttribute{
 								Optional:    true,
+								Computed:    true,
 								ElementType: types.StringType,
 								Description: `The userIds field.`,
 							},

--- a/internal/provider/app_entitlement_resource_sdk.go
+++ b/internal/provider/app_entitlement_resource_sdk.go
@@ -28,9 +28,16 @@ func (r *AppEntitlementResourceModel) ToUpdateSDKType() *shared.AppEntitlement {
 			} else {
 				entitlementID = nil
 			}
+			implicit := new(bool)
+			if !r.ProvisionPolicy.DelegatedProvision.Implicit.IsUnknown() && !r.ProvisionPolicy.DelegatedProvision.Implicit.IsNull() {
+				*implicit = r.ProvisionPolicy.DelegatedProvision.Implicit.ValueBool()
+			} else {
+				implicit = nil
+			}
 			delegatedProvision = &shared.DelegatedProvision{
 				AppID:         appID,
 				EntitlementID: entitlementID,
+				Implicit:      implicit,
 			}
 		}
 		var manualProvision *shared.ManualProvision
@@ -274,52 +281,41 @@ func (r *AppEntitlementResourceModel) RefreshFromGetResponse(resp *shared.AppEnt
 	}
 
 	if resp.ProvisionPolicy != nil {
-		if r.ProvisionPolicy != nil {
-			r.ProvisionPolicy = &ProvisionPolicy{}
-			if r.ProvisionPolicy.ConnectorProvision == nil {
-				r.ProvisionPolicy.ConnectorProvision = &ConnectorProvision{}
-			}
-			if resp.ProvisionPolicy.ConnectorProvision == nil {
-				r.ProvisionPolicy.ConnectorProvision = nil
+		r.ProvisionPolicy = &ProvisionPolicy{}
+		if resp.ProvisionPolicy.ConnectorProvision != nil {
+			r.ProvisionPolicy.ConnectorProvision = &ConnectorProvision{}
+		}
+		if resp.ProvisionPolicy.DelegatedProvision != nil {
+			r.ProvisionPolicy.DelegatedProvision = &DelegatedProvision{}
+			if resp.ProvisionPolicy.DelegatedProvision.AppID != nil {
+				r.ProvisionPolicy.DelegatedProvision.AppID = types.StringValue(*resp.ProvisionPolicy.DelegatedProvision.AppID)
 			} else {
-				r.ProvisionPolicy.ConnectorProvision = &ConnectorProvision{}
+				r.ProvisionPolicy.DelegatedProvision.AppID = types.StringNull()
 			}
-			if r.ProvisionPolicy.DelegatedProvision == nil {
-				r.ProvisionPolicy.DelegatedProvision = &DelegatedProvision{}
-			}
-			if resp.ProvisionPolicy.DelegatedProvision == nil {
-				r.ProvisionPolicy.DelegatedProvision = nil
+			if resp.ProvisionPolicy.DelegatedProvision.EntitlementID != nil {
+				r.ProvisionPolicy.DelegatedProvision.EntitlementID = types.StringValue(*resp.ProvisionPolicy.DelegatedProvision.EntitlementID)
 			} else {
-				r.ProvisionPolicy.DelegatedProvision = &DelegatedProvision{}
-				if resp.ProvisionPolicy.DelegatedProvision.AppID != nil {
-					r.ProvisionPolicy.DelegatedProvision.AppID = types.StringValue(*resp.ProvisionPolicy.DelegatedProvision.AppID)
-				} else {
-					r.ProvisionPolicy.DelegatedProvision.AppID = types.StringNull()
-				}
-				if resp.ProvisionPolicy.DelegatedProvision.EntitlementID != nil {
-					r.ProvisionPolicy.DelegatedProvision.EntitlementID = types.StringValue(*resp.ProvisionPolicy.DelegatedProvision.EntitlementID)
-				} else {
-					r.ProvisionPolicy.DelegatedProvision.EntitlementID = types.StringNull()
-				}
+				r.ProvisionPolicy.DelegatedProvision.EntitlementID = types.StringNull()
 			}
-			if r.ProvisionPolicy.ManualProvision == nil {
-				r.ProvisionPolicy.ManualProvision = &ManualProvision{}
-			}
-			if resp.ProvisionPolicy.ManualProvision == nil {
-				r.ProvisionPolicy.ManualProvision = nil
+			if resp.ProvisionPolicy.DelegatedProvision.Implicit != nil {
+				r.ProvisionPolicy.DelegatedProvision.Implicit = types.BoolValue(*resp.ProvisionPolicy.DelegatedProvision.Implicit)
 			} else {
-				r.ProvisionPolicy.ManualProvision = &ManualProvision{}
-				if resp.ProvisionPolicy.ManualProvision.Instructions != nil {
-					r.ProvisionPolicy.ManualProvision.Instructions = types.StringValue(*resp.ProvisionPolicy.ManualProvision.Instructions)
-				} else {
-					r.ProvisionPolicy.ManualProvision.Instructions = types.StringNull()
-				}
-				r.ProvisionPolicy.ManualProvision.UserIds = nil
-				for _, v := range resp.ProvisionPolicy.ManualProvision.UserIds {
-					r.ProvisionPolicy.ManualProvision.UserIds = append(r.ProvisionPolicy.ManualProvision.UserIds, types.StringValue(v))
-				}
+				r.ProvisionPolicy.DelegatedProvision.Implicit = types.BoolNull()
 			}
 		}
+		if resp.ProvisionPolicy.ManualProvision != nil {
+			r.ProvisionPolicy.ManualProvision = &ManualProvision{}
+			if resp.ProvisionPolicy.ManualProvision.Instructions != nil {
+				r.ProvisionPolicy.ManualProvision.Instructions = types.StringValue(*resp.ProvisionPolicy.ManualProvision.Instructions)
+			} else {
+				r.ProvisionPolicy.ManualProvision.Instructions = types.StringNull()
+			}
+			r.ProvisionPolicy.ManualProvision.UserIds = nil
+			for _, v := range resp.ProvisionPolicy.ManualProvision.UserIds {
+				r.ProvisionPolicy.ManualProvision.UserIds = append(r.ProvisionPolicy.ManualProvision.UserIds, types.StringValue(v))
+			}
+		}
+
 	}
 	if resp.RevokePolicyID != nil {
 		r.RevokePolicyID = types.StringValue(*resp.RevokePolicyID)


### PR DESCRIPTION
Fixes this issue https://github.com/ConductorOne/terraform-provider-conductorone/issues/66

Two bugs:
1. On error we do not return so we caused a panic
2. Since the provision policy can be set by the API and the user it should be `computed and optional`. Since it wasn't `computed and optional` auto generated provider code was not properly setting the field. That is why it would be set to nil when reverse terraform gening. The object was also improperly created so a field had to be added