### PR TITLE
Fixed a bug with the prefix, it should prefix to all numbers and I made it more unique to avoid false positives

### DIFF
--- a/internal/provider/policy_resource_sdk.go
+++ b/internal/provider/policy_resource_sdk.go
@@ -13,6 +13,7 @@ import (
 func BoolPointer(b bool) *bool {
 	return &b
 }
+
 const prefix = "c1_prefixed_"
 
 func isDigit(c byte) bool {
@@ -20,7 +21,7 @@ func isDigit(c byte) bool {
 }
 
 func PrependPolicyStepId(id string) string {
-	if (isDigit(id[0])) {
+	if isDigit(id[0]) {
 		return prefix + id
 	}
 	return id
@@ -29,7 +30,7 @@ func PrependPolicyStepId(id string) string {
 func RemovePolicyStepIdPrefix(id string) string {
 	prefix_length := len(prefix)
 	// We only want to remove the prefix if we appended it, this is not a foolproof way to check but the odds someone will have a policy step id that starts with c1_prefixed_\d{1} is low.
-	if (len(id) >= prefix_length+1 && id[:prefix_length] == prefix && isDigit(id[prefix_length])) {
+	if len(id) >= prefix_length+1 && id[:prefix_length] == prefix && isDigit(id[prefix_length]) {
 		return strings.TrimPrefix(id, prefix)
 	}
 	return id

--- a/internal/provider/policy_resource_sdk.go
+++ b/internal/provider/policy_resource_sdk.go
@@ -14,8 +14,13 @@ func BoolPointer(b bool) *bool {
 	return &b
 }
 const prefix = "c1_prefixed_"
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
 func PrependPolicyStepId(id string) string {
-	if (id[0] >= '0' && id[0] <= '9') {
+	if (isDigit(id[0])) {
 		return prefix + id
 	}
 	return id
@@ -24,7 +29,7 @@ func PrependPolicyStepId(id string) string {
 func RemovePolicyStepIdPrefix(id string) string {
 	prefix_length := len(prefix)
 	// We only want to remove the prefix if we appended it, this is not a foolproof way to check but the odds someone will have a policy step id that starts with c1_prefixed_\d{1} is low.
-	if (len(id) >= prefix_length+1 && id[prefix_length]>= '0' && id[prefix_length] <= '9') {
+	if (len(id) >= prefix_length+1 && id[:prefix_length] == prefix && isDigit(id[prefix_length])) {
 		return strings.TrimPrefix(id, prefix)
 	}
 	return id

--- a/internal/provider/policy_resource_sdk.go
+++ b/internal/provider/policy_resource_sdk.go
@@ -4,28 +4,30 @@ package provider
 
 import (
 	"conductorone/internal/sdk/pkg/models/shared"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var conditionalRegex = regexp.MustCompile("^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}")
-
 func BoolPointer(b bool) *bool {
 	return &b
 }
-
+const prefix = "c1_prefixed_"
 func PrependPolicyStepId(id string) string {
-	if conditionalRegex.MatchString(id) {
-		return "id_" + id
+	if (id[0] >= '0' && id[0] <= '9') {
+		return prefix + id
 	}
 	return id
 }
 
 func RemovePolicyStepIdPrefix(id string) string {
-	return strings.TrimPrefix(id, "id_")
+	prefix_length := len(prefix)
+	// We only want to remove the prefix if we appended it, this is not a foolproof way to check but the odds someone will have a policy step id that starts with c1_prefixed_\d{1} is low.
+	if (len(id) >= prefix_length+1 && id[prefix_length]>= '0' && id[prefix_length] <= '9') {
+		return strings.TrimPrefix(id, prefix)
+	}
+	return id
 }
 
 func (r *PolicyResourceModel) ToCreateSDKType() *shared.CreatePolicyRequest {


### PR DESCRIPTION
This is an improvement to the current behavior because more cases where the id starts with a digit are covered and it is more explicit that c1 is prefixing something to the field name.

However, it remains an unintuitive user experience and is worth improving on in the future. Here is an example of a working tf file, notice the discrepancy between the policy_key in the rule and the policy_step key. 


<img width="719" alt="image" src="https://github.com/ConductorOne/terraform-provider-conductorone/assets/60042005/c24bc6ee-ee77-4d5b-8cf7-2baf270574f0">
