### PR TITLE
Fix updating app entitlement provisioning policy when it involves external ticketing or multistep provisioning.

### DIFF
--- a/internal/provider/app_entitlement_resource.go
+++ b/internal/provider/app_entitlement_resource.go
@@ -469,19 +469,19 @@ func (r *AppEntitlementResource) Update(ctx context.Context, req resource.Update
 		isMultiStepSet := appEntitlement.ProvisionPolicy.MultiStep != nil
 
 		if currentAppEntitlement.ProvisionPolicy.ConnectorProvision != nil {
-			if isDelegatedSet || isManualSet || isWebhookSet {
+			if isDelegatedSet || isManualSet || isWebhookSet || isExternalTicketSet || isMultiStepSet {
 				appEntitlement.ProvisionPolicy.ConnectorProvision = nil
 			}
 		} else if currentAppEntitlement.ProvisionPolicy.DelegatedProvision != nil {
-			if isConnectorSet || isManualSet || isWebhookSet {
+			if isConnectorSet || isManualSet || isWebhookSet || isExternalTicketSet || isMultiStepSet {
 				appEntitlement.ProvisionPolicy.DelegatedProvision = nil
 			}
 		} else if currentAppEntitlement.ProvisionPolicy.ManualProvision != nil {
-			if isConnectorSet || isDelegatedSet || isWebhookSet {
+			if isConnectorSet || isDelegatedSet || isWebhookSet || isExternalTicketSet || isMultiStepSet {
 				appEntitlement.ProvisionPolicy.ManualProvision = nil
 			}
 		} else if currentAppEntitlement.ProvisionPolicy.WebhookProvision != nil {
-			if isConnectorSet || isDelegatedSet || isManualSet {
+			if isConnectorSet || isDelegatedSet || isManualSet || isExternalTicketSet || isMultiStepSet {
 				appEntitlement.ProvisionPolicy.WebhookProvision = nil
 			}
 		} else if currentAppEntitlement.ProvisionPolicy.ExternalTicketProvision != nil {


### PR DESCRIPTION
When we added support for external ticketing and multistep, we didn't update all of the cases when resolving the final policy to send to the API. This would result in errors when trying to apply multistep on an entitlement that has already been configured.

I was able to setup multistep with the following syntax:
```hcl
provision_policy = {
    "multi_step" : jsonencode({
      "provisionSteps" : [
        {
          "webhook" : {
            "webhookId" : "2eeiSXde5ee0PiJg2iEZsMuIgpS"
          }
        },
        {
          "connector": {}
        }
      ]
    })
  }
```