### PR TITLE
Redact authorization header

### DIFF
--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -18,6 +18,7 @@ import (
 )
 
 func debugResponse(response *http.Response) string {
+	response.Request.Header.Set("Authorization", "[REDACTED]")
 	dumpReq, err := httputil.DumpRequest(response.Request, false)
 	if err != nil {
 		return err.Error()


### PR DESCRIPTION
This removed the authorization header when we dump the debug response on failure
<img width="732" alt="image" src="https://github.com/ConductorOne/terraform-provider-conductorone/assets/60042005/ec89dc88-dc3a-4052-9d2c-d361fe3de46e">
 