### PR TITLE
Add ability to specify client secret and ID by env variables so they don't end up in the tf state

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"context"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/providervalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -84,9 +85,21 @@ func (p *ConductoroneProvider) Configure(ctx context.Context, req provider.Confi
 	}
 
 	ServerURL := data.ServerURL.ValueString()
+	if ServerURL == "" {
+		ServerURL = os.Getenv("CONDUCTORONE_SERVER_URL")
+	}
 	ClientID := data.ClientID.ValueString()
+	if ClientID == "" {
+		ClientID = os.Getenv("CONDUCTORONE_CLIENT_ID")
+	}
 	ClientSecret := data.ClientSecret.ValueString()
+	if ClientSecret == "" {
+		ClientSecret = os.Getenv("CONDUCTORONE_CLIENT_SECRET")
+	}
 	TenantDomain := data.TenantDomain.ValueString()
+	if TenantDomain == "" {
+		TenantDomain = os.Getenv("CONDUCTORONE_TENANT_DOMAIN")
+	}
 
 	optStr := ""
 	if TenantDomain != "" {

--- a/internal/sdk/token_source.go
+++ b/internal/sdk/token_source.go
@@ -186,3 +186,9 @@ func NewTokenSource(ctx context.Context, clientID string, clientSecret string, t
 		httpClient:   httpClient,
 	}), nil
 }
+
+func NewStaticTokenSource(ctx context.Context, token string) oauth2.TokenSource {
+	return oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: token,
+	})
+}


### PR DESCRIPTION
You can now specify `CONDUCTORONE_CLIENT_ID`, `CONDUCTORONE_CLIENT_SECRET` and `CONDUCTORONE_ACCESS_TOKEN` as environment variables for the Terraform provider. 