### PR TITLE
Add pull-requests: write perm to speakeasy generate workflow

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -2,6 +2,7 @@ name: Generate
 permissions:
   checks: write
   contents: write
+  pull-requests: write
   statuses: write
 "on":
   workflow_dispatch:


### PR DESCRIPTION
## Summary

One-line addition of `pull-requests: write` to `.github/workflows/speakeasy_sdk_generation.yml`.

## Why

[PR #156 (2025-09-26)](https://github.com/ConductorOne/terraform-provider-conductorone/pull/156) flipped the speakeasy regen workflow from \`mode: direct\` → \`mode: pr\` without adding the matching permission. \`direct\` mode commits straight to main and only needs \`contents: write\`; \`pr\` mode needs \`pull-requests: write\` to open the regen PR.

The workflow has been silently unable to create regen PRs since that change. It still pushes the regen *branch* (because \`contents: write\` is granted), so the underlying compile errors we've been chasing (#198/#199/#200) showed up first — but even with all those fixed, the PR-creation step would have failed without this perm.

\`conductorone-sdk-go\`'s regen workflow has had \`pull-requests: write\` from the start, which is why its \`mode: pr\` flow works (e.g. [PR #108](https://github.com/ConductorOne/conductorone-sdk-go/pull/108)).

## Test plan

- [ ] After merge, kick \`workflow_dispatch\` with \`force: true\` and confirm a PR is opened (not just a branch pushed and abandoned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)