### PR TITLE
Pin speakeasy CLI to 1.761.10 (stops 1.761.9 → 1.658.1 fallback)

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: latest
+speakeasyVersion: 1.761.10
 sources:
     my-source:
         inputs:


### PR DESCRIPTION
## Summary

Pin `.speakeasy/workflow.yaml` from `speakeasyVersion: latest` to `1.761.10`.

## Human Why

we should pin our deps so that CI is predictable

## Why

The Speakeasy CI workflow has been failing on the dep-bump merge (#198) with `Server does not implement tfprotov5.ProviderServer (missing method GenerateResourceConfig)` despite the go.mod pinning `terraform-plugin-framework v1.19.0` (which DOES implement it).

Root cause: `speakeasyVersion: latest` resolves to 1.761.9 in CI. 1.761.9 fails at the `tfplugindocs` render step ("data source entitled `repo_*` does not exist") because it infers the provider name from the checkout dir. The sdk-generation-action then auto-falls-back to the cached **1.658.1** — released 2025-12-04, **three months before terraform-plugin-framework v1.19.0** (2026-03-10). 1.658.1's terraform templates predate the v0.30.0 `GenerateResourceConfig` interface change, so it regenerates SDK source against older framework APIs. `go mod tidy` then walks framework back below v1.19.0 to satisfy, breaking the interface assertion in vendored `proto5server/serve.go:14`.

1.761.10 (released 2026-04-30) ships [pagination/error/template fixes (#2029)](https://github.com/speakeasy-api/speakeasy/releases/tag/v1.761.10) which may also address the docs-render bug. Either way, pinning prevents the silent downgrade-to-Dec-2025 path.

## Test plan

- [ ] CI Speakeasy daily/manual regen workflow runs without `Step Failed: Compile SDK` due to missing `GenerateResourceConfig`
- [ ] If 1.761.10 still fails on tfplugindocs render, follow-up: pass `--provider-name conductorone` explicitly to tfplugindocs in `tools/ci_tools.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)