### PR TITLE
Update openapi.yaml to latest c1 main (6 weeks of drift + IGA-1181)

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -35,7 +35,7 @@ generation:
   persistentEdits: {}
   versioningStrategy: automatic
 terraform:
-  version: 1.7.16
+  version: 2.0.0-alpha.1
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,15 +21,42 @@ components:
                   - c1StatusIndicator
                   - c1CodeBlock
                   - c1ResourcePicker
+                  - c1DurationPicker
+                  - c1TodoList
+                  - c1SlackNotifications
+                  - c1MsTeamsNotifications
+                  - c1ConnectorSyncProgress
+                  - c1ConnectorConfigForm
+                  - c1OnboardingWelcome
+                  - c1OnboardingPlan
+                  - c1ConnectorSyncDetail
             properties:
                 button:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.ButtonComponent'
                 c1CodeBlock:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.C1CodeBlockComponent'
+                c1ConnectorConfigForm:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1ConnectorConfigFormComponent'
+                c1ConnectorSyncDetail:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1ConnectorSyncDetailComponent'
+                c1ConnectorSyncProgress:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1ConnectorSyncProgressComponent'
+                c1DurationPicker:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1DurationPickerComponent'
+                c1MsTeamsNotifications:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1MSTeamsNotificationsComponent'
+                c1OnboardingPlan:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1OnboardingPlanComponent'
+                c1OnboardingWelcome:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1OnboardingWelcomeComponent'
                 c1ResourcePicker:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.C1ResourcePickerComponent'
+                c1SlackNotifications:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1SlackNotificationsComponent'
                 c1StatusIndicator:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.C1StatusIndicatorComponent'
+                c1TodoList:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.C1TodoListComponent'
                 card:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.CardComponent'
                 checkBox:
@@ -238,6 +265,10 @@ components:
                     description: The actionName field.
                     readOnly: false
                     type: string
+                componentsSnapshot:
+                    description: The componentsSnapshot field.
+                    readOnly: false
+                    type: string
                 conversationId:
                     description: The conversationId field.
                     readOnly: false
@@ -293,7 +324,7 @@ components:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.FunctionCall'
             title: Action
             type: object
-            x-speakeasy-name-override: Action
+            x-speakeasy-name-override: A2UIAction
         c1.api.a2ui.v1.AndCheck:
             description: AndCheck requires all checks to pass.
             nullable: true
@@ -355,6 +386,179 @@ components:
             title: C 1 Code Block Component
             type: object
             x-speakeasy-name-override: C1CodeBlockComponent
+        c1.api.a2ui.v1.C1ConnectorConfigFormComponent:
+            description: |-
+                C1ConnectorConfigFormComponent renders the shared admin connector-settings form inside an
+                 A2UI surface. The frontend resolves the catalog, connector, and config schema itself from
+                 the ids below, keeping the configuration field values out of the agent's data model — the
+                 agent never receives API keys, passwords, or other secrets entered by the user.
+            nullable: true
+            properties:
+                appId:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                connectorId:
+                    description: The connectorId field.
+                    readOnly: false
+                    type: string
+                skipActionName:
+                    description: The skipActionName field.
+                    readOnly: false
+                    type: string
+                submitActionName:
+                    description: The submitActionName field.
+                    readOnly: false
+                    type: string
+            title: C 1 Connector Config Form Component
+            type: object
+            x-speakeasy-name-override: C1ConnectorConfigFormComponent
+        c1.api.a2ui.v1.C1ConnectorSyncDetailComponent:
+            description: |-
+                C1ConnectorSyncDetailComponent renders the same live card as
+                 C1ConnectorSyncProgressComponent but pre-expanded with the phase checklist,
+                 live count tiles, and "What's happening" explainer visible from the first
+                 paint. Intended for message-body placement — emit one after each
+                 `submit_app_config` so the transcript carries a clear "this is what just
+                 happened" receipt for the connector the user just connected.
+            nullable: true
+            properties:
+                appId:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                connectorId:
+                    description: The connectorId field.
+                    readOnly: false
+                    type: string
+                title:
+                    description: The title field.
+                    readOnly: false
+                    type: string
+            title: C 1 Connector Sync Detail Component
+            type: object
+            x-speakeasy-name-override: C1ConnectorSyncDetailComponent
+        c1.api.a2ui.v1.C1ConnectorSyncProgressComponent:
+            description: |-
+                C1ConnectorSyncProgressComponent renders a live connector sync status card.
+                 Subscribes to WebSocket updates for real-time sync lifecycle status.
+            nullable: true
+            properties:
+                appId:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                connectorId:
+                    description: The connectorId field.
+                    readOnly: false
+                    type: string
+                title:
+                    description: The title field.
+                    readOnly: false
+                    type: string
+            title: C 1 Connector Sync Progress Component
+            type: object
+            x-speakeasy-name-override: C1ConnectorSyncProgressComponent
+        c1.api.a2ui.v1.C1DurationPickerComponent:
+            description: |-
+                C1DurationPickerComponent is the access-request duration picker (presets + custom with number/unit).
+                 Value is duration in seconds bound to the given path.
+            nullable: true
+            properties:
+                label:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
+                maxDurationSeconds:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicNumber'
+                value:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicNumber'
+            title: C 1 Duration Picker Component
+            type: object
+            x-speakeasy-name-override: C1DurationPickerComponent
+        c1.api.a2ui.v1.C1MSTeamsNotificationsComponent:
+            description: |-
+                C1MSTeamsNotificationsComponent renders a self-contained Microsoft Teams integration card.
+                 Fetches status and consent URLs via frontend API calls.
+            nullable: true
+            title: C 1 Ms Teams Notifications Component
+            type: object
+            x-speakeasy-name-override: C1MSTeamsNotificationsComponent
+        c1.api.a2ui.v1.C1OnboardingPlanCategory:
+            description: C1OnboardingPlanCategory groups related plan steps under a section heading.
+            properties:
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+                steps:
+                    description: The steps field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.a2ui.v1.C1OnboardingPlanStep'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                title:
+                    description: The title field.
+                    readOnly: false
+                    type: string
+            title: C 1 Onboarding Plan Category
+            type: object
+            x-speakeasy-name-override: C1OnboardingPlanCategory
+        c1.api.a2ui.v1.C1OnboardingPlanComponent:
+            description: |-
+                C1OnboardingPlanComponent renders a personalized onboarding plan with categorized steps.
+                 The agent dynamically populates categories and steps based on user intent and context.
+            nullable: true
+            properties:
+                categories:
+                    description: The categories field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.a2ui.v1.C1OnboardingPlanCategory'
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: C 1 Onboarding Plan Component
+            type: object
+            x-speakeasy-name-override: C1OnboardingPlanComponent
+        c1.api.a2ui.v1.C1OnboardingPlanStep:
+            description: C1OnboardingPlanStep is a single actionable item in the onboarding plan.
+            properties:
+                agentAssisted:
+                    description: The agentAssisted field.
+                    readOnly: false
+                    type: boolean
+                description:
+                    description: The description field.
+                    readOnly: false
+                    type: string
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+                title:
+                    description: The title field.
+                    readOnly: false
+                    type: string
+            title: C 1 Onboarding Plan Step
+            type: object
+            x-speakeasy-name-override: C1OnboardingPlanStep
+        c1.api.a2ui.v1.C1OnboardingWelcomeComponent:
+            description: |-
+                C1OnboardingWelcomeComponent renders the onboarding welcome screen with org context and intent collection.
+                 Backend pre-populates recommended_catalog_id / recommended_display_name from detected IDP.
+                 Frontend detects auth backend via introspect for contextual UI text.
+            nullable: true
+            properties:
+                recommendedCatalogId:
+                    description: The recommendedCatalogId field.
+                    readOnly: false
+                    type: string
+                recommendedDisplayName:
+                    description: The recommendedDisplayName field.
+                    readOnly: false
+                    type: string
+            title: C 1 Onboarding Welcome Component
+            type: object
+            x-speakeasy-name-override: C1OnboardingWelcomeComponent
         c1.api.a2ui.v1.C1ResourcePickerComponent:
             description: C1ResourcePickerComponent allows selecting C1 resources.
             nullable: true
@@ -374,6 +578,14 @@ components:
             title: C 1 Resource Picker Component
             type: object
             x-speakeasy-name-override: C1ResourcePickerComponent
+        c1.api.a2ui.v1.C1SlackNotificationsComponent:
+            description: |-
+                C1SlackNotificationsComponent renders a self-contained Slack integration card.
+                 Fetches status and OAuth URLs via frontend API calls.
+            nullable: true
+            title: C 1 Slack Notifications Component
+            type: object
+            x-speakeasy-name-override: C1SlackNotificationsComponent
         c1.api.a2ui.v1.C1StatusIndicatorComponent:
             description: C1StatusIndicatorComponent shows agent progress status.
             nullable: true
@@ -389,6 +601,44 @@ components:
             title: C 1 Status Indicator Component
             type: object
             x-speakeasy-name-override: C1StatusIndicatorComponent
+        c1.api.a2ui.v1.C1TodoItem:
+            description: The C1TodoItem message.
+            properties:
+                description:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+                label:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
+                status:
+                    description: The status field.
+                    readOnly: false
+                    type: string
+                trailingAction:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.ServerEvent'
+                trailingActionLabel:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
+            title: C 1 Todo Item
+            type: object
+            x-speakeasy-name-override: C1TodoItem
+        c1.api.a2ui.v1.C1TodoListComponent:
+            description: C1TodoListComponent renders a phase/step checklist with progress tracking.
+            nullable: true
+            properties:
+                items:
+                    description: The items field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.a2ui.v1.C1TodoItem'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                title:
+                    $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
+            title: C 1 Todo List Component
+            type: object
+            x-speakeasy-name-override: C1TodoListComponent
         c1.api.a2ui.v1.CardComponent:
             description: CardComponent is a container with styling.
             nullable: true
@@ -451,6 +701,10 @@ components:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
                 multiSelect:
                     description: The multiSelect field.
+                    readOnly: false
+                    type: boolean
+                required:
+                    description: The required field.
                     readOnly: false
                     type: boolean
                 value:
@@ -734,14 +988,21 @@ components:
                     type: array
                 label:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
-                multiline:
-                    description: The multiline field.
-                    readOnly: false
-                    type: boolean
                 placeholder:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
                 value:
                     $ref: '#/components/schemas/c1.api.a2ui.v1.DynamicString'
+                variant:
+                    description: The variant field.
+                    enum:
+                        - TEXT_FIELD_VARIANT_UNSPECIFIED
+                        - TEXT_FIELD_VARIANT_SHORT_TEXT
+                        - TEXT_FIELD_VARIANT_LONG_TEXT
+                        - TEXT_FIELD_VARIANT_NUMBER
+                        - TEXT_FIELD_VARIANT_OBSCURED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
             title: Text Field Component
             type: object
             x-speakeasy-name-override: TextFieldComponent
@@ -764,14 +1025,14 @@ components:
             type: object
             x-speakeasy-name-override: ValidationCheck
         c1.api.accessconflict.v1.AppEntitlementMonitorBinding:
-            description: The AppEntitlementMonitorBinding message.
+            description: Represents the association of an app entitlement with one side (A or B) of a conflict monitor.
             properties:
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The unique identifier of the bound app entitlement.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The unique identifier of the application containing the entitlement.
                     readOnly: false
                     type: string
                 createdAt:
@@ -783,7 +1044,7 @@ components:
                     readOnly: false
                     type: string
                 entitlementGroup:
-                    description: The entitlementGroup field.
+                    description: Which side of the conflict monitor (A or B) this entitlement is assigned to.
                     enum:
                         - ENTITLEMENT_GROUP_UNSPECIFIED
                         - ENTITLEMENT_GROUP_A
@@ -792,7 +1053,7 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 monitorId:
-                    description: The monitorId field.
+                    description: The unique identifier of the conflict monitor this binding belongs to.
                     readOnly: false
                     type: string
                 updatedAt:
@@ -803,7 +1064,9 @@ components:
             type: object
             x-speakeasy-name-override: AppEntitlementMonitorBinding
         c1.api.accessconflict.v1.ConflictMonitor:
-            description: The ConflictMonitor message.
+            description: |-
+                A conflict monitor defines a Separation of Duty rule between two entitlement sets.
+                 It detects when any user holds entitlements from both set A and set B simultaneously.
             properties:
                 createdAt:
                     format: date-time
@@ -814,27 +1077,27 @@ components:
                     readOnly: false
                     type: string
                 description:
-                    description: The description field.
+                    description: A description explaining the purpose of this Separation of Duty rule.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name of the conflict monitor.
                     readOnly: false
                     type: string
                 enabled:
-                    description: The enabled field.
+                    description: Whether the conflict monitor is actively scanning for violations.
                     readOnly: false
                     type: boolean
                 entitlementSetAId:
-                    description: The entitlementSetAId field.
+                    description: The identifier of entitlement set A in the conflict rule.
                     readOnly: false
                     type: string
                 entitlementSetBId:
-                    description: The entitlementSetBId field.
+                    description: The identifier of entitlement set B in the conflict rule.
                     readOnly: false
                     type: string
                 id:
-                    description: The id field.
+                    description: The unique identifier of this conflict monitor.
                     readOnly: false
                     type: string
                 notificationConfig:
@@ -847,14 +1110,14 @@ components:
             type: object
             x-speakeasy-name-override: ConflictMonitor
         c1.api.accessconflict.v1.ConflictMonitorCreateRequest:
-            description: The ConflictMonitorCreateRequest message.
+            description: The request message for creating a new conflict monitor.
             properties:
                 description:
-                    description: The description field.
+                    description: An optional description explaining the purpose of this Separation of Duty rule.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name for the conflict monitor.
                     readOnly: false
                     type: string
                 notificationConfig:
@@ -865,12 +1128,12 @@ components:
             type: object
             x-speakeasy-name-override: ConflictMonitorCreateRequest
         c1.api.accessconflict.v1.ConflictMonitorDeleteRequestInput:
-            description: The ConflictMonitorDeleteRequest message.
+            description: The request message for deleting a conflict monitor.
             title: Conflict Monitor Delete Request
             type: object
             x-speakeasy-name-override: ConflictMonitorDeleteRequest
         c1.api.accessconflict.v1.ConflictMonitorDeleteResponse:
-            description: The ConflictMonitorDeleteResponse message.
+            description: The response message for deleting a conflict monitor.
             title: Conflict Monitor Delete Response
             type: object
             x-speakeasy-name-override: ConflictMonitorDeleteResponse
@@ -885,14 +1148,14 @@ components:
             type: object
             x-speakeasy-name-override: ConflictMonitorRef
         c1.api.accessconflict.v1.ConflictMonitorUpdateRequestInput:
-            description: The ConflictMonitorUpdateRequest message.
+            description: The request message for updating an existing conflict monitor.
             properties:
                 description:
-                    description: The description field.
+                    description: The updated description for the conflict monitor.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The updated human-readable name for the conflict monitor.
                     readOnly: false
                     type: string
                 notificationConfig:
@@ -901,18 +1164,18 @@ components:
             type: object
             x-speakeasy-name-override: ConflictMonitorUpdateRequest
         c1.api.accessconflict.v1.CreateAppEntitlementMonitorBindingRequest:
-            description: The CreateAppEntitlementMonitorBindingRequest message.
+            description: The request message for creating a new app entitlement monitor binding.
             properties:
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The unique identifier of the app entitlement to bind.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The unique identifier of the application containing the entitlement.
                     readOnly: false
                     type: string
                 entitlementGroup:
-                    description: The entitlementGroup field.
+                    description: Which side of the conflict monitor (A or B) to place this entitlement in.
                     enum:
                         - ENTITLEMENT_GROUP_UNSPECIFIED
                         - ENTITLEMENT_GROUP_A
@@ -921,25 +1184,25 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 monitorId:
-                    description: The monitorId field.
+                    description: The unique identifier of the conflict monitor to bind the entitlement to.
                     readOnly: false
                     type: string
             title: Create App Entitlement Monitor Binding Request
             type: object
             x-speakeasy-name-override: CreateAppEntitlementMonitorBindingRequest
         c1.api.accessconflict.v1.DeleteAppEntitlementMonitorBindingRequest:
-            description: The DeleteAppEntitlementMonitorBindingRequest message.
+            description: The request message for deleting an app entitlement monitor binding.
             properties:
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The unique identifier of the app entitlement to unbind.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The unique identifier of the application containing the entitlement.
                     readOnly: false
                     type: string
                 entitlementGroup:
-                    description: The entitlementGroup field.
+                    description: Which side of the conflict monitor (A or B) the binding belongs to.
                     enum:
                         - ENTITLEMENT_GROUP_UNSPECIFIED
                         - ENTITLEMENT_GROUP_A
@@ -948,14 +1211,14 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 monitorId:
-                    description: The monitorId field.
+                    description: The unique identifier of the conflict monitor.
                     readOnly: false
                     type: string
             title: Delete App Entitlement Monitor Binding Request
             type: object
             x-speakeasy-name-override: DeleteAppEntitlementMonitorBindingRequest
         c1.api.accessconflict.v1.DeleteAppEntitlementMonitorBindingResponse:
-            description: The DeleteAppEntitlementMonitorBindingResponse message.
+            description: The response message for deleting an app entitlement monitor binding.
             title: Delete App Entitlement Monitor Binding Response
             type: object
             x-speakeasy-name-override: DeleteAppEntitlementMonitorBindingResponse
@@ -977,18 +1240,18 @@ components:
             type: object
             x-speakeasy-name-override: EmailNotifications
         c1.api.accessconflict.v1.GetAppEntitlementMonitorBindingRequest:
-            description: The GetAppEntitlementMonitorBindingRequest message.
+            description: The request message for retrieving a single app entitlement monitor binding.
             properties:
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The unique identifier of the app entitlement bound to the monitor.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The unique identifier of the application containing the entitlement.
                     readOnly: false
                     type: string
                 entitlementGroup:
-                    description: The entitlementGroup field.
+                    description: Which side of the conflict monitor (A or B) this binding belongs to.
                     enum:
                         - ENTITLEMENT_GROUP_UNSPECIFIED
                         - ENTITLEMENT_GROUP_A
@@ -997,7 +1260,7 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 monitorId:
-                    description: The monitorId field.
+                    description: The unique identifier of the conflict monitor.
                     readOnly: false
                     type: string
             title: Get App Entitlement Monitor Binding Request
@@ -1012,7 +1275,7 @@ components:
                     $ref: '#/components/schemas/c1.api.accessconflict.v1.SlackNotifications'
             title: Notification Config
             type: object
-            x-speakeasy-name-override: NotificationConfig
+            x-speakeasy-name-override: AccessConflictNotificationConfig
         c1.api.accessconflict.v1.SlackNotifications:
             description: The SlackNotifications message.
             properties:
@@ -1033,7 +1296,7 @@ components:
             x-speakeasy-name-override: SlackNotifications
         c1.api.accessreview.v1.AccessReview:
             description: |
-                The AccessReview message.
+                An access review campaign (also called a certification campaign) that verifies whether users still need their access entitlements.
 
                 This message contains a oneof named setup_metadata. Only a single field of the following list may be set at a time:
                   - singleApp
@@ -1074,7 +1337,7 @@ components:
                     readOnly: false
                     type: boolean
                 autoResolve:
-                    description: The autoResolve field.
+                    description: When true, selections are automatically resolved if the entitlement grant no longer exists.
                     readOnly: false
                     type: boolean
                 autoStartCampaign:
@@ -1083,10 +1346,16 @@ components:
                     type: boolean
                 bindings:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.BindingObjectSetup'
+                campaignHealth:
+                    $ref: '#/components/schemas/c1.api.accessreview.v1.CampaignHealthSnapshot'
+                campaignInsights:
+                    $ref: '#/components/schemas/c1.api.accessreview.v1.CampaignInsights'
                 closedAt:
                     format: date-time
                     readOnly: false
                     type: string
+                columnConfig:
+                    $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewColumnConfig'
                 completionDate:
                     format: date-time
                     readOnly: false
@@ -1100,7 +1369,7 @@ components:
                     readOnly: true
                     type: string
                 createdById:
-                    description: The createdById field.
+                    description: The ID of the user who created this campaign.
                     readOnly: false
                     type: string
                 defaultView:
@@ -1110,17 +1379,28 @@ components:
                         - ACCESS_REVIEW_VIEW_TYPE_BY_APP
                         - ACCESS_REVIEW_VIEW_TYPE_BY_USER
                         - ACCESS_REVIEW_VIEW_TYPE_UNSTRUCTURED
+                        - ACCESS_REVIEW_VIEW_TYPE_BY_RESOURCE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
                 description:
-                    description: The description field.
+                    description: An optional description providing context about this campaign.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name of this campaign.
                     readOnly: false
                     type: string
+                errorState:
+                    description: |-
+                        Error state set when a prepare action fails with a recoverable condition.
+                         Cleared when the campaign scope is changed.
+                    enum:
+                        - ACCESS_REVIEW_ERROR_STATE_UNSPECIFIED
+                        - ACCESS_REVIEW_ERROR_STATE_SELECTION_QUOTA_EXCEED_ERROR
+                    readOnly: true
+                    type: string
+                    x-speakeasy-unknown-values: allow
                 exclusionScope:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewExclusionScope'
                 exemptCertifiedAccessConflicts:
@@ -1128,16 +1408,16 @@ components:
                     readOnly: false
                     type: boolean
                 expectedTicketCount:
-                    description: The expectedTicketCount field.
+                    description: The estimated number of review tasks that will be generated when the campaign starts.
                     format: int32
                     readOnly: false
                     type: integer
                 hasAccuracySupport:
-                    description: The hasAccuracySupport field.
+                    description: Whether the connectors in this campaign support accuracy checking.
                     readOnly: false
                     type: boolean
                 id:
-                    description: The id field.
+                    description: The unique identifier of this access review campaign.
                     readOnly: false
                     type: string
                 inclusionScope:
@@ -1147,11 +1427,11 @@ components:
                 notificationConfig:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.NotificationConfig'
                 policyId:
-                    description: The policyId field.
+                    description: The ID of the review policy that governs how review tasks are assigned and resolved.
                     readOnly: false
                     type: string
                 reviewInstructions:
-                    description: The reviewInstructions field.
+                    description: Optional instructions displayed to reviewers when completing their review tasks.
                     readOnly: false
                     type: string
                 scheduledStartDate:
@@ -1167,13 +1447,14 @@ components:
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_ENTITLEMENTS
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_ACCESS_CONFLICTS
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_RESOURCE
+                        - ACCESS_REVIEW_SCOPE_TYPE_BY_INHERITANCE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
                 scopeV2:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewScopeV2'
                 scopingVersion:
-                    description: The scopingVersion field.
+                    description: Internal version counter incremented when the campaign scope changes.
                     format: int64
                     readOnly: false
                     type: string
@@ -1186,7 +1467,7 @@ components:
                     readOnly: false
                     type: string
                 state:
-                    description: The state field.
+                    description: The current lifecycle state of the campaign (e.g., draft, open, closed).
                     enum:
                         - ACCESS_REVIEW_STATE_UNSPECIFIED
                         - ACCESS_REVIEW_STATE_OPEN
@@ -1218,6 +1499,50 @@ components:
             type: object
             x-speakeasy-entity: Access Review
             x-speakeasy-name-override: AccessReview
+        c1.api.accessreview.v1.AccessReviewColumnConfig:
+            description: Configuration for which columns are visible in the reviewer task list.
+            properties:
+                columns:
+                    description: |-
+                        Ordered list of columns visible to reviewers.
+                         If empty, the default column set for the campaign's default_view is used.
+                    items:
+                        enum:
+                            - ACCESS_REVIEW_TASK_COLUMN_UNSPECIFIED
+                            - ACCESS_REVIEW_TASK_COLUMN_VIEW_LINK
+                            - ACCESS_REVIEW_TASK_COLUMN_CURRENT_STATE
+                            - ACCESS_REVIEW_TASK_COLUMN_ACCOUNT
+                            - ACCESS_REVIEW_TASK_COLUMN_ACCOUNT_OWNER
+                            - ACCESS_REVIEW_TASK_COLUMN_ENTITLEMENT
+                            - ACCESS_REVIEW_TASK_COLUMN_ENTITLEMENT_DESCRIPTION
+                            - ACCESS_REVIEW_TASK_COLUMN_RESOURCE
+                            - ACCESS_REVIEW_TASK_COLUMN_RESOURCE_TYPE
+                            - ACCESS_REVIEW_TASK_COLUMN_INSIGHTS
+                            - ACCESS_REVIEW_TASK_COLUMN_RECOMMENDATION
+                            - ACCESS_REVIEW_TASK_COLUMN_ASSIGNED_TO
+                            - ACCESS_REVIEW_TASK_COLUMN_STATUS
+                            - ACCESS_REVIEW_TASK_COLUMN_APP
+                            - ACCESS_REVIEW_TASK_COLUMN_DUE
+                            - ACCESS_REVIEW_TASK_COLUMN_PROJECT
+                            - ACCESS_REVIEW_TASK_COLUMN_CREATED_ON
+                            - ACCESS_REVIEW_TASK_COLUMN_TASK_AGE
+                            - ACCESS_REVIEW_TASK_COLUMN_RESOLVED_ON
+                            - ACCESS_REVIEW_TASK_COLUMN_ENROLLMENT_STATUS
+                            - ACCESS_REVIEW_TASK_COLUMN_INHERITED_FROM
+                            - ACCESS_REVIEW_TASK_COLUMN_DEPARTMENT
+                            - ACCESS_REVIEW_TASK_COLUMN_JOB_TITLE
+                            - ACCESS_REVIEW_TASK_COLUMN_CREATED_BY
+                            - ACCESS_REVIEW_TASK_COLUMN_LAST_LOGIN
+                            - ACCESS_REVIEW_TASK_COLUMN_RESOURCE_PARENT
+                            - ACCESS_REVIEW_TASK_COLUMN_RESOURCE_CHILDREN
+                        type: string
+                        x-speakeasy-unknown-values: allow
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Access Review Column Config
+            type: object
+            x-speakeasy-name-override: AccessReviewColumnConfig
         c1.api.accessreview.v1.AccessReviewExclusionScope:
             description: The AccessReviewExclusionScope message.
             properties:
@@ -1444,15 +1769,15 @@ components:
                     readOnly: false
                     type: string
                 description:
-                    description: The description field.
+                    description: An optional description providing context about the campaign.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The display name for the new campaign.
                     readOnly: false
                     type: string
                 duplicateFrom:
-                    description: The duplicateFrom field.
+                    description: The ID of an existing campaign to copy scope and entitlement configuration from. Optional.
                     readOnly: false
                     type: string
                 expandMask:
@@ -1460,23 +1785,24 @@ components:
                 notificationConfig:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.NotificationConfig'
                 ownerIds:
-                    description: The ownerIds field.
+                    description: The IDs of the users who own and manage this campaign. At least one owner is required.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 policyId:
-                    description: The policyId field.
+                    description: The ID of the review policy that governs task assignment and resolution.
                     readOnly: false
                     type: string
                 scopeType:
-                    description: The scopeType field.
+                    description: The type of scoping method for the campaign (e.g., by entitlements, by access conflicts, or by resource).
                     enum:
                         - ACCESS_REVIEW_SCOPE_TYPE_UNSPECIFIED
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_ENTITLEMENTS
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_ACCESS_CONFLICTS
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_RESOURCE
+                        - ACCESS_REVIEW_SCOPE_TYPE_BY_INHERITANCE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -1491,7 +1817,7 @@ components:
                 accessReview:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewView'
                 expanded:
-                    description: The expanded field.
+                    description: Related objects requested via the expand mask.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -1523,7 +1849,7 @@ components:
                 accessReview:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewView'
                 expanded:
-                    description: The expanded field.
+                    description: Related objects requested via the expand mask.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -1543,7 +1869,7 @@ components:
             description: The AccessReviewServiceListResponse message.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: Related objects requested via the expand mask.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -1557,14 +1883,14 @@ components:
                     readOnly: false
                     type: array
                 list:
-                    description: The list field.
+                    description: The list of access review campaigns for the current page.
                     items:
                         $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewView'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: Access Review Service List Response
@@ -1590,7 +1916,7 @@ components:
                 accessReview:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewView'
                 expanded:
-                    description: The expanded field.
+                    description: Related objects requested via the expand mask.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -1610,7 +1936,7 @@ components:
             description: The AccessReviewSetScopeByResourceTypeRequest message.
             properties:
                 resourceTypeSelections:
-                    description: The resourceTypeSelections field.
+                    description: The resource types to include in the campaign scope. Replaces all previously selected resource types.
                     items:
                         $ref: '#/components/schemas/c1.api.accessreview.v1.ResourceTypeIdRef'
                     nullable: true
@@ -1627,26 +1953,26 @@ components:
             type: object
             x-speakeasy-name-override: AccessReviewSetScopeByResourceTypeResponse
         c1.api.accessreview.v1.AccessReviewSetupEntitlement:
-            description: The AccessReviewSetupEntitlement message.
+            description: An entitlement that has been selected for inclusion in an access review campaign during setup.
             properties:
                 accessReviewId:
-                    description: The accessReviewId field.
+                    description: The ID of the access review campaign this entitlement belongs to.
                     readOnly: false
                     type: string
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The ID of the entitlement being reviewed.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The ID of the application that owns the entitlement.
                     readOnly: false
                     type: string
                 appResourceId:
-                    description: The appResourceId field.
+                    description: The ID of the specific resource associated with this entitlement, if applicable.
                     readOnly: false
                     type: string
                 appResourceTypeId:
-                    description: The appResourceTypeId field.
+                    description: The ID of the resource type associated with this entitlement, if applicable.
                     readOnly: false
                     type: string
                 createdAt:
@@ -1654,7 +1980,7 @@ components:
                     readOnly: true
                     type: string
                 customPolicyId:
-                    description: The customPolicyId field.
+                    description: An override policy ID for this specific entitlement. Populated when use_policy_override is enabled on the campaign.
                     readOnly: false
                     type: string
                 deletedAt:
@@ -1662,11 +1988,11 @@ components:
                     readOnly: true
                     type: string
                 policyId:
-                    description: The policyId field.
+                    description: The ID of the review policy applied to this entitlement. Defaults to the campaign policy.
                     readOnly: false
                     type: string
                 tenantId:
-                    description: The tenantId field.
+                    description: The tenant that owns this setup entitlement.
                     readOnly: false
                     type: string
                 updatedAt:
@@ -1680,7 +2006,7 @@ components:
             description: The AccessReviewSetupEntitlementAndScopeServiceSetRequest message.
             properties:
                 entitlements:
-                    description: The entitlements field.
+                    description: The entitlements to include in the campaign. Replaces all previously selected entitlements.
                     items:
                         $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewSetupEntitlementInput'
                     nullable: true
@@ -1697,7 +2023,7 @@ components:
             description: The AccessReviewSetupEntitlementAndScopeServiceSetResponse message.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: Related objects requested via the expand mask.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -1711,7 +2037,7 @@ components:
                     readOnly: false
                     type: array
                 list:
-                    description: The list field.
+                    description: The current list of setup entitlements for the campaign.
                     items:
                         $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewSetupEntitlementView'
                     nullable: true
@@ -1736,14 +2062,14 @@ components:
             type: object
             x-speakeasy-name-override: AccessReviewSetupEntitlementExpandMask
         c1.api.accessreview.v1.AccessReviewSetupEntitlementInput:
-            description: The AccessReviewSetupEntitlementInput message.
+            description: Identifies an entitlement to add or remove from a campaign's setup.
             properties:
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The ID of the entitlement.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The ID of the application that owns the entitlement.
                     readOnly: false
                     type: string
             title: Access Review Setup Entitlement Input
@@ -1771,7 +2097,8 @@ components:
             x-speakeasy-name-override: AccessReviewSetupEntitlementView
         c1.api.accessreview.v1.AccessReviewTemplate:
             description: |
-                The AccessReviewTemplate message.
+                A reusable template that defines the configuration for creating access review campaigns.
+                 Templates can optionally be scheduled to automatically create campaigns on a recurring basis.
 
                 This message contains a oneof named slack_channel_details. Only a single field of the following list may be set at a time:
                   - slackChannel
@@ -1815,6 +2142,8 @@ components:
                          next_scheduled_campaign_at will be used as the scheduled start date
                     readOnly: false
                     type: boolean
+                columnConfig:
+                    $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewColumnConfig'
                 createdAt:
                     format: date-time
                     readOnly: true
@@ -1826,6 +2155,7 @@ components:
                         - ACCESS_REVIEW_VIEW_TYPE_BY_APP
                         - ACCESS_REVIEW_VIEW_TYPE_BY_USER
                         - ACCESS_REVIEW_VIEW_TYPE_UNSTRUCTURED
+                        - ACCESS_REVIEW_VIEW_TYPE_BY_RESOURCE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -1834,11 +2164,11 @@ components:
                     readOnly: true
                     type: string
                 description:
-                    description: The description field.
+                    description: An optional description providing context about this template.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name of this template.
                     readOnly: false
                     type: string
                 exemptCertifiedAccessConflicts:
@@ -1846,13 +2176,13 @@ components:
                     readOnly: false
                     type: boolean
                 id:
-                    description: The id field.
+                    description: The unique identifier of this template.
                     readOnly: false
                     type: string
                 inclusionScope:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewInclusionScope'
                 isCampaignScheduleEnabled:
-                    description: The isCampaignScheduleEnabled field.
+                    description: Whether automatic campaign creation on the recurrence schedule is enabled.
                     readOnly: false
                     type: boolean
                 nextScheduledCampaignAt:
@@ -1862,12 +2192,12 @@ components:
                 notificationConfig:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.NotificationConfig'
                 occurrences:
-                    description: The occurrences field.
+                    description: The number of campaigns that have been created from this template.
                     format: int32
                     readOnly: false
                     type: integer
                 policyId:
-                    description: The policyId field.
+                    description: The ID of the default review policy applied to campaigns created from this template.
                     readOnly: false
                     type: string
                 recurrenceRule:
@@ -1885,6 +2215,7 @@ components:
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_ENTITLEMENTS
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_ACCESS_CONFLICTS
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_RESOURCE
+                        - ACCESS_REVIEW_SCOPE_TYPE_BY_INHERITANCE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -1942,6 +2273,8 @@ components:
                     description: The autoStartCampaign field.
                     readOnly: false
                     type: boolean
+                columnConfig:
+                    $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewColumnConfig'
                 defaultView:
                     description: The defaultView field.
                     enum:
@@ -1949,15 +2282,16 @@ components:
                         - ACCESS_REVIEW_VIEW_TYPE_BY_APP
                         - ACCESS_REVIEW_VIEW_TYPE_BY_USER
                         - ACCESS_REVIEW_VIEW_TYPE_UNSTRUCTURED
+                        - ACCESS_REVIEW_VIEW_TYPE_BY_RESOURCE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
                 description:
-                    description: The description field.
+                    description: An optional description providing context about the template.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The display name for the new template.
                     readOnly: false
                     type: string
                 exemptCertifiedAccessConflicts:
@@ -1971,14 +2305,14 @@ components:
                 notificationConfig:
                     $ref: '#/components/schemas/c1.api.accessreview.v1.NotificationConfig'
                 ownerIds:
-                    description: The ownerIds field.
+                    description: The IDs of the users who own this template. At least one owner is required.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 policyId:
-                    description: The policyId field.
+                    description: The ID of the default review policy for campaigns created from this template.
                     readOnly: false
                     type: string
                 recurrenceRule:
@@ -1996,6 +2330,7 @@ components:
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_ENTITLEMENTS
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_ACCESS_CONFLICTS
                         - ACCESS_REVIEW_SCOPE_TYPE_BY_RESOURCE
+                        - ACCESS_REVIEW_SCOPE_TYPE_BY_INHERITANCE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -2058,7 +2393,7 @@ components:
             description: The AccessReviewTemplateSetScopeByResourceTypeRequest message.
             properties:
                 resourceTypeSelections:
-                    description: The resourceTypeSelections field.
+                    description: The resource types to include in the template scope. Replaces all previously selected resource types.
                     items:
                         $ref: '#/components/schemas/c1.api.accessreview.v1.ResourceTypeIdRef'
                     nullable: true
@@ -2075,26 +2410,26 @@ components:
             type: object
             x-speakeasy-name-override: AccessReviewTemplateSetScopeByResourceTypeResponse
         c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlement:
-            description: The AccessReviewTemplateSetupEntitlement message.
+            description: An entitlement that has been selected for inclusion in an access review template's scope.
             properties:
                 accessReviewTemplateId:
-                    description: The accessReviewTemplateId field.
+                    description: The ID of the access review template this entitlement belongs to.
                     readOnly: false
                     type: string
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The ID of the entitlement to be reviewed.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The ID of the application that owns the entitlement.
                     readOnly: false
                     type: string
                 appResourceId:
-                    description: The appResourceId field.
+                    description: The ID of the specific resource associated with this entitlement, if applicable.
                     readOnly: false
                     type: string
                 appResourceTypeId:
-                    description: The appResourceTypeId field.
+                    description: The ID of the resource type associated with this entitlement, if applicable.
                     readOnly: false
                     type: string
                 createdAt:
@@ -2102,7 +2437,7 @@ components:
                     readOnly: true
                     type: string
                 customPolicyId:
-                    description: The customPolicyId field.
+                    description: An override policy ID for this specific entitlement. Populated when use_policy_override is enabled on the template.
                     readOnly: false
                     type: string
                 deletedAt:
@@ -2110,11 +2445,11 @@ components:
                     readOnly: true
                     type: string
                 policyId:
-                    description: The policyId field.
+                    description: The ID of the review policy applied to this entitlement. Defaults to the template policy.
                     readOnly: false
                     type: string
                 tenantId:
-                    description: The tenantId field.
+                    description: The tenant that owns this setup entitlement.
                     readOnly: false
                     type: string
                 updatedAt:
@@ -2138,14 +2473,14 @@ components:
             type: object
             x-speakeasy-name-override: AccessReviewTemplateSetupEntitlementExpandMask
         c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementInput:
-            description: The AccessReviewTemplateSetupEntitlementInput message.
+            description: Identifies an entitlement to add or remove from a template's setup.
             properties:
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The ID of the entitlement.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The ID of the application that owns the entitlement.
                     readOnly: false
                     type: string
             title: Access Review Template Setup Entitlement Input
@@ -2155,7 +2490,7 @@ components:
             description: The AccessReviewTemplateSetupEntitlementServiceSetRequest message.
             properties:
                 entitlements:
-                    description: The entitlements field.
+                    description: The entitlements to include in the template. Replaces all previously selected entitlements.
                     items:
                         $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementInput'
                     nullable: true
@@ -2172,7 +2507,7 @@ components:
             description: The AccessReviewTemplateSetupEntitlementServiceSetResponse message.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: Related objects requested via the expand mask.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -2186,7 +2521,7 @@ components:
                     readOnly: false
                     type: array
                 list:
-                    description: The list field.
+                    description: The current list of setup entitlements for the template.
                     items:
                         $ref: '#/components/schemas/c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementView'
                     nullable: true
@@ -2356,6 +2691,31 @@ components:
             title: Campaign Entitlement Details
             type: object
             x-speakeasy-name-override: CampaignEntitlementDetails
+        c1.api.accessreview.v1.CampaignHealthSnapshot:
+            description: Campaign health snapshot. Read-only; updated by backend maintenance processors.
+            properties:
+                checkedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                phantomLockedCount:
+                    description: Number of pending actions locked by terminal (dead) submissions.
+                    format: int32
+                    readOnly: false
+                    type: integer
+            title: Campaign Health Snapshot
+            type: object
+            x-speakeasy-name-override: CampaignHealthSnapshot
+        c1.api.accessreview.v1.CampaignInsights:
+            description: AI-generated campaign insights (markdown). Read-only; set by backend when campaign is closed.
+            properties:
+                markdown:
+                    description: The markdown field.
+                    readOnly: false
+                    type: string
+            title: Campaign Insights
+            type: object
+            x-speakeasy-name-override: CampaignInsights
         c1.api.accessreview.v1.CelExpressionScope:
             description: The CelExpressionScope message.
             nullable: true
@@ -2538,23 +2898,23 @@ components:
             type: object
             x-speakeasy-name-override: MultiAppSetup
         c1.api.accessreview.v1.NotificationConfig:
-            description: The NotificationConfig message.
+            description: Controls which email notifications are sent during the access review lifecycle.
             properties:
                 sendClose:
-                    description: The sendClose field.
+                    description: Whether to send a notification when the campaign is closed.
                     readOnly: false
                     type: boolean
                 sendKickoff:
-                    description: The sendKickoff field.
+                    description: Whether to send a notification when the campaign is started.
                     readOnly: false
                     type: boolean
                 sendReminders:
-                    description: The sendReminders field.
+                    description: Whether to send periodic reminder emails to reviewers with outstanding tasks.
                     readOnly: false
                     type: boolean
             title: Notification Config
             type: object
-            x-speakeasy-name-override: NotificationConfig
+            x-speakeasy-name-override: AccessReviewNotificationConfig
         c1.api.accessreview.v1.RecurrenceRule:
             description: |
                 The RecurrenceRule message.
@@ -2607,14 +2967,14 @@ components:
             type: object
             x-speakeasy-name-override: ResourceSelectionScope
         c1.api.accessreview.v1.ResourceTypeIdRef:
-            description: The ResourceTypeIdRef message.
+            description: A reference to a resource type within an application.
             properties:
                 appId:
-                    description: The appId field.
+                    description: The ID of the application that owns the resource type.
                     readOnly: false
                     type: string
                 resourceTypeId:
-                    description: The resourceTypeId field.
+                    description: The ID of the resource type.
                     readOnly: false
                     type: string
             title: Resource Type Id Ref
@@ -2766,17 +3126,17 @@ components:
             type: object
             x-speakeasy-name-override: AddAppOwnerResponse
         c1.api.app.v1.AddAppResourceOwnerRequestInput:
-            description: The AddAppResourceOwnerRequest message.
+            description: The request message for adding an owner to an app resource.
             properties:
                 userId:
-                    description: The userId field.
+                    description: The C1 user ID to add as an owner.
                     readOnly: false
                     type: string
             title: Add App Resource Owner Request
             type: object
             x-speakeasy-name-override: AddAppResourceOwnerRequest
         c1.api.app.v1.AddAppResourceOwnerResponse:
-            description: The AddAppResourceOwnerResponse message.
+            description: The empty response message for adding an owner to an app resource.
             title: Add App Resource Owner Response
             type: object
             x-speakeasy-name-override: AddAppResourceOwnerResponse
@@ -2784,7 +3144,7 @@ components:
             description: The AddAutomationExclusionRequest message.
             properties:
                 userIds:
-                    description: The userIds field.
+                    description: The IDs of users to add to the automation exclusion list.
                     items:
                         type: string
                     nullable: true
@@ -2802,7 +3162,7 @@ components:
             description: The AddManuallyManagedUsersRequest message.
             properties:
                 userIds:
-                    description: The userIds field.
+                    description: The IDs of users to add as manually managed members.
                     items:
                         type: string
                     nullable: true
@@ -2814,6 +3174,18 @@ components:
         c1.api.app.v1.App:
             description: The App object provides all of the details for an app, as well as some configuration.
             properties:
+                accessModel:
+                    description: |-
+                        How this app models access. Derived during uplift from the app's resource type traits.
+                         Sparse ACL feature.
+                    enum:
+                        - APP_ACCESS_MODEL_UNSPECIFIED
+                        - APP_ACCESS_MODEL_CLASSIC
+                        - APP_ACCESS_MODEL_HYBRID
+                        - APP_ACCESS_MODEL_SPARSE
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
                 appAccountId:
                     description: The ID of the Account named by AccountName.
                     readOnly: true
@@ -2976,7 +3348,7 @@ components:
                     readOnly: false
                     type: string
                 requestPolicyId:
-                    description: The requestPolicyId field.
+                    description: The ID of the request policy to apply to entitlements matching this rule.
                     readOnly: false
                     type: string
                 requestSchemaId:
@@ -3042,7 +3414,7 @@ components:
                     readOnly: false
                     type: string
                 requestPolicyId:
-                    description: The requestPolicyId field.
+                    description: The ID of the request policy to apply to entitlements matching this rule.
                     readOnly: false
                     type: string
                 requestSchemaId:
@@ -3155,6 +3527,12 @@ components:
                     description: The ID of the policy that will be used for emergency access grant tasks.
                     readOnly: false
                     type: string
+                externalId:
+                    description: |-
+                        The upstream product's native external ID for this entitlement (e.g. an Okta group ID).
+                         Populated from the connector's external ID during sync.
+                    readOnly: true
+                    type: string
                 grantCount:
                     description: The amount of grants open for this entitlement
                     format: int64
@@ -3177,7 +3555,7 @@ components:
                     readOnly: false
                     type: boolean
                 matchBatonId:
-                    description: The matchBatonId field.
+                    description: An identifier used to match this entitlement to a connector-synced entitlement during sync.
                     readOnly: false
                     type: string
                 overrideAccessRequestsDefaults:
@@ -3187,7 +3565,7 @@ components:
                 provisionerPolicy:
                     $ref: '#/components/schemas/c1.api.policy.v1.ProvisionPolicy'
                 purpose:
-                    description: The purpose field.
+                    description: The purpose of this entitlement (e.g., assignment, permission, ownership).
                     enum:
                         - APP_ENTITLEMENT_PURPOSE_VALUE_UNSPECIFIED
                         - APP_ENTITLEMENT_PURPOSE_VALUE_ASSIGNMENT
@@ -3205,7 +3583,7 @@ components:
                     readOnly: false
                     type: string
                 riskLevelValueId:
-                    description: The riskLevelValueId field.
+                    description: The ID of the risk level assigned to this entitlement.
                     readOnly: false
                     type: string
                 slug:
@@ -3276,6 +3654,12 @@ components:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementAutomationRuleEntitlement'
                 lastRunStatus:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementAutomationLastRunStatus'
+                managedByRequestCatalogId:
+                    description: |-
+                        When set, this automation is managed by an access profile's bundle automation.
+                         Read-only. Not settable via this API.
+                    readOnly: true
+                    type: string
                 none:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementAutomationRuleNone'
                 updatedAt:
@@ -3366,11 +3750,7 @@ components:
             type: object
             x-speakeasy-name-override: AppEntitlementExpandMask
         c1.api.app.v1.AppEntitlementProxy:
-            description: |
-                The AppEntitlementProxy message.
-
-                This message contains a oneof named _implicit. Only a single field of the following list may be set at a time:
-                  - implicit
+            description: An entitlement proxy binding that defines a hierarchical relationship between two entitlements.
             properties:
                 createdAt:
                     format: date-time
@@ -3385,32 +3765,28 @@ components:
                     readOnly: false
                     type: string
                 dstAppEntitlementId:
-                    description: The dstAppEntitlementId field.
+                    description: The ID of the destination (child) entitlement.
                     readOnly: false
                     type: string
                 dstAppId:
-                    description: The dstAppId field.
+                    description: The ID of the app that owns the destination entitlement.
                     readOnly: false
                     type: string
                 implicit:
-                    description: |-
-                        If true, the binding doesn't not exist yet and is from the list of the entitlements from the parent app.
-                         typically the IdP that handles provisioning for the app instead of C1s connector.
-                        This field is part of the `_implicit` oneof.
-                        See the documentation for `c1.api.app.v1.AppEntitlementProxy` for more details.
+                    description: If true, the binding does not exist yet and is inferred from the entitlements of the parent app.
                     nullable: true
                     readOnly: false
                     type: boolean
                 srcAppEntitlementId:
-                    description: The srcAppEntitlementId field.
+                    description: The ID of the source (parent) entitlement.
                     readOnly: false
                     type: string
                 srcAppId:
-                    description: The srcAppId field.
+                    description: The ID of the app that owns the source entitlement.
                     readOnly: false
                     type: string
                 systemBuiltin:
-                    description: The systemBuiltin field.
+                    description: If true, this binding was created by the system and cannot be removed by the user.
                     readOnly: false
                     type: boolean
                 updatedAt:
@@ -3493,6 +3869,13 @@ components:
                     description: Search for grants of an entitlement
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                entitlementSlugs:
+                    description: Filter for entitlements whose slug is in this list (e.g. "enrollment" for access profiles)
+                    items:
+                        type: string
                     nullable: true
                     readOnly: false
                     type: array
@@ -3598,14 +3981,14 @@ components:
                     readOnly: false
                     type: array
                 complianceFrameworkIds:
-                    description: Search for app entitlements that are part of these compliace frameworks.
+                    description: Search for app entitlements that are part of these compliance frameworks.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 displayName:
-                    description: The displayName field.
+                    description: Filter results to entitlements with this exact display name.
                     readOnly: false
                     type: string
                 excludeAppIds:
@@ -3616,25 +3999,25 @@ components:
                     readOnly: false
                     type: array
                 excludeAppUserIds:
-                    description: Exclude app entitlements from the results that these app users have granted.
+                    description: Exclude entitlements from results that are granted to any of these app users.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 excludeImmutable:
-                    description: The excludeImmutable field.
+                    description: If true, exclude immutable entitlements (e.g., system-managed entitlements that cannot be modified).
                     readOnly: false
                     type: boolean
                 excludeResourceTypeIds:
-                    description: The excludeResourceTypeIds field.
+                    description: Exclude entitlements with any of these resource type IDs from results.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 excludedEntitlementRefs:
-                    description: The excludedEntitlementRefs field.
+                    description: Exclude these specific entitlements from results.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                     nullable: true
@@ -3647,11 +4030,11 @@ components:
                     readOnly: false
                     type: boolean
                 isAutomated:
-                    description: The isAutomated field.
+                    description: If true, restrict results to entitlements that have an automation rule configured.
                     readOnly: false
                     type: boolean
                 membershipType:
-                    description: The membershipType field.
+                    description: Filter results to entitlements where the user has any of these membership types (e.g., member, owner, admin).
                     items:
                         enum:
                             - APP_ENTITLEMENT_MEMBERSHIP_TYPE_UNSPECIFIED
@@ -3665,7 +4048,7 @@ components:
                     readOnly: false
                     type: array
                 onlyGetExpiring:
-                    description: Restrict results to only those who have expiring app entitlement user bindings.
+                    description: If true, restrict results to entitlements that have at least one expiring grant.
                     readOnly: false
                     type: boolean
                 pageSize:
@@ -3689,7 +4072,7 @@ components:
                     readOnly: false
                     type: string
                 refs:
-                    description: The refs field.
+                    description: Filter results to only these specific entitlements.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                     nullable: true
@@ -3703,7 +4086,7 @@ components:
                     readOnly: false
                     type: array
                 resourceTraitIds:
-                    description: The resourceTraitIds field.
+                    description: Filter results to entitlements whose resource types have any of these trait IDs.
                     items:
                         type: string
                     nullable: true
@@ -3724,7 +4107,7 @@ components:
                     readOnly: false
                     type: array
                 sourceConnectorId:
-                    description: The sourceConnectorId field.
+                    description: Filter results to entitlements synced from this connector.
                     readOnly: false
                     type: string
             title: App Entitlement Search Service Search Request
@@ -4017,20 +4400,20 @@ components:
             type: object
             x-speakeasy-name-override: AppEntitlementView
         c1.api.app.v1.AppEntitlementWithExpired:
-            description: The AppEntitlementWithExpired message.
+            description: A grant with its expiry and discovery timestamps, along with the associated app user and ConductorOne user.
             properties:
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 appUser:
                     $ref: '#/components/schemas/c1.api.app.v1.AppUser'
                 appUserId:
-                    description: The appUserId field.
+                    description: The ID of the app user who holds the grant.
                     readOnly: false
                     type: string
                 discovered:
@@ -4042,14 +4425,14 @@ components:
                     readOnly: false
                     type: string
                 grantReasons:
-                    description: The grantReasons field.
+                    description: The reasons this grant was given (e.g., access request, automation).
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.GrantReason'
                     nullable: true
                     readOnly: false
                     type: array
                 grantSources:
-                    description: The grantSources field.
+                    description: Entitlements that are the source of this grant (e.g., a group membership that implies a role).
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                     nullable: true
@@ -4197,6 +4580,12 @@ components:
                     description: The display name for this resource.
                     readOnly: false
                     type: string
+                externalId:
+                    description: |-
+                        The upstream product's native external ID for this resource (e.g. an Okta group ID).
+                         Populated from the connector's external ID during sync.
+                    readOnly: true
+                    type: string
                 grantCount:
                     description: The number of grants to this resource.
                     format: int64
@@ -4246,18 +4635,18 @@ components:
             type: object
             x-speakeasy-name-override: AppResourceExpandMask
         c1.api.app.v1.AppResourceRef:
-            description: The AppResourceRef message.
+            description: A reference to a specific app resource by its composite key.
             properties:
                 appId:
-                    description: The appId field.
+                    description: The ID of the app that owns the resource.
                     readOnly: false
                     type: string
                 appResourceTypeId:
-                    description: The appResourceTypeId field.
+                    description: The ID of the resource type that classifies this resource.
                     readOnly: false
                     type: string
                 id:
-                    description: The id field.
+                    description: The unique ID of the app resource.
                     readOnly: false
                     type: string
             title: App Resource Ref
@@ -4320,7 +4709,7 @@ components:
             type: object
             x-speakeasy-name-override: AppResourceServiceListResponse
         c1.api.app.v1.AppResourceServiceUpdateRequestInput:
-            description: The AppResourceServiceUpdateRequest message.
+            description: The request message for updating an app resource.
             properties:
                 appResource:
                     $ref: '#/components/schemas/c1.api.app.v1.AppResource'
@@ -4334,12 +4723,12 @@ components:
             type: object
             x-speakeasy-name-override: AppResourceServiceUpdateRequest
         c1.api.app.v1.AppResourceServiceUpdateResponse:
-            description: The AppResourceServiceUpdateResponse message.
+            description: The response message for updating an app resource.
             properties:
                 appResourceView:
                     $ref: '#/components/schemas/c1.api.app.v1.AppResourceView'
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -4695,27 +5084,27 @@ components:
             type: object
             x-speakeasy-name-override: AppUserRef
         c1.api.app.v1.AppUserServiceListCredentialsResponse:
-            description: The AppUserServiceListCredentialsResponse message.
+            description: The response message for listing credentials of an app user.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of credential results.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppUserCredential'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             title: App User Service List Credentials Response
             type: object
             x-speakeasy-name-override: AppUserServiceListCredentialsResponse
         c1.api.app.v1.AppUserServiceListResponse:
-            description: The AppUserServiceListResponse message.
+            description: The response message for listing app users.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -4729,14 +5118,14 @@ components:
                     readOnly: false
                     type: array
                 list:
-                    description: The list field.
+                    description: The list of app user results.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppUserView'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             title: App User Service List Response
@@ -4951,10 +5340,10 @@ components:
             type: object
             x-speakeasy-name-override: AppUserView
         c1.api.app.v1.AppUsersForUserServiceListResponse:
-            description: The AppUsersForUserServiceListResponse message.
+            description: The response message for listing app users correlated to a specific C1 user.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -4968,14 +5357,14 @@ components:
                     readOnly: false
                     type: array
                 list:
-                    description: The list field.
+                    description: The list of app user results.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppUserView'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             title: App Users For User Service List Response
@@ -4987,12 +5376,12 @@ components:
             type: object
             x-speakeasy-name-override: CancelAccessRequestDefaultsRequest
         c1.api.app.v1.ConfirmSyncValidRequestInput:
-            description: The ConfirmSyncValidRequest message.
+            description: The ConfirmSyncValidRequest message contains the fields required to confirm a sync as valid.
             title: Confirm Sync Valid Request
             type: object
             x-speakeasy-name-override: ConfirmSyncValidRequest
         c1.api.app.v1.ConfirmSyncValidResponse:
-            description: The ConfirmSyncValidResponse message.
+            description: Empty response body. Status code indicates success.
             title: Confirm Sync Valid Response
             type: object
             x-speakeasy-name-override: ConfirmSyncValidResponse
@@ -5020,6 +5409,10 @@ components:
                             type: string
                     readOnly: false
                     type: object
+                configUpdatedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
                 connectorApiVersion:
                     description: The connectorApiVersion field.
                     format: uint32
@@ -5057,6 +5450,12 @@ components:
                     type: string
                 oauthAuthorizedAs:
                     $ref: '#/components/schemas/c1.api.app.v1.OAuth2AuthorizedAs'
+                parallelSyncWorkerCount:
+                    description: 'Number of sync workers to use for parallel sync, when the PARALLEL_SYNC feature is enabled. Zero disables parallel sync. Optional on write: omit the field in UpdateAdvancedConfig to leave the stored value unchanged. The public API allows setting up to 4.'
+                    format: int32
+                    nullable: true
+                    readOnly: false
+                    type: integer
                 profileAllowList:
                     description: List of profile attributes to sync, when set only these attributes will be synced
                     items:
@@ -5181,15 +5580,15 @@ components:
             type: object
             x-speakeasy-name-override: ConnectorRef
         c1.api.app.v1.ConnectorScheduleCron:
-            description: The ConnectorScheduleCron message.
+            description: A cron-based schedule definition for connector syncs.
             nullable: true
             properties:
                 cronSpec:
-                    description: The cronSpec field.
+                    description: The cron expression defining the sync schedule.
                     readOnly: false
                     type: string
                 timezone:
-                    description: The timezone field.
+                    description: The IANA timezone name for the cron schedule (e.g., "America/Los_Angeles").
                     readOnly: false
                     type: string
             title: Connector Schedule Cron
@@ -5198,6 +5597,13 @@ components:
         c1.api.app.v1.ConnectorServiceCreateDelegatedRequestInput:
             description: The ConnectorServiceCreateDelegatedRequest message contains the fields required to create a connector.
             properties:
+                appEntitlementOwnerRefs:
+                    description: Sets entitlement owners on the app.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
                 appManagedStateBindingRef:
                     $ref: '#/components/schemas/c1.api.app.v1.AppManagedStateBindingRef'
                 catalogId:
@@ -5506,7 +5912,7 @@ components:
             type: object
             x-speakeasy-name-override: ConnectorView
         c1.api.app.v1.CreateAppEntitlementProxyRequestInput:
-            description: The CreateAppEntitlementProxyRequest message.
+            description: The request message for creating an entitlement proxy binding.
             properties:
                 expandMask:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementProxyExpandMask'
@@ -5514,12 +5920,12 @@ components:
             type: object
             x-speakeasy-name-override: CreateAppEntitlementProxyRequest
         c1.api.app.v1.CreateAppEntitlementProxyResponse:
-            description: The CreateAppEntitlementProxyResponse message.
+            description: The response message for creating an entitlement proxy binding.
             properties:
                 appProxyEntitlementView:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementProxyView'
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -5544,41 +5950,41 @@ components:
                   - durationGrant
             properties:
                 alias:
-                    description: The alias field.
+                    description: A unique alias for the entitlement, used for programmatic lookups and Cone.
                     readOnly: false
                     type: string
                 appEntitlementOwnerIds:
-                    description: The appEntitlementOwnerIds field.
+                    description: The IDs of users to set as owners of this entitlement.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 appResourceId:
-                    description: The appResourceId field.
+                    description: The ID of the resource that this entitlement belongs to.
                     readOnly: false
                     type: string
                 appResourceTypeId:
-                    description: The appResourceTypeId field.
+                    description: The ID of the resource type that this entitlement belongs to.
                     readOnly: false
                     type: string
                 certifyPolicyId:
-                    description: The certifyPolicyId field.
+                    description: The ID of the policy to use for certification tasks.
                     readOnly: false
                     type: string
                 complianceFrameworkValueIds:
-                    description: The complianceFrameworkValueIds field.
+                    description: The IDs of compliance frameworks to associate with this entitlement (e.g., SOX, HIPAA).
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 description:
-                    description: The description field.
+                    description: The description of the new entitlement.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The display name of the new entitlement.
                     readOnly: false
                     type: string
                 durationGrant:
@@ -5590,17 +5996,17 @@ components:
                     readOnly: false
                     type: object
                 emergencyGrantEnabled:
-                    description: The emergencyGrantEnabled field.
+                    description: Whether emergency grant requests are enabled for this entitlement.
                     readOnly: false
                     type: boolean
                 emergencyGrantPolicyId:
-                    description: The emergencyGrantPolicyId field.
+                    description: The ID of the policy to use for emergency grant tasks. Required if emergency_grant_enabled is true.
                     readOnly: false
                     type: string
                 expandMask:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementExpandMask'
                 grantPolicyId:
-                    description: The grantPolicyId field.
+                    description: The ID of the policy to use for grant request tasks.
                     readOnly: false
                     type: string
                 matchBatonId:
@@ -5608,13 +6014,13 @@ components:
                     readOnly: false
                     type: string
                 overrideAccessRequestsDefaults:
-                    description: The overrideAccessRequestsDefaults field.
+                    description: Whether to override the app-level access request defaults for this entitlement.
                     readOnly: false
                     type: boolean
                 provisionPolicy:
                     $ref: '#/components/schemas/c1.api.policy.v1.ProvisionPolicy'
                 purpose:
-                    description: The purpose field.
+                    description: The purpose of the entitlement (e.g., assignment, permission, ownership).
                     enum:
                         - APP_ENTITLEMENT_PURPOSE_VALUE_UNSPECIFIED
                         - APP_ENTITLEMENT_PURPOSE_VALUE_ASSIGNMENT
@@ -5624,15 +6030,15 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 revokePolicyId:
-                    description: The revokePolicyId field.
+                    description: The ID of the policy to use for revoke request tasks.
                     readOnly: false
                     type: string
                 riskLevelValueId:
-                    description: The riskLevelValueId field.
+                    description: The ID of the risk level to assign to this entitlement.
                     readOnly: false
                     type: string
                 slug:
-                    description: The slug field.
+                    description: A short label describing the permission the entitlement grants (e.g., "Admin", "Read").
                     readOnly: false
                     type: string
             required:
@@ -5665,6 +6071,13 @@ components:
         c1.api.app.v1.CreateAppRequest:
             description: The CreateAppRequest message is used to create a new app.
             properties:
+                appEntitlementOwnerRefs:
+                    description: Sets entitlement owners on the app.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
                 certifyPolicyId:
                     description: Creates the app with this certify policy.
                     readOnly: false
@@ -5701,7 +6114,7 @@ components:
                     readOnly: false
                     type: integer
                 owners:
-                    description: Creates the app with this array of owners.
+                    description: Creates the app with this array of user owners.
                     items:
                         type: string
                     nullable: true
@@ -5736,7 +6149,7 @@ components:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementAutomation'
             title: Create Automation Request
             type: object
-            x-speakeasy-name-override: CreateAutomationRequest
+            x-speakeasy-name-override: AppCreateAutomationRequest
         c1.api.app.v1.CreateAutomationResponse:
             description: The CreateAutomationResponse message.
             properties:
@@ -5744,16 +6157,16 @@ components:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementAutomation'
             title: Create Automation Response
             type: object
-            x-speakeasy-name-override: CreateAutomationResponse
+            x-speakeasy-name-override: AppCreateAutomationResponse
         c1.api.app.v1.CreateManuallyManagedAppResourceRequestInput:
-            description: The CreateManuallyManagedAppResourceRequest message.
+            description: The request message for creating a manually managed app resource.
             properties:
                 description:
-                    description: The description field.
+                    description: An optional description for the new resource.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The display name for the new resource.
                     readOnly: false
                     type: string
                 matchBatonId:
@@ -5761,7 +6174,7 @@ components:
                     readOnly: false
                     type: string
                 resourceOwnerUserIds:
-                    description: The resourceOwnerUserIds field.
+                    description: C1 user IDs to assign as owners of this resource.
                     items:
                         type: string
                     nullable: true
@@ -5773,7 +6186,7 @@ components:
             type: object
             x-speakeasy-name-override: CreateManuallyManagedAppResourceRequest
         c1.api.app.v1.CreateManuallyManagedAppResourceResponse:
-            description: The CreateManuallyManagedAppResourceResponse message.
+            description: The response message for creating a manually managed app resource.
             properties:
                 appResource:
                     $ref: '#/components/schemas/c1.api.app.v1.AppResource'
@@ -5781,14 +6194,14 @@ components:
             type: object
             x-speakeasy-name-override: CreateManuallyManagedAppResourceResponse
         c1.api.app.v1.CreateManuallyManagedResourceTypeRequestInput:
-            description: The CreateManuallyManagedResourceTypeRequest message.
+            description: The request message for creating a manually managed resource type.
             properties:
                 displayName:
-                    description: The displayName field.
+                    description: The display name for the new resource type.
                     readOnly: false
                     type: string
                 resourceType:
-                    description: The resourceType field.
+                    description: The category of the resource type (e.g., ROLE, GROUP, LICENSE).
                     enum:
                         - ROLE
                         - GROUP
@@ -5808,12 +6221,12 @@ components:
             type: object
             x-speakeasy-name-override: CreateManuallyManagedResourceTypeRequest
         c1.api.app.v1.CreateManuallyManagedResourceTypeResponse:
-            description: The CreateManuallyManagedResourceTypeResponse message.
+            description: The response message for creating a manually managed resource type.
             properties:
                 appResourceType:
                     $ref: '#/components/schemas/c1.api.app.v1.AppResourceType'
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -5840,12 +6253,12 @@ components:
             type: object
             x-speakeasy-name-override: DeleteAppEntitlementOwnersResponse
         c1.api.app.v1.DeleteAppEntitlementProxyRequestInput:
-            description: The DeleteAppEntitlementProxyRequest message.
+            description: The request message for deleting an entitlement proxy binding.
             title: Delete App Entitlement Proxy Request
             type: object
             x-speakeasy-name-override: DeleteAppEntitlementProxyRequest
         c1.api.app.v1.DeleteAppEntitlementProxyResponse:
-            description: The DeleteAppEntitlementProxyResponse message.
+            description: The empty response message for deleting an entitlement proxy binding.
             title: Delete App Entitlement Proxy Response
             type: object
             x-speakeasy-name-override: DeleteAppEntitlementProxyResponse
@@ -5902,47 +6315,47 @@ components:
             description: The DeleteAutomationRequest message.
             title: Delete Automation Request
             type: object
-            x-speakeasy-name-override: DeleteAutomationRequest
+            x-speakeasy-name-override: AppDeleteAutomationRequest
         c1.api.app.v1.DeleteAutomationResponse:
             description: The DeleteAutomationResponse message.
             title: Delete Automation Response
             type: object
-            x-speakeasy-name-override: DeleteAutomationResponse
+            x-speakeasy-name-override: AppDeleteAutomationResponse
         c1.api.app.v1.DeleteManuallyManagedAppResourceRequestInput:
-            description: The DeleteManuallyManagedAppResourceRequest message.
+            description: The request message for deleting a manually managed app resource.
             title: Delete Manually Managed App Resource Request
             type: object
             x-speakeasy-name-override: DeleteManuallyManagedAppResourceRequest
         c1.api.app.v1.DeleteManuallyManagedAppResourceResponse:
-            description: The DeleteManuallyManagedAppResourceResponse message.
+            description: The empty response message for deleting a manually managed app resource.
             title: Delete Manually Managed App Resource Response
             type: object
             x-speakeasy-name-override: DeleteManuallyManagedAppResourceResponse
         c1.api.app.v1.DeleteManuallyManagedResourceTypeRequestInput:
-            description: The DeleteManuallyManagedResourceTypeRequest message.
+            description: The request message for deleting a manually managed resource type.
             title: Delete Manually Managed Resource Type Request
             type: object
             x-speakeasy-name-override: DeleteManuallyManagedResourceTypeRequest
         c1.api.app.v1.DeleteManuallyManagedResourceTypeResponse:
-            description: The DeleteManuallyManagedResourceTypeResponse message.
+            description: The empty response message for deleting a manually managed resource type.
             title: Delete Manually Managed Resource Type Response
             type: object
             x-speakeasy-name-override: DeleteManuallyManagedResourceTypeResponse
         c1.api.app.v1.EditorValidateRequest:
-            description: The EditorValidateRequest message.
+            description: The EditorValidateRequest message contains the configuration text to validate.
             properties:
                 text:
-                    description: The text field.
+                    description: The configuration text to validate.
                     readOnly: false
                     type: string
             title: Editor Validate Request
             type: object
-            x-speakeasy-name-override: EditorValidateRequest
+            x-speakeasy-name-override: AppEditorValidateRequest
         c1.api.app.v1.EditorValidateResponse:
-            description: The EditorValidateResponse message.
+            description: The EditorValidateResponse message contains validation results.
             properties:
                 markers:
-                    description: The markers field.
+                    description: The list of diagnostic markers found during validation.
                     items:
                         $ref: '#/components/schemas/c1.api.editor.v1.EditorMarker'
                     nullable: true
@@ -5950,7 +6363,7 @@ components:
                     type: array
             title: Editor Validate Response
             type: object
-            x-speakeasy-name-override: EditorValidateResponse
+            x-speakeasy-name-override: AppEditorValidateResponse
         c1.api.app.v1.EncryptedData:
             description: EncryptedData is a message that contains encrypted bytes and metadata.
             nullable: true
@@ -5989,17 +6402,17 @@ components:
             type: object
             x-speakeasy-name-override: ForceSyncRequest
         c1.api.app.v1.ForceSyncResponse:
-            description: The ForceSyncResponse message.
+            description: Empty response body. Status code indicates success.
             title: Force Sync Response
             type: object
             x-speakeasy-name-override: ForceSyncResponse
         c1.api.app.v1.GetAppEntitlementProxyResponse:
-            description: The GetAppEntitlementProxyResponse message.
+            description: The response message for getting a specific entitlement proxy binding.
             properties:
                 appProxyEntitlementView:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementProxyView'
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -6343,13 +6756,13 @@ components:
             description: The ManuallyManagedUsersResponse message.
             properties:
                 bulkActionId:
-                    description: The bulkActionId field.
+                    description: The ID of the bulk action created to process the membership additions.
                     readOnly: false
                     type: string
                 failedUsersErrorMap:
                     additionalProperties:
                         type: string
-                    description: The failedUsersErrorMap field.
+                    description: A map of user IDs to error messages for users that could not be added.
                     readOnly: false
                     type: object
             title: Manually Managed Users Response
@@ -6370,12 +6783,12 @@ components:
             type: object
             x-speakeasy-name-override: OAuth2AuthorizedAs
         c1.api.app.v1.PauseSyncRequestInput:
-            description: The PauseSyncRequest message.
+            description: The PauseSyncRequest message contains the fields required to pause syncing for a connector.
             title: Pause Sync Request
             type: object
             x-speakeasy-name-override: PauseSyncRequest
         c1.api.app.v1.PauseSyncResponse:
-            description: The PauseSyncResponse message.
+            description: Empty response body. Status code indicates success.
             title: Pause Sync Response
             type: object
             x-speakeasy-name-override: PauseSyncResponse
@@ -6400,17 +6813,17 @@ components:
             type: object
             x-speakeasy-name-override: RemoveAppOwnerResponse
         c1.api.app.v1.RemoveAppResourceOwnerRequestInput:
-            description: The RemoveAppResourceOwnerRequest message.
+            description: The request message for removing an owner from an app resource.
             properties:
                 userId:
-                    description: The userId field.
+                    description: The C1 user ID to remove as an owner.
                     readOnly: false
                     type: string
             title: Remove App Resource Owner Request
             type: object
             x-speakeasy-name-override: RemoveAppResourceOwnerRequest
         c1.api.app.v1.RemoveAppResourceOwnerResponse:
-            description: The RemoveAppResourceOwnerResponse message.
+            description: The empty response message for removing an owner from an app resource.
             title: Remove App Resource Owner Response
             type: object
             x-speakeasy-name-override: RemoveAppResourceOwnerResponse
@@ -6418,7 +6831,7 @@ components:
             description: The RemoveAutomationExclusionRequest message.
             properties:
                 userIds:
-                    description: The userIds field.
+                    description: The IDs of users to remove from the automation exclusion list.
                     items:
                         type: string
                     nullable: true
@@ -6436,7 +6849,7 @@ components:
             description: The RemoveEntitlementMembershipRequest message.
             properties:
                 appUserId:
-                    description: The appUserId field.
+                    description: The ID of the app user whose membership to remove.
                     readOnly: false
                     type: string
             title: Remove Entitlement Membership Request
@@ -6455,12 +6868,12 @@ components:
             type: object
             x-speakeasy-name-override: RemoveEntitlementMembershipResponse
         c1.api.app.v1.RemoveGrantDurationRequestInput:
-            description: The RemoveGrantDurationRequest message.
+            description: The request message for removing the expiration time from a grant.
             title: Remove Grant Duration Request
             type: object
             x-speakeasy-name-override: RemoveGrantDurationRequest
         c1.api.app.v1.RemoveGrantDurationResponse:
-            description: The RemoveGrantDurationResponse message.
+            description: The response message for removing the expiration time from a grant.
             properties:
                 binding:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementUserBinding'
@@ -6468,12 +6881,12 @@ components:
             type: object
             x-speakeasy-name-override: RemoveGrantDurationResponse
         c1.api.app.v1.ResumeSyncRequestInput:
-            description: The ResumeSyncRequest message.
+            description: The ResumeSyncRequest message contains the fields required to resume syncing for a connector.
             title: Resume Sync Request
             type: object
             x-speakeasy-name-override: ResumeSyncRequest
         c1.api.app.v1.ResumeSyncResponse:
-            description: The ResumeSyncResponse message.
+            description: Empty response body. Status code indicates success.
             title: Resume Sync Response
             type: object
             x-speakeasy-name-override: ResumeSyncResponse
@@ -6580,80 +6993,80 @@ components:
             type: object
             x-speakeasy-name-override: SearchAppResourceTypesResponse
         c1.api.app.v1.SearchAppResourcesRequest:
-            description: The SearchAppResourcesRequest message.
+            description: Search app resources based on filters specified in the request body.
             properties:
                 appId:
-                    description: The appId field.
+                    description: The app ID to restrict the search to.
                     readOnly: false
                     type: string
                 appUserIds:
-                    description: The appUserIds field.
+                    description: A list of app user IDs to restrict the search by.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 excludeDeletedResourceBindings:
-                    description: The excludeDeletedResourceBindings field.
+                    description: If true, exclude resources whose bindings have been deleted.
                     readOnly: false
                     type: boolean
                 excludeResourceIds:
-                    description: The excludeResourceIds field.
+                    description: A list of resource IDs to exclude from the search results.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 excludeResourceTypeTraitIds:
-                    description: The excludeResourceTypeTraitIds field.
+                    description: A list of resource type trait IDs to exclude from the search.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 ownerUserIds:
-                    description: The ownerUserIds field.
+                    description: A list of C1 user IDs to filter resources by ownership.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 pageSize:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
                 query:
-                    description: The query field.
+                    description: Fuzzy search the display name of resources.
                     readOnly: false
                     type: string
                 refs:
-                    description: The refs field.
+                    description: A list of specific app resource references to restrict the search to.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppResourceRef'
                     nullable: true
                     readOnly: false
                     type: array
                 resourceIds:
-                    description: The resourceIds field.
+                    description: A list of resource IDs to restrict the search to.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 resourceTypeIds:
-                    description: The resourceTypeIds field.
+                    description: A list of resource type IDs to restrict the search by.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 resourceTypeTraitIds:
-                    description: The resourceTypeTraitIds field.
+                    description: A list of resource type trait IDs to restrict the search by.
                     items:
                         type: string
                     nullable: true
@@ -6663,10 +7076,10 @@ components:
             type: object
             x-speakeasy-name-override: SearchAppResourcesRequest
         c1.api.app.v1.SearchAppResourcesResponse:
-            description: The SearchAppResourcesResponse message.
+            description: The SearchAppResourcesResponse message contains a list of results and a nextPageToken if applicable.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -6680,14 +7093,14 @@ components:
                     readOnly: false
                     type: array
                 list:
-                    description: The list field.
+                    description: The list of app resource results.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppResourceView'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             title: Search App Resources Response
@@ -6849,24 +7262,24 @@ components:
             type: object
             x-speakeasy-name-override: SearchGrantFeedResponse
         c1.api.app.v1.SearchPastGrantsRequest:
-            description: The SearchPastGrantsRequest message.
+            description: The request message for searching historical grants.
             properties:
                 appEntitlementRefs:
-                    description: The appEntitlementRefs field.
+                    description: A list of entitlement references to restrict the search to.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                     nullable: true
                     readOnly: false
                     type: array
                 appIds:
-                    description: The appIds field.
+                    description: A list of app IDs to restrict the search to.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 appUserRefs:
-                    description: The appUserRefs field.
+                    description: A list of app user references to restrict the search to.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppUserRef'
                     nullable: true
@@ -6875,12 +7288,12 @@ components:
                 expandMask:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementUserBindingExpandHistoryMask'
                 pageSize:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             title: Search Past Grants Request
@@ -6920,6 +7333,58 @@ components:
             title: Search Past Grants Response
             type: object
             x-speakeasy-name-override: SearchPastGrantsResponse
+        c1.api.app.v1.SearchUserOwnershipRequest:
+            description: |-
+                Search for all ownership assignments for a given user. Returns apps, resources, and
+                 entitlements the user owns, each tagged with a UserOwnershipType discriminator.
+                 Filter by ownership_types to restrict results to specific kinds of ownership.
+            properties:
+                ownershipTypes:
+                    description: Filter results to only include these ownership types. If empty, all types are returned.
+                    items:
+                        enum:
+                            - USER_OWNERSHIP_TYPE_UNSPECIFIED
+                            - USER_OWNERSHIP_TYPE_APP
+                            - USER_OWNERSHIP_TYPE_RESOURCE
+                            - USER_OWNERSHIP_TYPE_ENTITLEMENT
+                        type: string
+                        x-speakeasy-unknown-values: allow
+                    nullable: true
+                    readOnly: false
+                    type: array
+                pageSize:
+                    description: Maximum number of results to return per page.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: Pagination token from a previous response.
+                    readOnly: false
+                    type: string
+                userId:
+                    description: The ID of the ConductorOne user whose ownership to search.
+                    readOnly: false
+                    type: string
+            title: Search User Ownership Request
+            type: object
+            x-speakeasy-name-override: SearchUserOwnershipRequest
+        c1.api.app.v1.SearchUserOwnershipResponse:
+            description: The SearchUserOwnershipResponse message contains a paginated list of ownership entries.
+            properties:
+                list:
+                    description: The list of ownership entries for the requested user.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v1.UserOwnershipEntry'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: Pagination token for the next page of results. Empty when there are no more results.
+                    readOnly: false
+                    type: string
+            title: Search User Ownership Response
+            type: object
+            x-speakeasy-name-override: SearchUserOwnershipResponse
         c1.api.app.v1.SecretTrait:
             description: The SecretTrait message.
             nullable: true
@@ -7016,6 +7481,14 @@ components:
         c1.api.app.v1.TaskAuditCancelledResult:
             description: The TaskAuditCancelledResult message.
             nullable: true
+            properties:
+                cancelReason:
+                    description: |-
+                        Human-readable reason the action was cancelled. Already populated on the
+                         model-side CanceledResult (e.g., "action is invalid - ticket is closed");
+                         this surfaces it to the UI.
+                    readOnly: false
+                    type: string
             title: Task Audit Cancelled Result
             type: object
             x-speakeasy-name-override: TaskAuditCancelledResult
@@ -7035,6 +7508,22 @@ components:
             title: Task Audit Error Result
             type: object
             x-speakeasy-name-override: TaskAuditErrorResult
+        c1.api.app.v1.TaskAuditPendingResult:
+            description: The TaskAuditPendingResult message.
+            nullable: true
+            properties:
+                pendingReason:
+                    description: |-
+                        Human-readable explanation of why the action is pending. Rendered in the
+                         ticket audit log so admins can see what the action is waiting on (e.g.,
+                         "GitHub org invite sent. User must accept the invitation before team
+                         membership can be granted."). Naming mirrors TaskAuditErrorResult.error_reason
+                         and TaskAuditCancelledResult.cancel_reason for consistency.
+                    readOnly: false
+                    type: string
+            title: Task Audit Pending Result
+            type: object
+            x-speakeasy-name-override: TaskAuditPendingResult
         c1.api.app.v1.TaskAuditSuccessResult:
             description: The TaskAuditSuccessResult message.
             nullable: true
@@ -7053,6 +7542,15 @@ components:
                     nullable: true
                     readOnly: false
                     type: array
+                successReason:
+                    description: |-
+                        Optional human-readable note about the successful action. Rendered in
+                         the ticket audit log when present (e.g., "Account already existed; no
+                         change made." for the AlreadyExistsResult path). Naming mirrors
+                         TaskAuditErrorResult.error_reason and TaskAuditCancelledResult.cancel_reason
+                         for consistency.
+                    readOnly: false
+                    type: string
             title: Task Audit Success Result
             type: object
             x-speakeasy-name-override: TaskAuditSuccessResult
@@ -7138,7 +7636,7 @@ components:
             x-speakeasy-name-override: UpdateAppUsageControlsResponse
         c1.api.app.v1.UpdateConnectorScheduleRequestInput:
             description: |
-                The UpdateConnectorScheduleRequest message.
+                The UpdateConnectorScheduleRequest message contains the fields required to update a connector's sync schedule.
 
                 This message contains a oneof named schedule. Only a single field of the following list may be set at a time:
                   - cron
@@ -7149,12 +7647,12 @@ components:
             type: object
             x-speakeasy-name-override: UpdateConnectorScheduleRequest
         c1.api.app.v1.UpdateConnectorScheduleResponse:
-            description: The UpdateConnectorScheduleResponse message.
+            description: Empty response body. Status code indicates success.
             title: Update Connector Schedule Response
             type: object
             x-speakeasy-name-override: UpdateConnectorScheduleResponse
         c1.api.app.v1.UpdateGrantDurationRequestInput:
-            description: The UpdateGrantDurationRequest message.
+            description: The request message for updating the duration of an existing grant.
             properties:
                 newDeprovisionAt:
                     format: date-time
@@ -7164,7 +7662,7 @@ components:
             type: object
             x-speakeasy-name-override: UpdateGrantDurationRequest
         c1.api.app.v1.UpdateGrantDurationResponse:
-            description: The UpdateGrantDurationResponse message.
+            description: The response message for updating the duration of a grant.
             properties:
                 binding:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementUserBinding'
@@ -7172,7 +7670,7 @@ components:
             type: object
             x-speakeasy-name-override: UpdateGrantDurationResponse
         c1.api.app.v1.UpdateManuallyManagedResourceTypeRequestInput:
-            description: The UpdateManuallyManagedResourceTypeRequest message.
+            description: The request message for updating a manually managed resource type.
             properties:
                 appResourceType:
                     $ref: '#/components/schemas/c1.api.app.v1.AppResourceType'
@@ -7184,12 +7682,12 @@ components:
             type: object
             x-speakeasy-name-override: UpdateManuallyManagedResourceTypeRequest
         c1.api.app.v1.UpdateManuallyManagedResourceTypeResponse:
-            description: The UpdateManuallyManagedResourceTypeResponse message.
+            description: The response message for updating a manually managed resource type.
             properties:
                 appResourceType:
                     $ref: '#/components/schemas/c1.api.app.v1.AppResourceType'
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -7205,19 +7703,67 @@ components:
             title: Update Manually Managed Resource Type Response
             type: object
             x-speakeasy-name-override: UpdateManuallyManagedResourceTypeResponse
+        c1.api.app.v1.UserOwnershipEntry:
+            description: |-
+                A single ownership entry. Fields are populated based on ownership_type:
+                 APP — only app_id and app_display_name are set.
+                 RESOURCE — app_id, app_display_name, resource_type_id, resource_id, and resource_display_name are set.
+                 ENTITLEMENT — app_id, app_display_name, resource_type_id, entitlement_id, and entitlement_display_name are set.
+            properties:
+                appDisplayName:
+                    description: The app display name.
+                    readOnly: false
+                    type: string
+                appId:
+                    description: The app ID.
+                    readOnly: false
+                    type: string
+                entitlementDisplayName:
+                    description: The entitlement display name, if applicable.
+                    readOnly: false
+                    type: string
+                entitlementId:
+                    description: The entitlement ID, if applicable.
+                    readOnly: false
+                    type: string
+                ownershipType:
+                    description: The type of ownership.
+                    enum:
+                        - USER_OWNERSHIP_TYPE_UNSPECIFIED
+                        - USER_OWNERSHIP_TYPE_APP
+                        - USER_OWNERSHIP_TYPE_RESOURCE
+                        - USER_OWNERSHIP_TYPE_ENTITLEMENT
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                resourceDisplayName:
+                    description: The resource display name, if applicable.
+                    readOnly: false
+                    type: string
+                resourceId:
+                    description: The resource ID, if applicable.
+                    readOnly: false
+                    type: string
+                resourceTypeId:
+                    description: The resource type ID, if applicable.
+                    readOnly: false
+                    type: string
+            title: User Ownership Entry
+            type: object
+            x-speakeasy-name-override: UserOwnershipEntry
         c1.api.app.v1.UserWithAppEntitlementUserBindingView:
             description: The UserWithAppEntitlementUserBindingView message.
             properties:
                 appEntitlementId:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement.
                     readOnly: false
                     type: string
                 appId:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 appUserId:
-                    description: The appUserId field.
+                    description: The ID of the app user associated with this binding.
                     readOnly: false
                     type: string
                 user:
@@ -7225,6 +7771,196 @@ components:
             title: User With App Entitlement User Binding View
             type: object
             x-speakeasy-name-override: UserWithAppEntitlementUserBindingView
+        c1.api.app.v2.AppEntitlementOwnerEntitlement:
+            description: AppEntitlementOwnerEntitlement represents an entitlement ownership source for an app entitlement.
+            properties:
+                appEntitlement:
+                    $ref: '#/components/schemas/c1.api.app.v1.AppEntitlement'
+                createdAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                roleSlug:
+                    description: The roleSlug field.
+                    readOnly: false
+                    type: string
+            title: App Entitlement Owner Entitlement
+            type: object
+            x-speakeasy-name-override: AppEntitlementOwnerEntitlement
+        c1.api.app.v2.AppEntitlementOwnerUser:
+            description: AppEntitlementOwnerUser represents a user ownership source for an app entitlement.
+            properties:
+                createdAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                roleSlug:
+                    description: The roleSlug field.
+                    readOnly: false
+                    type: string
+                user:
+                    $ref: '#/components/schemas/c1.api.user.v1.User'
+            title: App Entitlement Owner User
+            type: object
+            x-speakeasy-name-override: AppEntitlementOwnerUser
+        c1.api.app.v2.AppOwnerEntitlement:
+            description: AppOwnerEntitlement represents an entitlement ownership source for an app.
+            properties:
+                appEntitlement:
+                    $ref: '#/components/schemas/c1.api.app.v1.AppEntitlement'
+                createdAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                roleSlug:
+                    description: The roleSlug field.
+                    readOnly: false
+                    type: string
+            title: App Owner Entitlement
+            type: object
+            x-speakeasy-name-override: AppOwnerEntitlement
+        c1.api.app.v2.AppOwnerUser:
+            description: AppOwnerUser represents a user ownership source for an app.
+            properties:
+                createdAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                roleSlug:
+                    description: The roleSlug field.
+                    readOnly: false
+                    type: string
+                user:
+                    $ref: '#/components/schemas/c1.api.user.v1.User'
+            title: App Owner User
+            type: object
+            x-speakeasy-name-override: AppOwnerUser
+        c1.api.app.v2.SearchAppEntitlementEntitlementOwnersResponse:
+            description: SearchAppEntitlementEntitlementOwnersResponse is the response for searching entitlement ownership sources on an entitlement.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v2.AppEntitlementOwnerEntitlement'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Search App Entitlement Entitlement Owners Response
+            type: object
+            x-speakeasy-name-override: SearchAppEntitlementEntitlementOwnersResponse
+        c1.api.app.v2.SearchAppEntitlementUserOwnersResponse:
+            description: SearchAppEntitlementUserOwnersResponse is the response for searching user ownership sources on an entitlement.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v2.AppEntitlementOwnerUser'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Search App Entitlement User Owners Response
+            type: object
+            x-speakeasy-name-override: SearchAppEntitlementUserOwnersResponse
+        c1.api.app.v2.SearchEntitlementOwnersResponse:
+            description: SearchEntitlementOwnersResponse is the response for searching entitlement ownership sources.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v2.AppOwnerEntitlement'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Search Entitlement Owners Response
+            type: object
+            x-speakeasy-name-override: SearchEntitlementOwnersResponse
+        c1.api.app.v2.SearchUserOwnersResponse:
+            description: SearchUserOwnersResponse is the response for searching user ownership sources.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v2.AppOwnerUser'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Search User Owners Response
+            type: object
+            x-speakeasy-name-override: SearchUserOwnersResponse
+        c1.api.app.v2.SetAppEntitlementOwnersV2RequestInput:
+            description: SetAppEntitlementOwnersV2Request is the request for setting the owners of an app entitlement for a given role.
+            properties:
+                appEntitlementRefs:
+                    description: The appEntitlementRefs field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                roleSlug:
+                    description: Empty defaults to the "primary" role on the server side.
+                    readOnly: false
+                    type: string
+                userRefs:
+                    description: The userRefs field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.user.v1.UserRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Set App Entitlement Owners V 2 Request
+            type: object
+            x-speakeasy-name-override: SetAppEntitlementOwnersV2Request
+        c1.api.app.v2.SetAppEntitlementOwnersV2Response:
+            description: SetAppEntitlementOwnersV2Response is the empty response for setting app entitlement owners.
+            title: Set App Entitlement Owners V 2 Response
+            type: object
+            x-speakeasy-name-override: SetAppEntitlementOwnersV2Response
+        c1.api.app.v2.SetAppOwnersRequestInput:
+            description: SetAppOwnersRequest is the request for setting user owners for an app and role.
+            properties:
+                appEntitlementRefs:
+                    description: The appEntitlementRefs field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                roleSlug:
+                    description: The roleSlug field.
+                    readOnly: false
+                    type: string
+                userRefs:
+                    description: The userRefs field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.user.v1.UserRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Set App Owners Request
+            type: object
+            x-speakeasy-name-override: SetAppOwnersRequestV2
+        c1.api.app.v2.SetAppOwnersResponse:
+            description: SetAppOwnersResponse is the empty response for setting app owners.
+            title: Set App Owners Response
+            type: object
+            x-speakeasy-name-override: SetAppOwnersResponseV2
         c1.api.attribute.v1.AttributeType:
             description: AttributeType defines the type of an attribute.
             properties:
@@ -7422,34 +8158,34 @@ components:
             type: object
             x-speakeasy-name-override: ListAttributeValuesResponse
         c1.api.attribute.v1.ListComplianceFrameworksResponse:
-            description: The ListComplianceFrameworksResponse message.
+            description: ListComplianceFrameworksResponse is the response for listing compliance framework attribute values.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of compliance framework attribute values.
                     items:
                         $ref: '#/components/schemas/c1.api.attribute.v1.AttributeValue'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: The token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: List Compliance Frameworks Response
             type: object
             x-speakeasy-name-override: ListComplianceFrameworksResponse
         c1.api.attribute.v1.ListRiskLevelsResponse:
-            description: The ListRiskLevelsResponse message.
+            description: ListRiskLevelsResponse is the response for listing risk level attribute values.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of risk level attribute values.
                     items:
                         $ref: '#/components/schemas/c1.api.attribute.v1.AttributeValue'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: The token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: List Risk Levels Response
@@ -7554,6 +8290,382 @@ components:
             title: Introspect Response
             type: object
             x-speakeasy-name-override: IntrospectResponse
+        c1.api.auth_config.v1.AuthConfigC1Local:
+            description: The AuthConfigC1Local message.
+            nullable: true
+            properties:
+                delegatedVerifiers:
+                    description: The delegatedVerifiers field.
+                    items:
+                        enum:
+                            - DELEGATED_VERIFIER_TYPE_UNSPECIFIED
+                            - DELEGATED_VERIFIER_TYPE_GOOGLE
+                            - DELEGATED_VERIFIER_TYPE_MICROSOFT
+                            - DELEGATED_VERIFIER_TYPE_GITHUB
+                        type: string
+                        x-speakeasy-unknown-values: allow
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Auth Config C 1 Local
+            type: object
+            x-speakeasy-name-override: AuthConfigC1Local
+        c1.api.auth_config.v1.AuthConfigGoogle:
+            description: The AuthConfigGoogle message.
+            nullable: true
+            properties:
+                hostedDomains:
+                    description: The hostedDomains field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Auth Config Google
+            type: object
+            x-speakeasy-name-override: AuthConfigGoogle
+        c1.api.auth_config.v1.AuthConfigJumpCloud:
+            description: The AuthConfigJumpCloud message.
+            nullable: true
+            properties:
+                oidcClientId:
+                    description: The oidcClientId field.
+                    readOnly: false
+                    type: string
+                oidcClientSecret:
+                    description: Write-only. Never returned in get/list.
+                    readOnly: false
+                    type: string
+            title: Auth Config Jump Cloud
+            type: object
+            x-speakeasy-name-override: AuthConfigJumpCloud
+        c1.api.auth_config.v1.AuthConfigMicrosoft:
+            description: The AuthConfigMicrosoft message.
+            nullable: true
+            properties:
+                tenantIds:
+                    description: The tenantIds field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Auth Config Microsoft
+            type: object
+            x-speakeasy-name-override: AuthConfigMicrosoft
+        c1.api.auth_config.v1.AuthConfigOIDC:
+            description: The AuthConfigOIDC message.
+            nullable: true
+            properties:
+                exactMatchClaims:
+                    additionalProperties:
+                        type: string
+                    description: The exactMatchClaims field.
+                    readOnly: false
+                    type: object
+                issuerId:
+                    description: The issuerId field.
+                    readOnly: false
+                    type: string
+                oidcClientId:
+                    description: The oidcClientId field.
+                    readOnly: false
+                    type: string
+                oidcClientSecret:
+                    description: The oidcClientSecret field.
+                    readOnly: false
+                    type: string
+                scopes:
+                    description: The scopes field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Auth Config Oidc
+            type: object
+            x-speakeasy-name-override: AuthConfigOIDC
+        c1.api.auth_config.v1.AuthConfigOkta:
+            description: The AuthConfigOkta message.
+            nullable: true
+            properties:
+                domain:
+                    description: The domain field.
+                    readOnly: false
+                    type: string
+                oidcClientId:
+                    description: The oidcClientId field.
+                    readOnly: false
+                    type: string
+                oidcClientSecret:
+                    description: Write-only. Never returned in get/list.
+                    readOnly: false
+                    type: string
+            title: Auth Config Okta
+            type: object
+            x-speakeasy-name-override: AuthConfigOkta
+        c1.api.auth_config.v1.AuthConfigOneLogin:
+            description: The AuthConfigOneLogin message.
+            nullable: true
+            properties:
+                domain:
+                    description: The domain field.
+                    readOnly: false
+                    type: string
+                oidcClientId:
+                    description: The oidcClientId field.
+                    readOnly: false
+                    type: string
+                oidcClientSecret:
+                    description: The oidcClientSecret field.
+                    readOnly: false
+                    type: string
+            title: Auth Config One Login
+            type: object
+            x-speakeasy-name-override: AuthConfigOneLogin
+        c1.api.auth_config.v1.AuthConfigPingOne:
+            description: The AuthConfigPingOne message.
+            nullable: true
+            properties:
+                environmentId:
+                    description: The environmentId field.
+                    readOnly: false
+                    type: string
+                oidcClientId:
+                    description: The oidcClientId field.
+                    readOnly: false
+                    type: string
+                oidcClientSecret:
+                    description: The oidcClientSecret field.
+                    readOnly: false
+                    type: string
+            title: Auth Config Ping One
+            type: object
+            x-speakeasy-name-override: AuthConfigPingOne
+        c1.api.auth_config.v1.TenantAuthConfig:
+            description: |
+                The TenantAuthConfig message.
+
+                This message contains a oneof named provider_config. Only a single field of the following list may be set at a time:
+                  - google
+                  - microsoft
+                  - okta
+                  - onelogin
+                  - jumpcloud
+                  - pingone
+                  - oidc
+                  - c1Local
+            properties:
+                bootstrapDomains:
+                    description: 'Bootstrap routing: email domains that route unknown users to this config.'
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                c1Local:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigC1Local'
+                createdAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                deprecationDeadline:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                deprecationMessage:
+                    description: User-visible message shown when status=DEPRECATED.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                google:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigGoogle'
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+                isDefaultBootstrap:
+                    description: The isDefaultBootstrap field.
+                    readOnly: false
+                    type: boolean
+                jumpcloud:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigJumpCloud'
+                microsoft:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigMicrosoft'
+                oidc:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigOIDC'
+                okta:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigOkta'
+                onelogin:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigOneLogin'
+                pingone:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigPingOne'
+                providerType:
+                    description: Provider type (read-only after creation — provider config determines type).
+                    enum:
+                        - AUTH_CONFIG_PROVIDER_TYPE_UNSPECIFIED
+                        - AUTH_CONFIG_PROVIDER_TYPE_GOOGLE
+                        - AUTH_CONFIG_PROVIDER_TYPE_MICROSOFT
+                        - AUTH_CONFIG_PROVIDER_TYPE_OKTA
+                        - AUTH_CONFIG_PROVIDER_TYPE_ONELOGIN
+                        - AUTH_CONFIG_PROVIDER_TYPE_JUMPCLOUD
+                        - AUTH_CONFIG_PROVIDER_TYPE_PINGONE
+                        - AUTH_CONFIG_PROVIDER_TYPE_OIDC
+                        - AUTH_CONFIG_PROVIDER_TYPE_C1_LOCAL
+                    readOnly: true
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                status:
+                    description: The status field.
+                    enum:
+                        - AUTH_CONFIG_STATUS_UNSPECIFIED
+                        - AUTH_CONFIG_STATUS_ACTIVE
+                        - AUTH_CONFIG_STATUS_DEPRECATED
+                        - AUTH_CONFIG_STATUS_DISABLED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                updatedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+            title: Tenant Auth Config
+            type: object
+            x-speakeasy-name-override: TenantAuthConfig
+        c1.api.auth_config.v1.TenantAuthConfigServiceCreateRequest:
+            description: |
+                The TenantAuthConfigServiceCreateRequest message.
+
+                This message contains a oneof named provider_config. Only a single field of the following list may be set at a time:
+                  - google
+                  - microsoft
+                  - okta
+                  - onelogin
+                  - jumpcloud
+                  - pingone
+                  - oidc
+                  - c1Local
+            properties:
+                bootstrapDomains:
+                    description: Email domains that route unknown users to this authentication provider during login.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                c1Local:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigC1Local'
+                deprecationDeadline:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                deprecationMessage:
+                    description: A user-visible message explaining why the provider is deprecated.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The human-readable name for this authentication provider.
+                    readOnly: false
+                    type: string
+                google:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigGoogle'
+                isDefaultBootstrap:
+                    description: Whether this provider is the default for users whose email domain has no explicit mapping.
+                    readOnly: false
+                    type: boolean
+                jumpcloud:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigJumpCloud'
+                microsoft:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigMicrosoft'
+                oidc:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigOIDC'
+                okta:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigOkta'
+                onelogin:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigOneLogin'
+                pingone:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.AuthConfigPingOne'
+                status:
+                    description: The initial status of the authentication provider.
+                    enum:
+                        - AUTH_CONFIG_STATUS_UNSPECIFIED
+                        - AUTH_CONFIG_STATUS_ACTIVE
+                        - AUTH_CONFIG_STATUS_DEPRECATED
+                        - AUTH_CONFIG_STATUS_DISABLED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            required:
+                - displayName
+            title: Tenant Auth Config Service Create Request
+            type: object
+            x-speakeasy-name-override: TenantAuthConfigServiceCreateRequest
+        c1.api.auth_config.v1.TenantAuthConfigServiceCreateResponse:
+            description: The TenantAuthConfigServiceCreateResponse message.
+            properties:
+                authConfig:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfig'
+            title: Tenant Auth Config Service Create Response
+            type: object
+            x-speakeasy-name-override: TenantAuthConfigServiceCreateResponse
+        c1.api.auth_config.v1.TenantAuthConfigServiceDeleteRequestInput:
+            description: The TenantAuthConfigServiceDeleteRequest message.
+            title: Tenant Auth Config Service Delete Request
+            type: object
+            x-speakeasy-name-override: TenantAuthConfigServiceDeleteRequest
+        c1.api.auth_config.v1.TenantAuthConfigServiceDeleteResponse:
+            description: The TenantAuthConfigServiceDeleteResponse message.
+            title: Tenant Auth Config Service Delete Response
+            type: object
+            x-speakeasy-name-override: TenantAuthConfigServiceDeleteResponse
+        c1.api.auth_config.v1.TenantAuthConfigServiceGetResponse:
+            description: The TenantAuthConfigServiceGetResponse message.
+            properties:
+                authConfig:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfig'
+            title: Tenant Auth Config Service Get Response
+            type: object
+            x-speakeasy-name-override: TenantAuthConfigServiceGetResponse
+        c1.api.auth_config.v1.TenantAuthConfigServiceListResponse:
+            description: The TenantAuthConfigServiceListResponse message.
+            properties:
+                list:
+                    description: The list of authentication provider configurations.
+                    items:
+                        $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfig'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: A token to retrieve the next page of results, or empty if there are no more results.
+                    readOnly: false
+                    type: string
+            title: Tenant Auth Config Service List Response
+            type: object
+            x-speakeasy-name-override: TenantAuthConfigServiceListResponse
+        c1.api.auth_config.v1.TenantAuthConfigServiceUpdateRequestInput:
+            description: The TenantAuthConfigServiceUpdateRequest message.
+            properties:
+                authConfig:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfig'
+                updateMask:
+                    nullable: true
+                    readOnly: false
+                    type: string
+            title: Tenant Auth Config Service Update Request
+            type: object
+            x-speakeasy-name-override: TenantAuthConfigServiceUpdateRequest
+        c1.api.auth_config.v1.TenantAuthConfigServiceUpdateResponse:
+            description: The TenantAuthConfigServiceUpdateResponse message.
+            properties:
+                authConfig:
+                    $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfig'
+            title: Tenant Auth Config Service Update Response
+            type: object
+            x-speakeasy-name-override: TenantAuthConfigServiceUpdateResponse
         c1.api.automations.v1.AccessConflictTrigger:
             description: |
                 The AccessConflictTrigger message.
@@ -7764,6 +8876,7 @@ components:
                         - TRIGGER_TYPE_FORM
                         - TRIGGER_TYPE_SCHEDULE_APP_USER
                         - TRIGGER_TYPE_ACCESS_CONFLICT
+                        - TRIGGER_TYPE_SCHEDULE_NO_USER
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -7915,6 +9028,7 @@ components:
                   - generatePassword
                   - evaluateExpressions
                   - setCredential
+                  - storeCredential
             properties:
                 accountLifecycleAction:
                     $ref: '#/components/schemas/c1.api.automations.v1.AccountLifecycleAction'
@@ -7958,6 +9072,8 @@ components:
                     description: The stepName field.
                     readOnly: false
                     type: string
+                storeCredential:
+                    $ref: '#/components/schemas/c1.api.automations.v1.StoreCredential'
                 taskAction:
                     $ref: '#/components/schemas/c1.api.automations.v1.TaskAction'
                 unenrollFromAllAccessProfiles:
@@ -8039,6 +9155,7 @@ components:
                   - schedule
                   - scheduleAppUser
                   - accessConflict
+                  - scheduleNoUser
             properties:
                 accessConflict:
                     $ref: '#/components/schemas/c1.api.automations.v1.AccessConflictTrigger'
@@ -8054,6 +9171,8 @@ components:
                     $ref: '#/components/schemas/c1.api.automations.v1.ScheduleTrigger'
                 scheduleAppUser:
                     $ref: '#/components/schemas/c1.api.automations.v1.ScheduleTriggerAppUser'
+                scheduleNoUser:
+                    $ref: '#/components/schemas/c1.api.automations.v1.ScheduleTriggerNoUser'
                 usageBasedRevocation:
                     $ref: '#/components/schemas/c1.api.automations.v1.UsageBasedRevocationTrigger'
                 userCreated:
@@ -8158,6 +9277,12 @@ components:
             properties:
                 connectorRef:
                     $ref: '#/components/schemas/c1.api.app.v1.ConnectorRef'
+                passwordCel:
+                    description: |-
+                        CEL expression referencing a GeneratePassword step output (e.g. "genStep.password").
+                         When set, the resolved password is encrypted for the connector and sent as CredentialOptions.EncryptedPassword.
+                    readOnly: false
+                    type: string
                 userIdCel:
                     description: |-
                         The userIdCel field.
@@ -8213,7 +9338,7 @@ components:
                     readOnly: false
                     type: string
                 automationSteps:
-                    description: The automationSteps field.
+                    description: Ordered list of steps that the automation executes.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.AutomationStep'
                     nullable: true
@@ -8222,37 +9347,37 @@ components:
                 context:
                     $ref: '#/components/schemas/c1.api.automations.v1.AutomationContext'
                 description:
-                    description: The description field.
+                    description: Optional description explaining the automation's purpose.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: Human-readable name for the automation.
                     readOnly: false
                     type: string
                 draftAutomationSteps:
-                    description: The draftAutomationSteps field.
+                    description: Steps saved as a draft that have not yet been published.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.AutomationStep'
                     nullable: true
                     readOnly: false
                     type: array
                 draftTriggers:
-                    description: The draftTriggers field.
+                    description: Triggers saved as a draft that have not yet been published.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.AutomationTrigger'
                     nullable: true
                     readOnly: false
                     type: array
                 enabled:
-                    description: The enabled field.
+                    description: Whether the automation is active and eligible for execution.
                     readOnly: false
                     type: boolean
                 isDraft:
-                    description: The isDraft field.
+                    description: Whether this automation is in draft mode. Draft automations are not eligible for trigger-based execution.
                     readOnly: false
                     type: boolean
                 triggers:
-                    description: The triggers field.
+                    description: Triggers that determine when the automation runs.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.AutomationTrigger'
                     nullable: true
@@ -8260,19 +9385,28 @@ components:
                     type: array
             title: Create Automation Request
             type: object
-            x-speakeasy-name-override: CreateAutomationRequest
+            x-speakeasy-name-override: AutomationsCreateAutomationRequest
         c1.api.automations.v1.CreateAutomationResponse:
             description: The CreateAutomationResponse message.
             properties:
                 automation:
                     $ref: '#/components/schemas/c1.api.automations.v1.Automation'
+                webhookCapabilityUrl:
+                    description: |-
+                        One-time absolute webhook URL for capability URL authentication, shown once at creation time.
+                         Contains the full URL including the embedded token (e.g. https://tenant.conductorone.com/api/v1/webhooks/incoming/{id}/t/{token}).
+                         Populated only when the webhook trigger uses capability URL authentication.
+                    readOnly: false
+                    type: string
                 webhookHmacSecret:
-                    description: If we create a new trigger with an HMAC secret we return the HMAC on this field
+                    description: |-
+                        One-time HMAC shared secret, shown once at creation time.
+                         Populated only when the webhook trigger uses HMAC authentication.
                     readOnly: false
                     type: string
             title: Create Automation Response
             type: object
-            x-speakeasy-name-override: CreateAutomationResponse
+            x-speakeasy-name-override: AutomationsCreateAutomationResponse
         c1.api.automations.v1.CreateRevokeTasks:
             description: The CreateRevokeTasks message.
             nullable: true
@@ -8381,12 +9515,12 @@ components:
             description: The DeleteAutomationRequest message.
             title: Delete Automation Request
             type: object
-            x-speakeasy-name-override: DeleteAutomationRequest
+            x-speakeasy-name-override: AutomationsDeleteAutomationRequest
         c1.api.automations.v1.DeleteAutomationResponse:
             description: The DeleteAutomationResponse message.
             title: Delete Automation Response
             type: object
-            x-speakeasy-name-override: DeleteAutomationResponse
+            x-speakeasy-name-override: AutomationsDeleteAutomationResponse
         c1.api.automations.v1.DisabledReasonCircuitBreaker:
             description: The DisabledReasonCircuitBreaker message.
             nullable: true
@@ -8551,7 +9685,7 @@ components:
             description: The ExecuteAutomationResponse message.
             properties:
                 executionId:
-                    description: The executionId field.
+                    description: The unique identifier of the newly created execution.
                     format: int64
                     readOnly: false
                     type: string
@@ -8581,19 +9715,84 @@ components:
             nullable: true
             properties:
                 passwordPolicyId:
-                    description: The ID of the password policy to use for generating the password.
+                    deprecated: true
+                    description: 'Deprecated: password policy ID lookup is no longer used.'
                     readOnly: false
                     type: string
+                policy:
+                    $ref: '#/components/schemas/c1.api.automations.v1.GeneratePasswordPolicy'
             title: Generate Password
             type: object
             x-speakeasy-name-override: GeneratePassword
+        c1.api.automations.v1.GeneratePasswordPolicy:
+            description: |
+                GeneratePasswordPolicy defines inline password generation rules.
+
+                This message contains a oneof named character_rules. Only a single field of the following list may be set at a time:
+                  - noRestrictions
+                  - customCharacters
+                  - excludedCharacters
+            properties:
+                customCharacters:
+                    description: |-
+                        The customCharacters field.
+                        This field is part of the `character_rules` oneof.
+                        See the documentation for `c1.api.automations.v1.GeneratePasswordPolicy` for more details.
+                    nullable: true
+                    readOnly: false
+                    type: string
+                excludedCharacters:
+                    description: |-
+                        The excludedCharacters field.
+                        This field is part of the `character_rules` oneof.
+                        See the documentation for `c1.api.automations.v1.GeneratePasswordPolicy` for more details.
+                    nullable: true
+                    readOnly: false
+                    type: string
+                maxCharacterCount:
+                    description: The maxCharacterCount field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                minCharacterCount:
+                    description: The minCharacterCount field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                noRestrictions:
+                    description: |-
+                        The noRestrictions field.
+                        This field is part of the `character_rules` oneof.
+                        See the documentation for `c1.api.automations.v1.GeneratePasswordPolicy` for more details.
+                    nullable: true
+                    readOnly: false
+                    type: boolean
+                requireLowercase:
+                    description: The requireLowercase field.
+                    readOnly: false
+                    type: boolean
+                requireNumbers:
+                    description: The requireNumbers field.
+                    readOnly: false
+                    type: boolean
+                requireSpecialCharacters:
+                    description: The requireSpecialCharacters field.
+                    readOnly: false
+                    type: boolean
+                requireUppercase:
+                    description: The requireUppercase field.
+                    readOnly: false
+                    type: boolean
+            title: Generate Password Policy
+            type: object
+            x-speakeasy-name-override: GeneratePasswordPolicy
         c1.api.automations.v1.GetAutomationExecutionResponse:
             description: The GetAutomationExecutionResponse message.
             properties:
                 automationExecution:
                     $ref: '#/components/schemas/c1.api.automations.v1.AutomationExecution'
                 expanded:
-                    description: The expanded field.
+                    description: Related objects requested via the expand mask.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -8872,14 +10071,14 @@ components:
             description: The ListAutomationExecutionsResponse message.
             properties:
                 automationExecutions:
-                    description: The automationExecutions field.
+                    description: The page of automation executions.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.AutomationExecution'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page of results, empty when no more results exist.
                     readOnly: false
                     type: string
             title: List Automation Executions Response
@@ -8889,14 +10088,14 @@ components:
             description: The ListAutomationsResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The page of automations.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.Automation'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page of results, empty when no more results exist.
                     readOnly: false
                     type: string
             title: List Automations Response
@@ -9078,20 +10277,50 @@ components:
             title: Schedule Trigger App User
             type: object
             x-speakeasy-name-override: ScheduleTriggerAppUser
-        c1.api.automations.v1.SearchAutomationExecutionsRequest:
-            description: The SearchAutomationExecutionsRequest message.
+        c1.api.automations.v1.ScheduleTriggerNoUser:
+            description: |-
+                ScheduleTriggerNoUser fires on a cron schedule with no subject user (e.g. reports, syncs, orchestration).
+                 Minimum cron interval is enforced at 1 hour in validation.
+            nullable: true
             properties:
-                automationTemplateId:
-                    description: The automationTemplateId field.
+                advanced:
+                    description: The advanced field.
+                    readOnly: false
+                    type: boolean
+                cronSpec:
+                    description: The cronSpec field.
                     readOnly: false
                     type: string
-                executionId:
-                    description: The executionId field.
-                    format: int64
+                start:
+                    format: date-time
                     readOnly: false
                     type: string
-                executionStepStates:
-                    description: The executionStepStates field.
+                timezone:
+                    description: The timezone field.
+                    readOnly: false
+                    type: string
+            title: Schedule Trigger No User
+            type: object
+            x-speakeasy-name-override: ScheduleTriggerNoUser
+        c1.api.automations.v1.SearchAllAutomationExecutionsRequest:
+            description: The SearchAllAutomationExecutionsRequest message.
+            properties:
+                appIds:
+                    description: Filter to executions associated with one or more apps.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                automationTemplateIds:
+                    description: Filter to one or more specific automation templates.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                executionStates:
+                    description: Filter by execution state (e.g. DONE, ERROR).
                     items:
                         enum:
                             - AUTOMATION_EXECUTION_STATE_UNSPECIFIED
@@ -9112,33 +10341,29 @@ components:
                 expandMask:
                     $ref: '#/components/schemas/c1.api.automations.v1.AutomationExecutionExpandMask'
                 pageSize:
-                    description: The pageSize field.
+                    description: Maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: Pagination token from a previous SearchAllAutomationExecutionsResponse.
                     readOnly: false
                     type: string
-                query:
-                    description: The query field.
-                    readOnly: false
-                    type: string
-                refs:
-                    description: The refs field.
+                subjectUserIds:
+                    description: Filter to executions where one or more C1 users are subjects.
                     items:
-                        $ref: '#/components/schemas/c1.api.automations.v1.AutomationExecutionRef'
+                        type: string
                     nullable: true
                     readOnly: false
                     type: array
-            title: Search Automation Executions Request
+            title: Search All Automation Executions Request
             type: object
-            x-speakeasy-name-override: SearchAutomationExecutionsRequest
-        c1.api.automations.v1.SearchAutomationExecutionsResponse:
-            description: The SearchAutomationExecutionsResponse message.
+            x-speakeasy-name-override: SearchAllAutomationExecutionsRequest
+        c1.api.automations.v1.SearchAllAutomationExecutionsResponse:
+            description: The SearchAllAutomationExecutionsResponse message.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: Related objects requested via the expand mask.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -9152,14 +10377,101 @@ components:
                     readOnly: false
                     type: array
                 list:
-                    description: The list field.
+                    description: The page of execution views matching the search criteria.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.AutomationExecutionView'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page of results, empty when no more results exist.
+                    readOnly: false
+                    type: string
+            title: Search All Automation Executions Response
+            type: object
+            x-speakeasy-name-override: SearchAllAutomationExecutionsResponse
+        c1.api.automations.v1.SearchAutomationExecutionsRequest:
+            description: The SearchAutomationExecutionsRequest message.
+            properties:
+                automationTemplateId:
+                    description: Filter results to executions of this automation template.
+                    readOnly: false
+                    type: string
+                executionId:
+                    description: Filter results to a specific execution by its numeric identifier.
+                    format: int64
+                    readOnly: false
+                    type: string
+                executionStepStates:
+                    description: Filter results to executions in any of the specified states.
+                    items:
+                        enum:
+                            - AUTOMATION_EXECUTION_STATE_UNSPECIFIED
+                            - AUTOMATION_EXECUTION_STATE_PENDING
+                            - AUTOMATION_EXECUTION_STATE_CREATING
+                            - AUTOMATION_EXECUTION_STATE_GET_STEP
+                            - AUTOMATION_EXECUTION_STATE_PROCESS_STEP
+                            - AUTOMATION_EXECUTION_STATE_COMPLETE_STEP
+                            - AUTOMATION_EXECUTION_STATE_DONE
+                            - AUTOMATION_EXECUTION_STATE_ERROR
+                            - AUTOMATION_EXECUTION_STATE_TERMINATE
+                            - AUTOMATION_EXECUTION_STATE_WAITING
+                        type: string
+                        x-speakeasy-unknown-values: allow
+                    nullable: true
+                    readOnly: false
+                    type: array
+                expandMask:
+                    $ref: '#/components/schemas/c1.api.automations.v1.AutomationExecutionExpandMask'
+                pageSize:
+                    description: Maximum number of results to return per page.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: Pagination token from a previous SearchAutomationExecutionsResponse.
+                    readOnly: false
+                    type: string
+                query:
+                    description: Free-text search query to filter executions.
+                    readOnly: false
+                    type: string
+                refs:
+                    description: Restrict results to specific execution references.
+                    items:
+                        $ref: '#/components/schemas/c1.api.automations.v1.AutomationExecutionRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Search Automation Executions Request
+            type: object
+            x-speakeasy-name-override: SearchAutomationExecutionsRequest
+        c1.api.automations.v1.SearchAutomationExecutionsResponse:
+            description: The SearchAutomationExecutionsResponse message.
+            properties:
+                expanded:
+                    description: Related objects requested via the expand mask.
+                    items:
+                        additionalProperties: true
+                        description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+                        properties:
+                            '@type':
+                                description: The type of the serialized message.
+                                type: string
+                        readOnly: false
+                        type: object
+                    nullable: true
+                    readOnly: false
+                    type: array
+                list:
+                    description: The page of execution views matching the search criteria.
+                    items:
+                        $ref: '#/components/schemas/c1.api.automations.v1.AutomationExecutionView'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: Token to retrieve the next page of results, empty when no more results exist.
                     readOnly: false
                     type: string
             title: Search Automation Executions Response
@@ -9169,16 +10481,16 @@ components:
             description: The SearchAutomationTemplateVersionsRequest message.
             properties:
                 automationTemplateId:
-                    description: The automationTemplateId field.
+                    description: The automation template whose version history to search.
                     readOnly: false
                     type: string
                 pageSize:
-                    description: The pageSize field.
+                    description: Maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: Pagination token from a previous SearchAutomationTemplateVersionsResponse.
                     readOnly: false
                     type: string
             title: Search Automation Template Versions Request
@@ -9188,14 +10500,14 @@ components:
             description: The SearchAutomationTemplateVersionsResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The page of template versions matching the search criteria.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.AutomationTemplateVersion'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page of results, empty when no more results exist.
                     readOnly: false
                     type: string
             title: Search Automation Template Versions Response
@@ -9205,31 +10517,55 @@ components:
             description: The SearchAutomationsRequest message.
             properties:
                 appId:
-                    description: The appId field.
+                    description: Filter results to automations belonging to this application.
                     readOnly: false
                     type: string
+                direction:
+                    description: |-
+                        Direction to sort in. Unspecified falls back to ASC when sort_field is set;
+                         when sort_field is also unspecified, the server default order (created_at
+                         DESC) applies.
+                    enum:
+                        - SORT_DIRECTION_UNSPECIFIED
+                        - SORT_DIRECTION_ASC
+                        - SORT_DIRECTION_DESC
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
                 pageSize:
-                    description: The pageSize field.
+                    description: Maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: Pagination token from a previous SearchAutomationsResponse.
                     readOnly: false
                     type: string
                 query:
-                    description: The query field.
+                    description: Free-text search query to filter automations by name or description.
                     readOnly: false
                     type: string
                 refs:
-                    description: The refs field.
+                    description: Restrict results to automations matching these template references.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.AutomationTemplateRef'
                     nullable: true
                     readOnly: false
                     type: array
+                sortField:
+                    description: Column to sort by. Unspecified (0) means sort by created_at desc (server default).
+                    enum:
+                        - AUTOMATION_SORT_FIELD_UNSPECIFIED
+                        - AUTOMATION_SORT_FIELD_DISPLAY_NAME
+                        - AUTOMATION_SORT_FIELD_CREATED_AT
+                        - AUTOMATION_SORT_FIELD_LAST_EXECUTED_AT
+                        - AUTOMATION_SORT_FIELD_ENABLED
+                        - AUTOMATION_SORT_FIELD_PRIMARY_TRIGGER_TYPE
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
                 triggerTypes:
-                    description: The triggerTypes field.
+                    description: Filter results to automations with any of the specified trigger types.
                     items:
                         enum:
                             - TRIGGER_TYPE_UNSPECIFIED
@@ -9245,6 +10581,7 @@ components:
                             - TRIGGER_TYPE_FORM
                             - TRIGGER_TYPE_SCHEDULE_APP_USER
                             - TRIGGER_TYPE_ACCESS_CONFLICT
+                            - TRIGGER_TYPE_SCHEDULE_NO_USER
                         type: string
                         x-speakeasy-unknown-values: allow
                     nullable: true
@@ -9257,14 +10594,14 @@ components:
             description: The SearchAutomationsResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The page of automations matching the search criteria.
                     items:
                         $ref: '#/components/schemas/c1.api.automations.v1.Automation'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page of results, empty when no more results exist.
                     readOnly: false
                     type: string
             title: Search Automations Response
@@ -9276,6 +10613,22 @@ components:
             properties:
                 body:
                     description: The body field.
+                    readOnly: false
+                    type: string
+                email:
+                    deprecated: true
+                    description: |-
+                        Deprecated: use email_cel instead. Static email field shipped behind FF 541 (SKU_MANUAL)
+                         with zero tenant enablement. CEL subsumes static: '"ops@example.com"' is valid CEL.
+                    readOnly: false
+                    type: string
+                emailCel:
+                    description: |-
+                        CEL expression resolving to one or more email addresses (string or list<string>).
+                         Evaluated against the workflow execution context (trigger + completed steps).
+                         Static emails work too: '"ops@example.com"' is valid CEL.
+                         Supports list<string> for multiple recipients: '["a@x.com", "b@x.com"]'.
+                         Requires the tenant to have a TenantEmailProvider configured.
                     readOnly: false
                     type: string
                 subject:
@@ -9306,7 +10659,10 @@ components:
             x-speakeasy-name-override: SendEmail
         c1.api.automations.v1.SendSlackMessage:
             description: |
-                The SendSlackMessage message.
+                SendSlackMessage posts to a channel or DMs one or more users. Delivery mode is
+                 inferred from which fields are populated: DM if any user field is set
+                 (use_subject_user, user_ids_cel, user_refs), otherwise channel. Priority for DM
+                 recipient resolution: use_subject_user > user_ids_cel > user_refs.
 
                 This message contains a oneof named channel. Only a single field of the following list may be set at a time:
                   - channelName
@@ -9333,6 +10689,21 @@ components:
                     nullable: true
                     readOnly: false
                     type: string
+                useSubjectUser:
+                    description: The useSubjectUser field.
+                    readOnly: false
+                    type: boolean
+                userIdsCel:
+                    description: The userIdsCel field.
+                    readOnly: false
+                    type: string
+                userRefs:
+                    description: The userRefs field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.user.v1.UserRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
             title: Send Slack Message
             type: object
             x-speakeasy-name-override: SendSlackMessage
@@ -9358,6 +10729,66 @@ components:
             title: Set Credential
             type: object
             x-speakeasy-name-override: SetCredential
+        c1.api.automations.v1.StoreCredential:
+            description: |-
+                StoreCredential stores a credential from GeneratePassword in a vault.
+                 Supports Paper Vault (SSO/email) and App Vault (entitlement-bound).
+            nullable: true
+            properties:
+                appIdCel:
+                    description: CEL expression that resolves to app ID (App Vault only)
+                    readOnly: false
+                    type: string
+                authType:
+                    description: Authentication type for the paper vault recipient (Paper Vault only)
+                    enum:
+                        - STORE_CREDENTIAL_AUTH_TYPE_UNSPECIFIED
+                        - STORE_CREDENTIAL_AUTH_TYPE_SSO_INTERNAL
+                        - STORE_CREDENTIAL_AUTH_TYPE_VERIFY_EMAIL
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                credentialCel:
+                    description: CEL expression that resolves to the encrypted credential from GeneratePassword
+                    readOnly: false
+                    type: string
+                expiry:
+                    format: duration
+                    readOnly: false
+                    type: string
+                labelCel:
+                    description: Optional display label for the vault
+                    readOnly: false
+                    type: string
+                maxViews:
+                    description: Maximum number of views (0 = unlimited, default 1) (Paper Vault only)
+                    format: uint32
+                    readOnly: false
+                    type: integer
+                recipientCel:
+                    description: CEL expression resolving to the C1 user ID of the recipient (SSO_INTERNAL / App Vault)
+                    readOnly: false
+                    type: string
+                recipientEmailCel:
+                    description: CEL expression resolving to a recipient email address (Paper Vault + VERIFY_EMAIL only)
+                    readOnly: false
+                    type: string
+                ttl:
+                    format: duration
+                    readOnly: false
+                    type: string
+                vaultType:
+                    description: 'Vault type selector (default: PAPER_VAULT for backward compatibility)'
+                    enum:
+                        - STORE_CREDENTIAL_VAULT_TYPE_UNSPECIFIED
+                        - STORE_CREDENTIAL_VAULT_TYPE_PAPER_VAULT
+                        - STORE_CREDENTIAL_VAULT_TYPE_APP_VAULT
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Store Credential
+            type: object
+            x-speakeasy-name-override: StoreCredential
         c1.api.automations.v1.TaskAction:
             description: |
                 The TaskAction message.
@@ -9395,7 +10826,7 @@ components:
                     x-speakeasy-unknown-values: allow
             title: Task Action
             type: object
-            x-speakeasy-name-override: TaskAction
+            x-speakeasy-name-override: AutomationsTaskAction
         c1.api.automations.v1.TerminateAutomationRequestInput:
             description: The TerminateAutomationRequest message.
             title: Terminate Automation Request
@@ -9456,8 +10887,17 @@ components:
             properties:
                 automation:
                     $ref: '#/components/schemas/c1.api.automations.v1.Automation'
+                webhookCapabilityUrl:
+                    description: |-
+                        One-time absolute webhook URL for capability URL authentication, shown once when the trigger is saved.
+                         Contains the full URL including the embedded token (e.g. https://tenant.conductorone.com/api/v1/webhooks/incoming/{id}/t/{token}).
+                         Populated only when the webhook trigger uses capability URL authentication.
+                    readOnly: false
+                    type: string
                 webhookHmacSecret:
-                    description: If we create a new trigger with an HMAC secret we return the HMAC on this field
+                    description: |-
+                        One-time HMAC shared secret, shown once when the trigger is saved.
+                         Populated only when the webhook trigger uses HMAC authentication.
                     readOnly: false
                     type: string
             title: Update Automation Response
@@ -9670,7 +11110,7 @@ components:
                     type: string
             title: Webhook
             type: object
-            x-speakeasy-name-override: Webhook
+            x-speakeasy-name-override: AutomationsWebhook
         c1.api.automations.v1.WebhookAutomationTrigger:
             description: |
                 The WebhookAutomationTrigger message.
@@ -9678,8 +11118,11 @@ components:
                 This message contains a oneof named auth_config. Only a single field of the following list may be set at a time:
                   - jwt
                   - hmac
+                  - capabilityUrl
             nullable: true
             properties:
+                capabilityUrl:
+                    $ref: '#/components/schemas/c1.api.automations.v1.WebhookListenerAuthCapabilityURL'
                 hmac:
                     $ref: '#/components/schemas/c1.api.automations.v1.WebhookListenerAuthHMAC'
                 jwt:
@@ -9691,6 +11134,16 @@ components:
             title: Webhook Automation Trigger
             type: object
             x-speakeasy-name-override: WebhookAutomationTrigger
+        c1.api.automations.v1.WebhookListenerAuthCapabilityURL:
+            description: |-
+                Capability URL authentication: the URL itself contains an unguessable token that acts
+                 as the credential. This is simpler to integrate but less secure than JWT or HMAC because
+                 the token can leak via server logs, referrer headers, and URL sharing.
+                 See https://www.w3.org/TR/capability-urls/ for background.
+            nullable: true
+            title: Webhook Listener Auth Capability Url
+            type: object
+            x-speakeasy-name-override: WebhookListenerAuthCapabilityURL
         c1.api.automations.v1.WebhookListenerAuthHMAC:
             description: The WebhookListenerAuthHMAC message.
             nullable: true
@@ -10005,6 +11458,902 @@ components:
             title: Editor Marker
             type: object
             x-speakeasy-name-override: EditorMarker
+        c1.api.finding.v1.AcceptRiskAction:
+            description: AcceptRiskAction parameters for UpdateFindingState.
+            nullable: true
+            properties:
+                expiresAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                justification:
+                    description: The justification field.
+                    readOnly: false
+                    type: string
+            title: Accept Risk Action
+            type: object
+            x-speakeasy-name-override: AcceptRiskAction
+        c1.api.finding.v1.AppUserTarget:
+            description: The AppUserTarget message.
+            nullable: true
+            properties:
+                appId:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                appUserId:
+                    description: The appUserId field.
+                    readOnly: false
+                    type: string
+            title: App User Target
+            type: object
+            x-speakeasy-name-override: AppUserTarget
+        c1.api.finding.v1.BulkAcceptRiskAction:
+            description: The BulkAcceptRiskAction message.
+            nullable: true
+            properties:
+                expiresAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                justification:
+                    description: The justification field.
+                    readOnly: false
+                    type: string
+            title: Bulk Accept Risk Action
+            type: object
+            x-speakeasy-name-override: BulkAcceptRiskAction
+        c1.api.finding.v1.BulkAssignOwnerAction:
+            description: The BulkAssignOwnerAction message.
+            nullable: true
+            properties:
+                owner:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingOwnerRef'
+            title: Bulk Assign Owner Action
+            type: object
+            x-speakeasy-name-override: BulkAssignOwnerAction
+        c1.api.finding.v1.BulkCreateFindingTasksRequest:
+            description: The BulkCreateFindingTasksRequest message.
+            properties:
+                policyId:
+                    description: Optional policy ID to use for the created tasks. Defaults to the app's grant policy.
+                    readOnly: false
+                    type: string
+                refs:
+                    description: Individual finding references to create tasks for (by-ID mode).
+                    items:
+                        $ref: '#/components/schemas/c1.api.finding.v1.FindingRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                searchRequest:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingSearchRequest'
+            title: Bulk Create Finding Tasks Request
+            type: object
+            x-speakeasy-name-override: BulkCreateFindingTasksRequest
+        c1.api.finding.v1.BulkCreateFindingTasksResponse:
+            description: The BulkCreateFindingTasksResponse message.
+            properties:
+                bulkActionId:
+                    description: The ID of the asynchronous bulk action, which can be used to track progress.
+                    readOnly: false
+                    type: string
+            title: Bulk Create Finding Tasks Response
+            type: object
+            x-speakeasy-name-override: BulkCreateFindingTasksResponse
+        c1.api.finding.v1.BulkReopenAction:
+            description: The BulkReopenAction message.
+            nullable: true
+            title: Bulk Reopen Action
+            type: object
+            x-speakeasy-name-override: BulkReopenAction
+        c1.api.finding.v1.BulkSnoozeAction:
+            description: The BulkSnoozeAction message.
+            nullable: true
+            properties:
+                reason:
+                    description: The reason field.
+                    readOnly: false
+                    type: string
+                snoozeUntil:
+                    format: date-time
+                    readOnly: false
+                    type: string
+            title: Bulk Snooze Action
+            type: object
+            x-speakeasy-name-override: BulkSnoozeAction
+        c1.api.finding.v1.BulkSuppressAction:
+            description: The BulkSuppressAction message.
+            nullable: true
+            properties:
+                reason:
+                    description: The reason field.
+                    readOnly: false
+                    type: string
+            title: Bulk Suppress Action
+            type: object
+            x-speakeasy-name-override: BulkSuppressAction
+        c1.api.finding.v1.BulkUnsuppressAction:
+            deprecated: true
+            description: The BulkUnsuppressAction message.
+            nullable: true
+            title: Bulk Unsuppress Action
+            type: object
+            x-speakeasy-name-override: BulkUnsuppressAction
+        c1.api.finding.v1.BulkUpdateFindingStateRequest:
+            description: |
+                The BulkUpdateFindingStateRequest message.
+
+                This message contains a oneof named action. Only a single field of the following list may be set at a time:
+                  - snooze
+                  - suppress
+                  - acceptRisk
+                  - unsuppress
+                  - assignOwner
+                  - reopen
+            properties:
+                acceptRisk:
+                    $ref: '#/components/schemas/c1.api.finding.v1.BulkAcceptRiskAction'
+                assignOwner:
+                    $ref: '#/components/schemas/c1.api.finding.v1.BulkAssignOwnerAction'
+                refs:
+                    description: 'By-ID mode: specify individual finding refs.'
+                    items:
+                        $ref: '#/components/schemas/c1.api.finding.v1.FindingRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                reopen:
+                    $ref: '#/components/schemas/c1.api.finding.v1.BulkReopenAction'
+                searchRequest:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingSearchRequest'
+                snooze:
+                    $ref: '#/components/schemas/c1.api.finding.v1.BulkSnoozeAction'
+                suppress:
+                    $ref: '#/components/schemas/c1.api.finding.v1.BulkSuppressAction'
+                unsuppress:
+                    $ref: '#/components/schemas/c1.api.finding.v1.BulkUnsuppressAction'
+            title: Bulk Update Finding State Request
+            type: object
+            x-speakeasy-name-override: BulkUpdateFindingStateRequest
+        c1.api.finding.v1.BulkUpdateFindingStateResponse:
+            description: The BulkUpdateFindingStateResponse message.
+            properties:
+                bulkActionId:
+                    description: The ID of the asynchronous bulk action, which can be used to track progress.
+                    readOnly: false
+                    type: string
+            title: Bulk Update Finding State Response
+            type: object
+            x-speakeasy-name-override: BulkUpdateFindingStateResponse
+        c1.api.finding.v1.CreateFindingRoutingRuleRequest:
+            description: The CreateFindingRoutingRuleRequest message.
+            properties:
+                routingRule:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingRoutingRule'
+            title: Create Finding Routing Rule Request
+            type: object
+            x-speakeasy-name-override: CreateFindingRoutingRuleRequest
+        c1.api.finding.v1.CreateFindingRoutingRuleResponse:
+            description: The CreateFindingRoutingRuleResponse message.
+            properties:
+                routingRule:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingRoutingRule'
+            title: Create Finding Routing Rule Response
+            type: object
+            x-speakeasy-name-override: CreateFindingRoutingRuleResponse
+        c1.api.finding.v1.CreateFindingTaskRequestInput:
+            description: The CreateFindingTaskRequest message.
+            properties:
+                policyId:
+                    description: |-
+                        Optional policy ID. Defaults to the app's grant policy or the built-in
+                         "Finding Review" policy.
+                    readOnly: false
+                    type: string
+            title: Create Finding Task Request
+            type: object
+            x-speakeasy-name-override: CreateFindingTaskRequest
+        c1.api.finding.v1.CreateFindingTaskResponse:
+            description: The CreateFindingTaskResponse message.
+            properties:
+                finding:
+                    $ref: '#/components/schemas/c1.api.finding.v1.Finding'
+                taskId:
+                    description: The ID of the created task.
+                    readOnly: false
+                    type: string
+            title: Create Finding Task Response
+            type: object
+            x-speakeasy-name-override: CreateFindingTaskResponse
+        c1.api.finding.v1.CreateTaskAction:
+            description: The CreateTaskAction message.
+            nullable: true
+            properties:
+                policyId:
+                    description: The policyId field.
+                    readOnly: false
+                    type: string
+            title: Create Task Action
+            type: object
+            x-speakeasy-name-override: CreateTaskAction
+        c1.api.finding.v1.DeleteFindingRoutingRuleRequestInput:
+            description: The DeleteFindingRoutingRuleRequest message.
+            title: Delete Finding Routing Rule Request
+            type: object
+            x-speakeasy-name-override: DeleteFindingRoutingRuleRequest
+        c1.api.finding.v1.DeleteFindingRoutingRuleResponse:
+            description: The DeleteFindingRoutingRuleResponse message.
+            title: Delete Finding Routing Rule Response
+            type: object
+            x-speakeasy-name-override: DeleteFindingRoutingRuleResponse
+        c1.api.finding.v1.Finding:
+            description: |
+                The Finding message.
+
+                This message contains a oneof named finding_type. Only a single field of the following list may be set at a time:
+                  - similarUsernameMatch
+                  - serviceAccountMisclassification
+
+
+                This message contains a oneof named target. Only a single field of the following list may be set at a time:
+                  - identityUserTarget
+                  - appUserTarget
+
+
+                This message contains a oneof named evidence. Only a single field of the following list may be set at a time:
+                  - similarUsernameMatchEvidence
+                  - serviceAccountMisclassificationEvidence
+            properties:
+                appId:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                appUserTarget:
+                    $ref: '#/components/schemas/c1.api.finding.v1.AppUserTarget'
+                assignedOwner:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingOwnerRef'
+                computedOwner:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingOwnerRef'
+                createdAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                customTags:
+                    additionalProperties:
+                        type: string
+                    description: The customTags field.
+                    readOnly: false
+                    type: object
+                fingerprint:
+                    description: The fingerprint field.
+                    readOnly: false
+                    type: string
+                firstObservedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+                identityUserTarget:
+                    $ref: '#/components/schemas/c1.api.finding.v1.IdentityUserTarget'
+                lastObservedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                recurrenceCount:
+                    description: The recurrenceCount field.
+                    format: uint32
+                    readOnly: false
+                    type: integer
+                remediationDescription:
+                    description: The remediationDescription field.
+                    readOnly: false
+                    type: string
+                resolvedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                riskAcceptanceExpiresAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                riskAcceptanceJustification:
+                    description: The riskAcceptanceJustification field.
+                    readOnly: false
+                    type: string
+                riskScore:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingRiskScore'
+                serviceAccountMisclassification:
+                    $ref: '#/components/schemas/c1.api.finding.v1.ServiceAccountMisclassificationType'
+                serviceAccountMisclassificationEvidence:
+                    $ref: '#/components/schemas/c1.api.finding.v1.ServiceAccountMisclassificationEvidence'
+                severity:
+                    description: The severity field.
+                    enum:
+                        - FINDING_SEVERITY_UNSPECIFIED
+                        - FINDING_SEVERITY_INFO
+                        - FINDING_SEVERITY_LOW
+                        - FINDING_SEVERITY_MEDIUM
+                        - FINDING_SEVERITY_HIGH
+                        - FINDING_SEVERITY_CRITICAL
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                similarUsernameMatch:
+                    $ref: '#/components/schemas/c1.api.finding.v1.SimilarUsernameMatchType'
+                similarUsernameMatchEvidence:
+                    $ref: '#/components/schemas/c1.api.finding.v1.SimilarUsernameMatchEvidence'
+                snoozeReason:
+                    description: The snoozeReason field.
+                    readOnly: false
+                    type: string
+                snoozeUntil:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                sourceDetectorId:
+                    description: The sourceDetectorId field.
+                    readOnly: false
+                    type: string
+                state:
+                    description: The state field.
+                    enum:
+                        - FINDING_STATE_UNSPECIFIED
+                        - FINDING_STATE_OPEN
+                        - FINDING_STATE_IN_PROGRESS
+                        - FINDING_STATE_RESOLVED
+                        - FINDING_STATE_SNOOZED
+                        - FINDING_STATE_RISK_ACCEPTED
+                        - FINDING_STATE_SUPPRESSED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                stateUpdatedById:
+                    description: The stateUpdatedById field.
+                    readOnly: false
+                    type: string
+                suppressReason:
+                    description: The suppressReason field.
+                    readOnly: false
+                    type: string
+                taskId:
+                    description: The taskId field.
+                    readOnly: false
+                    type: string
+                updatedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+            title: Finding
+            type: object
+            x-speakeasy-name-override: Finding
+        c1.api.finding.v1.FindingOwnerRef:
+            description: |
+                The FindingOwnerRef message.
+
+                This message contains a oneof named owner. Only a single field of the following list may be set at a time:
+                  - identityUserId
+                  - appOwnerAppId
+                  - managerOfUserId
+                  - userSetId
+            properties:
+                appOwnerAppId:
+                    description: |-
+                        The appOwnerAppId field.
+                        This field is part of the `owner` oneof.
+                        See the documentation for `c1.api.finding.v1.FindingOwnerRef` for more details.
+                    nullable: true
+                    readOnly: false
+                    type: string
+                identityUserId:
+                    description: |-
+                        The identityUserId field.
+                        This field is part of the `owner` oneof.
+                        See the documentation for `c1.api.finding.v1.FindingOwnerRef` for more details.
+                    nullable: true
+                    readOnly: false
+                    type: string
+                managerOfUserId:
+                    description: |-
+                        The managerOfUserId field.
+                        This field is part of the `owner` oneof.
+                        See the documentation for `c1.api.finding.v1.FindingOwnerRef` for more details.
+                    nullable: true
+                    readOnly: false
+                    type: string
+                userSetId:
+                    description: |-
+                        The userSetId field.
+                        This field is part of the `owner` oneof.
+                        See the documentation for `c1.api.finding.v1.FindingOwnerRef` for more details.
+                    nullable: true
+                    readOnly: false
+                    type: string
+            title: Finding Owner Ref
+            type: object
+            x-speakeasy-name-override: FindingOwnerRef
+        c1.api.finding.v1.FindingRef:
+            description: The FindingRef message.
+            properties:
+                id:
+                    description: The ID of the finding.
+                    readOnly: false
+                    type: string
+            title: Finding Ref
+            type: object
+            x-speakeasy-name-override: FindingRef
+        c1.api.finding.v1.FindingRiskFactor:
+            description: The FindingRiskFactor message.
+            properties:
+                description:
+                    description: The description field.
+                    readOnly: false
+                    type: string
+                name:
+                    description: The name field.
+                    readOnly: false
+                    type: string
+                severity:
+                    description: The severity field.
+                    enum:
+                        - FINDING_SEVERITY_UNSPECIFIED
+                        - FINDING_SEVERITY_INFO
+                        - FINDING_SEVERITY_LOW
+                        - FINDING_SEVERITY_MEDIUM
+                        - FINDING_SEVERITY_HIGH
+                        - FINDING_SEVERITY_CRITICAL
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                weight:
+                    description: The weight field.
+                    format: uint32
+                    readOnly: false
+                    type: integer
+            title: Finding Risk Factor
+            type: object
+            x-speakeasy-name-override: FindingRiskFactor
+        c1.api.finding.v1.FindingRiskScore:
+            description: The FindingRiskScore message.
+            properties:
+                originalScore:
+                    description: The originalScore field.
+                    format: uint32
+                    readOnly: false
+                    type: integer
+                overrideByUserId:
+                    description: The overrideByUserId field.
+                    readOnly: false
+                    type: string
+                overrideScore:
+                    description: The overrideScore field.
+                    format: uint32
+                    readOnly: false
+                    type: integer
+                riskFactors:
+                    description: The riskFactors field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.finding.v1.FindingRiskFactor'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                score:
+                    description: The score field.
+                    format: uint32
+                    readOnly: false
+                    type: integer
+                systemScore:
+                    description: The systemScore field.
+                    format: uint32
+                    readOnly: false
+                    type: integer
+            title: Finding Risk Score
+            type: object
+            x-speakeasy-name-override: FindingRiskScore
+        c1.api.finding.v1.FindingRoutingRule:
+            description: The FindingRoutingRule message.
+            properties:
+                action:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingRoutingRuleAction'
+                appId:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                condition:
+                    description: The condition field.
+                    readOnly: false
+                    type: string
+                createdAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                description:
+                    description: The description field.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                enabled:
+                    description: The enabled field.
+                    readOnly: false
+                    type: boolean
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+                priority:
+                    description: The priority field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                templateId:
+                    description: The templateId field.
+                    readOnly: false
+                    type: string
+                updatedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+            title: Finding Routing Rule
+            type: object
+            x-speakeasy-name-override: FindingRoutingRule
+        c1.api.finding.v1.FindingRoutingRuleAction:
+            description: |
+                The FindingRoutingRuleAction message.
+
+                This message contains a oneof named action. Only a single field of the following list may be set at a time:
+                  - createTask
+                  - suppress
+                  - notify
+            properties:
+                createTask:
+                    $ref: '#/components/schemas/c1.api.finding.v1.CreateTaskAction'
+                notify:
+                    $ref: '#/components/schemas/c1.api.finding.v1.NotifyAction'
+                suppress:
+                    $ref: '#/components/schemas/c1.api.finding.v1.SuppressRoutingAction'
+            title: Finding Routing Rule Action
+            type: object
+            x-speakeasy-name-override: FindingRoutingRuleAction
+        c1.api.finding.v1.FindingSearchRequest:
+            description: The FindingSearchRequest message.
+            properties:
+                appIds:
+                    description: Filter by app IDs (OR within field).
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                appUserIds:
+                    description: |-
+                        Filter by app user IDs (OR within field). Matches findings whose
+                         target.app_user_target.app_user_id is in this list.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                findingTypes:
+                    description: Filter by finding type discriminators (OR within field).
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                pageSize:
+                    description: Maximum number of findings to return per page.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: Pagination token from a previous response.
+                    readOnly: false
+                    type: string
+                query:
+                    description: Free text search query.
+                    readOnly: false
+                    type: string
+                severities:
+                    description: Filter by severities (OR within field).
+                    items:
+                        enum:
+                            - FINDING_SEVERITY_UNSPECIFIED
+                            - FINDING_SEVERITY_INFO
+                            - FINDING_SEVERITY_LOW
+                            - FINDING_SEVERITY_MEDIUM
+                            - FINDING_SEVERITY_HIGH
+                            - FINDING_SEVERITY_CRITICAL
+                        type: string
+                        x-speakeasy-unknown-values: allow
+                    nullable: true
+                    readOnly: false
+                    type: array
+                states:
+                    description: Filter by states (OR within field).
+                    items:
+                        enum:
+                            - FINDING_STATE_UNSPECIFIED
+                            - FINDING_STATE_OPEN
+                            - FINDING_STATE_IN_PROGRESS
+                            - FINDING_STATE_RESOLVED
+                            - FINDING_STATE_SNOOZED
+                            - FINDING_STATE_RISK_ACCEPTED
+                            - FINDING_STATE_SUPPRESSED
+                        type: string
+                        x-speakeasy-unknown-values: allow
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Finding Search Request
+            type: object
+            x-speakeasy-name-override: FindingSearchRequest
+        c1.api.finding.v1.FindingSearchResponse:
+            description: The FindingSearchResponse message.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.finding.v1.Finding'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Finding Search Response
+            type: object
+            x-speakeasy-name-override: FindingSearchResponse
+        c1.api.finding.v1.GetFindingResponse:
+            description: The GetFindingResponse message.
+            properties:
+                expanded:
+                    description: The expanded field.
+                    items:
+                        additionalProperties: true
+                        description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+                        properties:
+                            '@type':
+                                description: The type of the serialized message.
+                                type: string
+                        readOnly: false
+                        type: object
+                    nullable: true
+                    readOnly: false
+                    type: array
+                finding:
+                    $ref: '#/components/schemas/c1.api.finding.v1.Finding'
+            title: Get Finding Response
+            type: object
+            x-speakeasy-name-override: GetFindingResponse
+        c1.api.finding.v1.GetFindingRoutingRuleResponse:
+            description: The GetFindingRoutingRuleResponse message.
+            properties:
+                routingRule:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingRoutingRule'
+            title: Get Finding Routing Rule Response
+            type: object
+            x-speakeasy-name-override: GetFindingRoutingRuleResponse
+        c1.api.finding.v1.IdentityUserTarget:
+            description: The IdentityUserTarget message.
+            nullable: true
+            properties:
+                identityUserId:
+                    description: The identityUserId field.
+                    readOnly: false
+                    type: string
+            title: Identity User Target
+            type: object
+            x-speakeasy-name-override: IdentityUserTarget
+        c1.api.finding.v1.ListFindingRoutingRulesResponse:
+            description: The ListFindingRoutingRulesResponse message.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.finding.v1.FindingRoutingRule'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: List Finding Routing Rules Response
+            type: object
+            x-speakeasy-name-override: ListFindingRoutingRulesResponse
+        c1.api.finding.v1.NotifyAction:
+            description: The NotifyAction message.
+            nullable: true
+            title: Notify Action
+            type: object
+            x-speakeasy-name-override: NotifyAction
+        c1.api.finding.v1.ReopenAction:
+            description: ReopenAction parameters for UpdateFindingState.
+            nullable: true
+            title: Reopen Action
+            type: object
+            x-speakeasy-name-override: ReopenAction
+        c1.api.finding.v1.ResolveAction:
+            description: ResolveAction parameters for UpdateFindingState (manual resolve).
+            nullable: true
+            properties:
+                reason:
+                    description: The reason field.
+                    readOnly: false
+                    type: string
+            title: Resolve Action
+            type: object
+            x-speakeasy-name-override: ResolveAction
+        c1.api.finding.v1.ServiceAccountMisclassificationEvidence:
+            description: The ServiceAccountMisclassificationEvidence message.
+            nullable: true
+            properties:
+                detectionReason:
+                    description: The detectionReason field.
+                    readOnly: false
+                    type: string
+            title: Service Account Misclassification Evidence
+            type: object
+            x-speakeasy-name-override: ServiceAccountMisclassificationEvidence
+        c1.api.finding.v1.ServiceAccountMisclassificationType:
+            description: The ServiceAccountMisclassificationType message.
+            nullable: true
+            properties:
+                currentAccountType:
+                    description: The currentAccountType field.
+                    enum:
+                        - APP_USER_TYPE_UNSPECIFIED
+                        - APP_USER_TYPE_USER
+                        - APP_USER_TYPE_SERVICE_ACCOUNT
+                        - APP_USER_TYPE_SYSTEM_ACCOUNT
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                detectedAccountType:
+                    description: The detectedAccountType field.
+                    enum:
+                        - APP_USER_TYPE_UNSPECIFIED
+                        - APP_USER_TYPE_USER
+                        - APP_USER_TYPE_SERVICE_ACCOUNT
+                        - APP_USER_TYPE_SYSTEM_ACCOUNT
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Service Account Misclassification Type
+            type: object
+            x-speakeasy-name-override: ServiceAccountMisclassificationType
+        c1.api.finding.v1.SimilarUsernameMatchEvidence:
+            description: The SimilarUsernameMatchEvidence message.
+            nullable: true
+            properties:
+                appUsername:
+                    description: The appUsername field.
+                    readOnly: false
+                    type: string
+                identityUsername:
+                    description: The identityUsername field.
+                    readOnly: false
+                    type: string
+                similarityScore:
+                    description: The similarityScore field.
+                    readOnly: false
+                    type: number
+            title: Similar Username Match Evidence
+            type: object
+            x-speakeasy-name-override: SimilarUsernameMatchEvidence
+        c1.api.finding.v1.SimilarUsernameMatchType:
+            description: The SimilarUsernameMatchType message.
+            nullable: true
+            properties:
+                proposedIdentityUserId:
+                    description: The proposedIdentityUserId field.
+                    readOnly: false
+                    type: string
+            title: Similar Username Match Type
+            type: object
+            x-speakeasy-name-override: SimilarUsernameMatchType
+        c1.api.finding.v1.SnoozeAction:
+            description: SnoozeAction parameters for UpdateFindingState.
+            nullable: true
+            properties:
+                reason:
+                    description: The reason field.
+                    readOnly: false
+                    type: string
+                snoozeUntil:
+                    format: date-time
+                    readOnly: false
+                    type: string
+            title: Snooze Action
+            type: object
+            x-speakeasy-name-override: SnoozeAction
+        c1.api.finding.v1.SuppressRoutingAction:
+            description: The SuppressRoutingAction message.
+            nullable: true
+            properties:
+                reason:
+                    description: The reason field.
+                    readOnly: false
+                    type: string
+            title: Suppress Routing Action
+            type: object
+            x-speakeasy-name-override: SuppressRoutingAction
+        c1.api.finding.v1.SuppressStateAction:
+            description: SuppressStateAction parameters for UpdateFindingState.
+            nullable: true
+            properties:
+                reason:
+                    description: The reason field.
+                    readOnly: false
+                    type: string
+            title: Suppress State Action
+            type: object
+            x-speakeasy-name-override: SuppressStateAction
+        c1.api.finding.v1.UnsuppressAction:
+            deprecated: true
+            description: UnsuppressAction parameters for UpdateFindingState.
+            nullable: true
+            title: Unsuppress Action
+            type: object
+            x-speakeasy-name-override: UnsuppressAction
+        c1.api.finding.v1.UpdateFindingRoutingRuleRequestInput:
+            description: The UpdateFindingRoutingRuleRequest message.
+            properties:
+                routingRule:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingRoutingRule'
+            title: Update Finding Routing Rule Request
+            type: object
+            x-speakeasy-name-override: UpdateFindingRoutingRuleRequest
+        c1.api.finding.v1.UpdateFindingRoutingRuleResponse:
+            description: The UpdateFindingRoutingRuleResponse message.
+            properties:
+                routingRule:
+                    $ref: '#/components/schemas/c1.api.finding.v1.FindingRoutingRule'
+            title: Update Finding Routing Rule Response
+            type: object
+            x-speakeasy-name-override: UpdateFindingRoutingRuleResponse
+        c1.api.finding.v1.UpdateFindingStateRequestInput:
+            description: |
+                The UpdateFindingStateRequest message.
+
+                This message contains a oneof named action. Only a single field of the following list may be set at a time:
+                  - snooze
+                  - suppress
+                  - acceptRisk
+                  - unsuppress
+                  - resolve
+                  - reopen
+            properties:
+                acceptRisk:
+                    $ref: '#/components/schemas/c1.api.finding.v1.AcceptRiskAction'
+                reopen:
+                    $ref: '#/components/schemas/c1.api.finding.v1.ReopenAction'
+                resolve:
+                    $ref: '#/components/schemas/c1.api.finding.v1.ResolveAction'
+                snooze:
+                    $ref: '#/components/schemas/c1.api.finding.v1.SnoozeAction'
+                suppress:
+                    $ref: '#/components/schemas/c1.api.finding.v1.SuppressStateAction'
+                unsuppress:
+                    $ref: '#/components/schemas/c1.api.finding.v1.UnsuppressAction'
+            title: Update Finding State Request
+            type: object
+            x-speakeasy-name-override: UpdateFindingStateRequest
+        c1.api.finding.v1.UpdateFindingStateResponse:
+            description: The UpdateFindingStateResponse message.
+            properties:
+                finding:
+                    $ref: '#/components/schemas/c1.api.finding.v1.Finding'
+            title: Update Finding State Response
+            type: object
+            x-speakeasy-name-override: UpdateFindingStateResponse
         c1.api.form.v1.AdminProviderConfig:
             description: The AdminProviderConfig message.
             nullable: true
@@ -10059,10 +12408,6 @@ components:
                 This message contains a oneof named view. Only a single field of the following list may be set at a time:
                   - checkboxField
                   - toggleField
-
-
-                This message contains a oneof named _rules. Only a single field of the following list may be set at a time:
-                  - rules
             nullable: true
             properties:
                 checkboxField:
@@ -10125,6 +12470,7 @@ components:
                   - int64Field
                   - fileField
                   - oauth2Field
+                  - stringMapField
 
 
                 This message contains a oneof named provider_config. Only a single field of the following list may be set at a time:
@@ -10162,6 +12508,8 @@ components:
                     $ref: '#/components/schemas/c1.api.form.v1.SharedProviderConfig'
                 stringField:
                     $ref: '#/components/schemas/c1.api.form.v1.StringField'
+                stringMapField:
+                    $ref: '#/components/schemas/c1.api.form.v1.StringMapField'
                 stringSliceField:
                     $ref: '#/components/schemas/c1.api.form.v1.StringSliceField'
                 userConfig:
@@ -10233,10 +12581,6 @@ components:
 
                 This message contains a oneof named view. Only a single field of the following list may be set at a time:
                   - fileInputField
-
-
-                This message contains a oneof named _max_file_size. Only a single field of the following list may be set at a time:
-                  - maxFileSize
             nullable: true
             properties:
                 acceptedFileTypes:
@@ -10249,10 +12593,7 @@ components:
                 fileInputField:
                     $ref: '#/components/schemas/c1.api.form.v1.FileInputField'
                 maxFileSize:
-                    description: |-
-                        The maxFileSize field.
-                        This field is part of the `_max_file_size` oneof.
-                        See the documentation for `c1.api.form.v1.FileField` for more details.
+                    description: The maxFileSize field.
                     format: int64
                     nullable: true
                     readOnly: false
@@ -10312,21 +12653,10 @@ components:
 
                 This message contains a oneof named view. Only a single field of the following list may be set at a time:
                   - numberField
-
-
-                This message contains a oneof named _default_value. Only a single field of the following list may be set at a time:
-                  - defaultValue
-
-
-                This message contains a oneof named _rules. Only a single field of the following list may be set at a time:
-                  - rules
             nullable: true
             properties:
                 defaultValue:
-                    description: |-
-                        The defaultValue field.
-                        This field is part of the `_default_value` oneof.
-                        See the documentation for `c1.api.form.v1.Int64Field` for more details.
+                    description: The defaultValue field.
                     format: int64
                     nullable: true
                     readOnly: false
@@ -10490,10 +12820,6 @@ components:
                   - passwordField
                   - selectField
                   - pickerField
-
-
-                This message contains a oneof named _rules. Only a single field of the following list may be set at a time:
-                  - rules
             nullable: true
             properties:
                 defaultValue:
@@ -10517,6 +12843,36 @@ components:
             title: String Field
             type: object
             x-speakeasy-name-override: StringField
+        c1.api.form.v1.StringMapField:
+            description: The StringMapField message.
+            nullable: true
+            properties:
+                defaultValue:
+                    additionalProperties:
+                        type: string
+                    description: The defaultValue field.
+                    readOnly: false
+                    type: object
+                rules:
+                    $ref: '#/components/schemas/c1.api.form.v1.StringMapRules'
+            title: String Map Field
+            type: object
+            x-speakeasy-name-override: StringMapField
+        c1.api.form.v1.StringMapRules:
+            description: The StringMapRules message.
+            nullable: true
+            properties:
+                isRequired:
+                    description: The isRequired field.
+                    readOnly: false
+                    type: boolean
+                validateEmpty:
+                    description: The validateEmpty field.
+                    readOnly: false
+                    type: boolean
+            title: String Map Rules
+            type: object
+            x-speakeasy-name-override: StringMapRules
         c1.api.form.v1.StringSliceField:
             description: |
                 The StringSliceField message.
@@ -10524,10 +12880,6 @@ components:
                 This message contains a oneof named view. Only a single field of the following list may be set at a time:
                   - chipsField
                   - pickerField
-
-
-                This message contains a oneof named _rules. Only a single field of the following list may be set at a time:
-                  - rules
             nullable: true
             properties:
                 chipsField:
@@ -10558,6 +12910,11 @@ components:
                     description: The multiline field.
                     readOnly: false
                     type: boolean
+                suffix:
+                    description: Static text displayed as an end adornment (e.g. ".example.com" for domain fields).
+                    nullable: true
+                    readOnly: false
+                    type: string
             title: Text Field
             type: object
             x-speakeasy-name-override: TextField
@@ -10602,6 +12959,7 @@ components:
                     enum:
                         - FUNCTION_TYPE_UNSPECIFIED
                         - FUNCTION_TYPE_ANY
+                        - FUNCTION_TYPE_CODE_MODE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -10651,6 +13009,16 @@ components:
                     format: date-time
                     readOnly: true
                     type: string
+                useSpn:
+                    description: |-
+                        FN-347 transition flag. When true, the function authenticates to c1-api
+                         as user:<sp_id> via the AssumeIdentity token exchange using its
+                         ServicePrincipalBinding; when false, it authenticates as
+                         function:<id>. Read-only from clients: set by CreateFunction (when the
+                         tenant has completed the FunctionsToSPN migration) and by the migration
+                         itself, never by UpdateFunction. Retired once all functions are on SPN.
+                    readOnly: true
+                    type: boolean
             title: Function
             type: object
             x-speakeasy-entity: Function
@@ -10884,6 +13252,7 @@ components:
                         enum:
                             - FUNCTION_TYPE_UNSPECIFIED
                             - FUNCTION_TYPE_ANY
+                            - FUNCTION_TYPE_CODE_MODE
                         type: string
                         x-speakeasy-unknown-values: allow
                     nullable: true
@@ -10922,26 +13291,40 @@ components:
             title: Functions Search Response
             type: object
             x-speakeasy-name-override: FunctionsSearchResponse
+        c1.api.functions.v1.FunctionsServiceCreateFinalCommitRequestInput:
+            description: The FunctionsServiceCreateFinalCommitRequest message.
+            title: Functions Service Create Final Commit Request
+            type: object
+            x-speakeasy-name-override: FunctionsServiceCreateFinalCommitRequest
+        c1.api.functions.v1.FunctionsServiceCreateFinalCommitResponse:
+            description: The FunctionsServiceCreateFinalCommitResponse message.
+            properties:
+                commit:
+                    $ref: '#/components/schemas/c1.api.functions.v1.FunctionCommit'
+            title: Functions Service Create Final Commit Response
+            type: object
+            x-speakeasy-name-override: FunctionsServiceCreateFinalCommitResponse
         c1.api.functions.v1.FunctionsServiceCreateFunctionRequest:
             description: The FunctionsServiceCreateFunctionRequest message.
             properties:
                 commitMessage:
-                    description: The commitMessage field.
+                    description: The commit message describing the initial code submission.
                     readOnly: false
                     type: string
                 description:
-                    description: The description field.
+                    description: A description of what the function does.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name for the function.
                     readOnly: false
                     type: string
                 functionType:
-                    description: The functionType field.
+                    description: The type of function to create, controlling its execution environment and capabilities.
                     enum:
                         - FUNCTION_TYPE_UNSPECIFIED
                         - FUNCTION_TYPE_ANY
+                        - FUNCTION_TYPE_CODE_MODE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -10949,7 +13332,7 @@ components:
                     additionalProperties:
                         format: base64
                         type: string
-                    description: The initialContent field.
+                    description: Map of filename to file content for the initial code commit.
                     readOnly: false
                     type: object
             title: Functions Service Create Function Request
@@ -10965,6 +13348,39 @@ components:
             title: Functions Service Create Function Response
             type: object
             x-speakeasy-name-override: FunctionsServiceCreateFunctionResponse
+        c1.api.functions.v1.FunctionsServiceCreateInitialCommitRequestInput:
+            description: The FunctionsServiceCreateInitialCommitRequest message.
+            properties:
+                commitMessage:
+                    description: The commitMessage field.
+                    readOnly: false
+                    type: string
+                filenames:
+                    description: The filenames field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Functions Service Create Initial Commit Request
+            type: object
+            x-speakeasy-name-override: FunctionsServiceCreateInitialCommitRequest
+        c1.api.functions.v1.FunctionsServiceCreateInitialCommitResponse:
+            description: The FunctionsServiceCreateInitialCommitResponse message.
+            properties:
+                commitId:
+                    description: The commitId field.
+                    readOnly: false
+                    type: string
+                uploadUrls:
+                    additionalProperties:
+                        type: string
+                    description: The uploadUrls field.
+                    readOnly: false
+                    type: object
+            title: Functions Service Create Initial Commit Response
+            type: object
+            x-speakeasy-name-override: FunctionsServiceCreateInitialCommitResponse
         c1.api.functions.v1.FunctionsServiceCreateTagRequestInput:
             description: The FunctionsServiceCreateTagRequest message.
             properties:
@@ -10994,6 +13410,21 @@ components:
             title: Functions Service Delete Function Response
             type: object
             x-speakeasy-name-override: FunctionsServiceDeleteFunctionResponse
+        c1.api.functions.v1.FunctionsServiceGetCommitContentResponse:
+            description: FunctionsServiceGetCommitContentResponse contains a commit and all its file contents.
+            properties:
+                commit:
+                    $ref: '#/components/schemas/c1.api.functions.v1.FunctionCommit'
+                files:
+                    additionalProperties:
+                        format: base64
+                        type: string
+                    description: Map of filename to file content bytes.
+                    readOnly: false
+                    type: object
+            title: Functions Service Get Commit Content Response
+            type: object
+            x-speakeasy-name-override: FunctionsServiceGetCommitContentResponse
         c1.api.functions.v1.FunctionsServiceGetFunctionResponse:
             description: The FunctionsServiceGetFunctionResponse message.
             properties:
@@ -11002,6 +13433,21 @@ components:
             title: Functions Service Get Function Response
             type: object
             x-speakeasy-name-override: FunctionsServiceGetFunctionResponse
+        c1.api.functions.v1.FunctionsServiceGetLockFileResponse:
+            description: FunctionsServiceGetLockFileResponse returns the deno lock file content for a commit.
+            properties:
+                content:
+                    description: The raw content of the deno lock file (empty if not found).
+                    format: base64
+                    readOnly: false
+                    type: string
+                exists:
+                    description: Whether the lock file exists for this commit.
+                    readOnly: false
+                    type: boolean
+            title: Functions Service Get Lock File Response
+            type: object
+            x-speakeasy-name-override: FunctionsServiceGetLockFileResponse
         c1.api.functions.v1.FunctionsServiceInvokeRequestInput:
             description: |
                 The FunctionsServiceInvokeRequest message.
@@ -11010,16 +13456,20 @@ components:
                   - json
             properties:
                 commitId:
-                    description: The commitId field.
+                    description: The commit ID specifying which version of the function code to run.
                     readOnly: false
                     type: string
                 json:
                     description: |-
-                        The json field.
+                        The JSON-encoded input data passed to the function.
                         This field is part of the `arg` oneof.
                         See the documentation for `c1.api.functions.v1.FunctionsServiceInvokeRequest` for more details.
                     format: base64
                     nullable: true
+                    readOnly: false
+                    type: string
+                vfsId:
+                    description: Optional VFS volume ID to attach to this invocation. If empty, VFS operations will error.
                     readOnly: false
                     type: string
             title: Functions Service Invoke Request
@@ -11033,13 +13483,13 @@ components:
                   - json
             properties:
                 invocationId:
-                    description: The invocationId field.
+                    description: The ID of the created invocation, used to track execution status and retrieve results.
                     readOnly: false
                     type: string
                 json:
                     deprecated: true
                     description: |-
-                        The json field.
+                        Deprecated. The JSON-encoded output returned by the function.
                         This field is part of the `resp` oneof.
                         See the documentation for `c1.api.functions.v1.FunctionsServiceInvokeResponse` for more details.
                     format: base64
@@ -11140,6 +13590,401 @@ components:
             title: Functions Service Update Function Response
             type: object
             x-speakeasy-name-override: FunctionsServiceUpdateFunctionResponse
+        c1.api.hooks.v1.BuiltInPattern:
+            description: |
+                BuiltInPattern references a ConductorOne-maintained DLP pattern.
+                 The specific pattern and its configuration are encoded as a oneof.
+
+                This message contains a oneof named config. Only a single field of the following list may be set at a time:
+                  - piiRedaction
+                  - creditCardBlocking
+                  - queryScopeLimit
+                  - writeAuthorization
+                  - sensitiveFileGuard
+            nullable: true
+            properties:
+                creditCardBlocking:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.CreditCardBlockingConfig'
+                piiRedaction:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.PIIRedactionConfig'
+                queryScopeLimit:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.QueryScopeLimitConfig'
+                sensitiveFileGuard:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.SensitiveFileGuardConfig'
+                writeAuthorization:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.WriteAuthorizationConfig'
+            title: Built In Pattern
+            type: object
+            x-speakeasy-name-override: BuiltInPattern
+        c1.api.hooks.v1.BusinessHours:
+            description: BusinessHours defines a weekly time window in a specific timezone.
+            properties:
+                days:
+                    description: 0=Sun, 1=Mon, ..., 6=Sat.
+                    items:
+                        format: int32
+                        type: integer
+                    nullable: true
+                    readOnly: false
+                    type: array
+                end:
+                    description: '"HH:MM" in 24-hour format.'
+                    readOnly: false
+                    type: string
+                start:
+                    description: '"HH:MM" in 24-hour format.'
+                    readOnly: false
+                    type: string
+                timezone:
+                    description: The timezone field.
+                    readOnly: false
+                    type: string
+            title: Business Hours
+            type: object
+            x-speakeasy-name-override: BusinessHours
+        c1.api.hooks.v1.CreditCardBlockingConfig:
+            description: |-
+                CreditCardBlockingConfig denies any tool call whose output contains a
+                 Luhn-valid credit card number. No configuration fields today; the
+                 presence of the oneof arm is the whole configuration.
+            nullable: true
+            title: Credit Card Blocking Config
+            type: object
+            x-speakeasy-name-override: CreditCardBlockingConfig
+        c1.api.hooks.v1.Hook:
+            description: |
+                Hook represents a customer-configured interception point for tool calls.
+
+                This message contains a oneof named hook_type. Only a single field of the following list may be set at a time:
+                  - function
+                  - builtinPattern
+            properties:
+                builtinPattern:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.BuiltInPattern'
+                createdAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                description:
+                    description: The description field.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                enabled:
+                    description: The enabled field.
+                    readOnly: false
+                    type: boolean
+                event:
+                    description: The event field.
+                    enum:
+                        - HOOK_EVENT_TYPE_UNSPECIFIED
+                        - HOOK_EVENT_TYPE_PRE_TOOL_USE
+                        - HOOK_EVENT_TYPE_POST_TOOL_USE
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                filter:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.HookFilter'
+                function:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.HookFunctionRef'
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+                priority:
+                    description: The priority field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                updatedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+            title: Hook
+            type: object
+            x-speakeasy-name-override: Hook
+        c1.api.hooks.v1.HookFilter:
+            description: HookFilter determines which tool calls a hook applies to.
+            properties:
+                celExpression:
+                    description: |-
+                        CEL expression evaluated against tool call context.
+                         Available variable: ctx.tool_name (string).
+                         Must evaluate to bool. Empty matches all tools.
+                    readOnly: false
+                    type: string
+            title: Hook Filter
+            type: object
+            x-speakeasy-name-override: HookFilter
+        c1.api.hooks.v1.HookFunctionRef:
+            description: HookFunctionRef identifies a customer-authored function to invoke.
+            nullable: true
+            properties:
+                commitId:
+                    description: If empty, the function's published commit is used at invocation time.
+                    readOnly: false
+                    type: string
+                functionId:
+                    description: The functionId field.
+                    readOnly: false
+                    type: string
+            title: Hook Function Ref
+            type: object
+            x-speakeasy-name-override: HookFunctionRef
+        c1.api.hooks.v1.HookRef:
+            description: The HookRef message.
+            properties:
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            title: Hook Ref
+            type: object
+            x-speakeasy-name-override: HookRef
+        c1.api.hooks.v1.HooksSearchRequest:
+            description: The HooksSearchRequest message.
+            properties:
+                pageSize:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+                query:
+                    description: The query field.
+                    readOnly: false
+                    type: string
+                refs:
+                    description: The refs field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.hooks.v1.HookRef'
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Hooks Search Request
+            type: object
+            x-speakeasy-name-override: HooksSearchRequest
+        c1.api.hooks.v1.HooksSearchResponse:
+            description: The HooksSearchResponse message.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.hooks.v1.Hook'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Hooks Search Response
+            type: object
+            x-speakeasy-name-override: HooksSearchResponse
+        c1.api.hooks.v1.HooksServiceCreateRequest:
+            description: |
+                The HooksServiceCreateRequest message.
+
+                This message contains a oneof named hook_type. Only a single field of the following list may be set at a time:
+                  - function
+                  - builtinPattern
+            properties:
+                builtinPattern:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.BuiltInPattern'
+                description:
+                    description: The description field.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                enabled:
+                    description: The enabled field.
+                    readOnly: false
+                    type: boolean
+                event:
+                    description: The event field.
+                    enum:
+                        - HOOK_EVENT_TYPE_UNSPECIFIED
+                        - HOOK_EVENT_TYPE_PRE_TOOL_USE
+                        - HOOK_EVENT_TYPE_POST_TOOL_USE
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                filter:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.HookFilter'
+                function:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.HookFunctionRef'
+                priority:
+                    description: The priority field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+            required:
+                - displayName
+            title: Hooks Service Create Request
+            type: object
+            x-speakeasy-name-override: HooksServiceCreateRequest
+        c1.api.hooks.v1.HooksServiceCreateResponse:
+            description: The HooksServiceCreateResponse message.
+            properties:
+                hook:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.Hook'
+            title: Hooks Service Create Response
+            type: object
+            x-speakeasy-name-override: HooksServiceCreateResponse
+        c1.api.hooks.v1.HooksServiceDeleteRequestInput:
+            description: The HooksServiceDeleteRequest message.
+            title: Hooks Service Delete Request
+            type: object
+            x-speakeasy-name-override: HooksServiceDeleteRequest
+        c1.api.hooks.v1.HooksServiceDeleteResponse:
+            description: The HooksServiceDeleteResponse message.
+            title: Hooks Service Delete Response
+            type: object
+            x-speakeasy-name-override: HooksServiceDeleteResponse
+        c1.api.hooks.v1.HooksServiceGetResponse:
+            description: The HooksServiceGetResponse message.
+            properties:
+                hook:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.Hook'
+            title: Hooks Service Get Response
+            type: object
+            x-speakeasy-name-override: HooksServiceGetResponse
+        c1.api.hooks.v1.HooksServiceListResponse:
+            description: The HooksServiceListResponse message.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.hooks.v1.Hook'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Hooks Service List Response
+            type: object
+            x-speakeasy-name-override: HooksServiceListResponse
+        c1.api.hooks.v1.HooksServiceUpdateRequestInput:
+            description: The HooksServiceUpdateRequest message.
+            properties:
+                hook:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.Hook'
+                updateMask:
+                    nullable: true
+                    readOnly: false
+                    type: string
+            title: Hooks Service Update Request
+            type: object
+            x-speakeasy-name-override: HooksServiceUpdateRequest
+        c1.api.hooks.v1.HooksServiceUpdateResponse:
+            description: The HooksServiceUpdateResponse message.
+            properties:
+                hook:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.Hook'
+            title: Hooks Service Update Response
+            type: object
+            x-speakeasy-name-override: HooksServiceUpdateResponse
+        c1.api.hooks.v1.PIIRedactionConfig:
+            description: PIIRedactionConfig configures post-tool-use redaction of sensitive fields.
+            nullable: true
+            properties:
+                redactFields:
+                    description: The redactFields field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                replacement:
+                    description: The replacement field.
+                    readOnly: false
+                    type: string
+            title: Pii Redaction Config
+            type: object
+            x-speakeasy-name-override: PIIRedactionConfig
+        c1.api.hooks.v1.QueryScopeLimitConfig:
+            description: |-
+                QueryScopeLimitConfig caps numeric fields (e.g. limit, page_size) in tool
+                 input so callers cannot request unbounded data.
+            nullable: true
+            properties:
+                fields:
+                    description: The fields field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                maxLimit:
+                    description: The maxLimit field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+            title: Query Scope Limit Config
+            type: object
+            x-speakeasy-name-override: QueryScopeLimitConfig
+        c1.api.hooks.v1.SensitiveFileGuardConfig:
+            description: |-
+                SensitiveFileGuardConfig blocks tool calls that reference sensitive file
+                 paths or directories.
+            nullable: true
+            properties:
+                blockedDirectories:
+                    description: The blockedDirectories field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                blockedPatterns:
+                    description: The blockedPatterns field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Sensitive File Guard Config
+            type: object
+            x-speakeasy-name-override: SensitiveFileGuardConfig
+        c1.api.hooks.v1.WriteAuthorizationConfig:
+            description: |-
+                WriteAuthorizationConfig blocks tool calls whose ToolClassification is in
+                 blocked_classifications, optionally permitting them within business hours.
+            nullable: true
+            properties:
+                blockedClassifications:
+                    description: |-
+                        Tool classifications to block. Must have at least one entry; a hook
+                         with no blocked classifications would be a silent misconfiguration.
+                    items:
+                        enum:
+                            - TOOL_CLASSIFICATION_UNSPECIFIED
+                            - TOOL_CLASSIFICATION_READ
+                            - TOOL_CLASSIFICATION_WRITE
+                            - TOOL_CLASSIFICATION_DESTRUCTIVE
+                            - TOOL_CLASSIFICATION_SENSITIVE
+                            - TOOL_CLASSIFICATION_DANGEROUS
+                        type: string
+                        x-speakeasy-unknown-values: allow
+                    nullable: true
+                    readOnly: false
+                    type: array
+                businessHours:
+                    $ref: '#/components/schemas/c1.api.hooks.v1.BusinessHours'
+            title: Write Authorization Config
+            type: object
+            x-speakeasy-name-override: WriteAuthorizationConfig
         c1.api.iam.v1.ActorObjectPermissions:
             description: The ActorObjectPermissions message.
             properties:
@@ -11182,6 +14027,12 @@ components:
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
+                clientIdUrl:
+                    description: |-
+                        Original CIMD metadata URL (e.g., "https://cursor.com/.well-known/oauth-client").
+                         Empty for DCR clients.
+                    readOnly: false
+                    type: string
                 clientName:
                     description: Original client name from DCR registration
                     readOnly: false
@@ -11196,6 +14047,10 @@ components:
                     type: string
                 lastUsedAt:
                     format: date-time
+                    readOnly: false
+                    type: string
+                mcpClientId:
+                    description: MCP client record ID for AI governance tracking. May be empty for legacy grants.
                     readOnly: false
                     type: string
                 roleIds:
@@ -11343,7 +14198,9 @@ components:
             description: The PersonalClient message contains information about a presonal client credential.
             properties:
                 allowSourceCidr:
-                    description: If set, only allows the CIDRs in the array to use the credential.
+                    description: |-
+                        If set, only allows the CIDRs in the array to use the credential.
+                         Accepts IPv4 (e.g. 10.0.0.0/24) or IPv6 (e.g. 2001:db8::/32) CIDRs.
                     items:
                         type: string
                     nullable: true
@@ -11403,20 +14260,20 @@ components:
             description: The PersonalClientSearchServiceSearchRequest message.
             properties:
                 pageSize:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: A pagination token returned from a previous Search call.
                     readOnly: false
                     type: string
                 query:
-                    description: The query field.
+                    description: A text query to filter personal clients by display name.
                     readOnly: false
                     type: string
                 users:
-                    description: The users field.
+                    description: Filter results to personal clients owned by the specified users.
                     items:
                         $ref: '#/components/schemas/c1.api.user.v1.UserRef'
                     nullable: true
@@ -11429,14 +14286,14 @@ components:
             description: The PersonalClientSearchServiceSearchResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of personal client credentials matching the search criteria.
                     items:
                         $ref: '#/components/schemas/c1.api.iam.v1.PersonalClient'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: A token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: Personal Client Search Service Search Response
@@ -11446,7 +14303,9 @@ components:
             description: The PersonalClientServiceCreateRequest message contains the fields for creating a new personal client.
             properties:
                 allowSourceCidr:
-                    description: A list of CIDRs to restrict this credential to.
+                    description: |-
+                        A list of CIDRs to restrict this credential to.
+                         Accepts IPv4 (e.g. 10.0.0.0/24) or IPv6 (e.g. 2001:db8::/32) CIDRs.
                     items:
                         type: string
                     nullable: true
@@ -11504,14 +14363,14 @@ components:
             description: The PersonalClientServiceListResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of personal client credentials owned by the calling user.
                     items:
                         $ref: '#/components/schemas/c1.api.iam.v1.PersonalClient'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: A token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: Personal Client Service List Response
@@ -11619,7 +14478,7 @@ components:
                     type: boolean
             title: Checkbox Field
             type: object
-            x-speakeasy-name-override: CheckboxField
+            x-speakeasy-name-override: ConnectorCheckboxField
         c1.api.integration.connector.v1.ConfigSchema:
             description: The ConfigSchema message.
             properties:
@@ -11666,25 +14525,25 @@ components:
             type: object
             x-speakeasy-name-override: ConfigSchema
         c1.api.integration.connector.v1.ConnectorCatalogServiceConfigurationSchemaRequest:
-            description: The ConnectorCatalogServiceConfigurationSchemaRequest message.
+            description: ConnectorCatalogServiceConfigurationSchemaRequest is the request for retrieving a connector's configuration schema.
             properties:
                 appId:
-                    description: The appId field.
+                    description: The ID of the app associated with the connector. Optional.
                     readOnly: false
                     type: string
                 catalogId:
-                    description: The catalogId field.
+                    description: The catalog entry ID identifying the connector type.
                     readOnly: false
                     type: string
                 connectorId:
-                    description: The connectorId field.
+                    description: The ID of an existing connector to retrieve its current configuration schema. Optional.
                     readOnly: false
                     type: string
             title: Connector Catalog Service Configuration Schema Request
             type: object
             x-speakeasy-name-override: ConnectorCatalogServiceConfigurationSchemaRequest
         c1.api.integration.connector.v1.ConnectorCatalogServiceConfigurationSchemaResponse:
-            description: The ConnectorCatalogServiceConfigurationSchemaResponse message.
+            description: ConnectorCatalogServiceConfigurationSchemaResponse is the response containing the connector's configuration schema.
             properties:
                 formSchema:
                     $ref: '#/components/schemas/c1.api.form.v1.Form'
@@ -11773,7 +14632,7 @@ components:
                     $ref: '#/components/schemas/c1.api.integration.connector.v1.TextField'
             title: Field
             type: object
-            x-speakeasy-name-override: Field
+            x-speakeasy-name-override: ConnectorField
         c1.api.integration.connector.v1.FieldGroup:
             description: The FieldGroup message.
             properties:
@@ -11802,7 +14661,7 @@ components:
                     type: string
             title: Field Group
             type: object
-            x-speakeasy-name-override: FieldGroup
+            x-speakeasy-name-override: ConnectorFieldGroup
         c1.api.integration.connector.v1.ImportField:
             description: The ImportField message.
             nullable: true
@@ -11887,7 +14746,7 @@ components:
                     type: array
             title: Select Field
             type: object
-            x-speakeasy-name-override: SelectField
+            x-speakeasy-name-override: ConnectorSelectField
         c1.api.integration.connector.v1.SelectField.Item:
             description: The Item message.
             properties:
@@ -11914,7 +14773,7 @@ components:
                     $ref: '#/components/schemas/validate.StringRules'
             title: String Field
             type: object
-            x-speakeasy-name-override: StringField
+            x-speakeasy-name-override: ConnectorStringField
         c1.api.integration.connector.v1.StringListField:
             description: The StringListField message.
             nullable: true
@@ -11934,7 +14793,7 @@ components:
                     type: boolean
             title: String Map Field
             type: object
-            x-speakeasy-name-override: StringMapField
+            x-speakeasy-name-override: ConnectorStringMapField
         c1.api.integration.connector.v1.TextField:
             description: The TextField message.
             nullable: true
@@ -11947,7 +14806,374 @@ components:
                     $ref: '#/components/schemas/validate.StringRules'
             title: Text Field
             type: object
-            x-speakeasy-name-override: TextField
+            x-speakeasy-name-override: ConnectorTextField
+        c1.api.local_directory.v1.LocalDirectoryConfig:
+            description: |-
+                LocalDirectoryConfig is the public representation of a C1-managed local
+                 directory configuration. The underlying directory infrastructure is provided
+                 by the linked App (identified by app_id).
+            properties:
+                allowSelfRegistration:
+                    description: Whether unauthenticated users may self-register in this directory.
+                    readOnly: false
+                    type: boolean
+                appId:
+                    description: app_id is the identifier for this config and its linked App. Read-only after creation.
+                    readOnly: true
+                    type: string
+                createdAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                defaultProfileTypeId:
+                    description: Optional FK to a ProfileType applied to new users created via this directory.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                invitationTtl:
+                    format: duration
+                    readOnly: false
+                    type: string
+                isDefault:
+                    description: |-
+                        Whether this is the default local directory for the tenant.
+                         At most one config per tenant may be the default.
+                    readOnly: false
+                    type: boolean
+                onboardingFlowId:
+                    description: Optional FK to an onboarding flow applied by default when inviting users.
+                    readOnly: false
+                    type: string
+                organizationId:
+                    description: Optional FK to a ThirdPartyOrganization. Empty means standalone (no vendor linkage).
+                    readOnly: false
+                    type: string
+                selfRegistrationDomains:
+                    description: |-
+                        Email domain allowlist for self-registration. Empty allows any domain when
+                         allow_self_registration is true.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                updatedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+            title: Local Directory Config
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfig
+        c1.api.local_directory.v1.LocalDirectoryConfigServiceCreateRequest:
+            description: The LocalDirectoryConfigServiceCreateRequest message.
+            properties:
+                allowSelfRegistration:
+                    description: The allowSelfRegistration field.
+                    readOnly: false
+                    type: boolean
+                appId:
+                    description: FK to the existing App that will back this local directory.
+                    readOnly: false
+                    type: string
+                defaultProfileTypeId:
+                    description: The defaultProfileTypeId field.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                invitationTtl:
+                    format: duration
+                    readOnly: false
+                    type: string
+                isDefault:
+                    description: Whether this should be the default local directory for the tenant.
+                    readOnly: false
+                    type: boolean
+                onboardingFlowId:
+                    description: The onboardingFlowId field.
+                    readOnly: false
+                    type: string
+                organizationId:
+                    description: Optional FK to a ThirdPartyOrganization.
+                    readOnly: false
+                    type: string
+                selfRegistrationDomains:
+                    description: The selfRegistrationDomains field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+            required:
+                - appId
+                - displayName
+            title: Local Directory Config Service Create Request
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfigServiceCreateRequest
+        c1.api.local_directory.v1.LocalDirectoryConfigServiceCreateResponse:
+            description: The LocalDirectoryConfigServiceCreateResponse message.
+            properties:
+                localDirectoryConfig:
+                    $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfig'
+            title: Local Directory Config Service Create Response
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfigServiceCreateResponse
+        c1.api.local_directory.v1.LocalDirectoryConfigServiceDeleteRequestInput:
+            description: The LocalDirectoryConfigServiceDeleteRequest message.
+            title: Local Directory Config Service Delete Request
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfigServiceDeleteRequest
+        c1.api.local_directory.v1.LocalDirectoryConfigServiceDeleteResponse:
+            description: The LocalDirectoryConfigServiceDeleteResponse message.
+            title: Local Directory Config Service Delete Response
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfigServiceDeleteResponse
+        c1.api.local_directory.v1.LocalDirectoryConfigServiceGetResponse:
+            description: The LocalDirectoryConfigServiceGetResponse message.
+            properties:
+                localDirectoryConfig:
+                    $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfig'
+            title: Local Directory Config Service Get Response
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfigServiceGetResponse
+        c1.api.local_directory.v1.LocalDirectoryConfigServiceListResponse:
+            description: The LocalDirectoryConfigServiceListResponse message.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfig'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Local Directory Config Service List Response
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfigServiceListResponse
+        c1.api.local_directory.v1.LocalDirectoryConfigServiceUpdateRequestInput:
+            description: The LocalDirectoryConfigServiceUpdateRequest message.
+            properties:
+                localDirectoryConfig:
+                    $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfig'
+                updateMask:
+                    nullable: true
+                    readOnly: false
+                    type: string
+            title: Local Directory Config Service Update Request
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfigServiceUpdateRequest
+        c1.api.local_directory.v1.LocalDirectoryConfigServiceUpdateResponse:
+            description: The LocalDirectoryConfigServiceUpdateResponse message.
+            properties:
+                localDirectoryConfig:
+                    $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfig'
+            title: Local Directory Config Service Update Response
+            type: object
+            x-speakeasy-name-override: LocalDirectoryConfigServiceUpdateResponse
+        c1.api.local_directory.v1.LocalUserInvitation:
+            description: LocalUserInvitation is the public representation of a per-directory user invitation.
+            properties:
+                acceptedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                createdAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                createdUserId:
+                    description: Set when status = ACCEPTED. FK to the created User. Read-only.
+                    readOnly: true
+                    type: string
+                directoryAppId:
+                    description: FK to the LocalDirectoryConfig (app_id) this invitation belongs to. Read-only after creation.
+                    readOnly: true
+                    type: string
+                displayName:
+                    description: Display name to pre-populate on the new user account.
+                    readOnly: false
+                    type: string
+                email:
+                    description: Email address the invitation was sent to.
+                    readOnly: false
+                    type: string
+                expiresAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                id:
+                    description: Unique KSUID identifier. Read-only.
+                    readOnly: true
+                    type: string
+                initialRoleIds:
+                    description: Optional initial role IDs to assign to the user upon acceptance.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                invitedByUserId:
+                    description: FK to the User who created the invitation. Read-only.
+                    readOnly: true
+                    type: string
+                jobId:
+                    description: Optional FK to a ThirdPartyJob.
+                    readOnly: false
+                    type: string
+                onboardingFlowId:
+                    description: Optional onboarding flow override for this invitation.
+                    readOnly: false
+                    type: string
+                purpose:
+                    description: Human-readable reason this user was invited.
+                    readOnly: false
+                    type: string
+                sponsorUserId:
+                    description: Optional sponsor User override for this invitation.
+                    readOnly: false
+                    type: string
+                status:
+                    description: Current lifecycle status. Read-only.
+                    enum:
+                        - LOCAL_INVITATION_STATUS_UNSPECIFIED
+                        - LOCAL_INVITATION_STATUS_PENDING
+                        - LOCAL_INVITATION_STATUS_ACCEPTED
+                        - LOCAL_INVITATION_STATUS_REVOKED
+                        - LOCAL_INVITATION_STATUS_EXPIRED
+                    readOnly: true
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                updatedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+            title: Local User Invitation
+            type: object
+            x-speakeasy-name-override: LocalUserInvitation
+        c1.api.local_directory.v1.LocalUserInvitationServiceCreateRequestInput:
+            description: The LocalUserInvitationServiceCreateRequest message.
+            properties:
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                email:
+                    description: The email field.
+                    readOnly: false
+                    type: string
+                initialRoleIds:
+                    description: Optional initial role IDs to assign upon acceptance.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                jobId:
+                    description: Optional FK to a ThirdPartyJob.
+                    readOnly: false
+                    type: string
+                onboardingFlowId:
+                    description: Optional onboarding flow override.
+                    readOnly: false
+                    type: string
+                purpose:
+                    description: Human-readable reason for the invitation.
+                    readOnly: false
+                    type: string
+                sponsorUserId:
+                    description: Optional sponsor User override.
+                    readOnly: false
+                    type: string
+            required:
+                - email
+                - displayName
+            title: Local User Invitation Service Create Request
+            type: object
+            x-speakeasy-name-override: LocalUserInvitationServiceCreateRequest
+        c1.api.local_directory.v1.LocalUserInvitationServiceCreateResponse:
+            description: The LocalUserInvitationServiceCreateResponse message.
+            properties:
+                invitation:
+                    $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitation'
+            title: Local User Invitation Service Create Response
+            type: object
+            x-speakeasy-name-override: LocalUserInvitationServiceCreateResponse
+        c1.api.local_directory.v1.LocalUserInvitationServiceGetResponse:
+            description: The LocalUserInvitationServiceGetResponse message.
+            properties:
+                invitation:
+                    $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitation'
+            title: Local User Invitation Service Get Response
+            type: object
+            x-speakeasy-name-override: LocalUserInvitationServiceGetResponse
+        c1.api.local_directory.v1.LocalUserInvitationServiceRevokeRequestInput:
+            description: The LocalUserInvitationServiceRevokeRequest message.
+            title: Local User Invitation Service Revoke Request
+            type: object
+            x-speakeasy-name-override: LocalUserInvitationServiceRevokeRequest
+        c1.api.local_directory.v1.LocalUserInvitationServiceRevokeResponse:
+            description: The LocalUserInvitationServiceRevokeResponse message.
+            properties:
+                invitation:
+                    $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitation'
+            title: Local User Invitation Service Revoke Response
+            type: object
+            x-speakeasy-name-override: LocalUserInvitationServiceRevokeResponse
+        c1.api.local_directory.v1.LocalUserInvitationServiceSearchRequest:
+            description: The LocalUserInvitationServiceSearchRequest message.
+            properties:
+                directoryAppId:
+                    description: The directoryAppId field.
+                    readOnly: false
+                    type: string
+                pageSize:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+                statusFilter:
+                    description: Optional filter by invitation status.
+                    enum:
+                        - LOCAL_INVITATION_STATUS_UNSPECIFIED
+                        - LOCAL_INVITATION_STATUS_PENDING
+                        - LOCAL_INVITATION_STATUS_ACCEPTED
+                        - LOCAL_INVITATION_STATUS_REVOKED
+                        - LOCAL_INVITATION_STATUS_EXPIRED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Local User Invitation Service Search Request
+            type: object
+            x-speakeasy-name-override: LocalUserInvitationServiceSearchRequest
+        c1.api.local_directory.v1.LocalUserInvitationServiceSearchResponse:
+            description: The LocalUserInvitationServiceSearchResponse message.
+            properties:
+                list:
+                    description: The list field.
+                    items:
+                        $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitation'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Local User Invitation Service Search Response
+            type: object
+            x-speakeasy-name-override: LocalUserInvitationServiceSearchResponse
         c1.api.policy.v1.Accept:
             description: This policy step indicates that a ticket should have an approved outcome. This is a terminal approval state and is used to explicitly define the end of approval steps.
             nullable: true
@@ -11979,12 +15205,15 @@ components:
                 This message contains a oneof named target. Only a single field of the following list may be set at a time:
                   - automation
                   - batonResourceAction
+                  - clientIdApproval
             nullable: true
             properties:
                 automation:
                     $ref: '#/components/schemas/c1.api.policy.v1.ActionTargetAutomation'
                 batonResourceAction:
                     $ref: '#/components/schemas/c1.api.policy.v1.ActionTargetBatonResourceAction'
+                clientIdApproval:
+                    $ref: '#/components/schemas/c1.api.policy.v1.ActionTargetClientIdApproval'
             title: Action
             type: object
             x-speakeasy-name-override: Action
@@ -11995,6 +15224,7 @@ components:
                 This message contains a oneof named target_instance. Only a single field of the following list may be set at a time:
                   - automation
                   - batonResourceActionInstance
+                  - clientIdApprovalInstance
 
 
                 This message contains a oneof named outcome. Only a single field of the following list may be set at a time:
@@ -12012,6 +15242,8 @@ components:
                     $ref: '#/components/schemas/c1.api.policy.v1.ActionTargetBatonResourceActionInstance'
                 cancelled:
                     $ref: '#/components/schemas/c1.api.policy.v1.ActionOutcomeCancelled'
+                clientIdApprovalInstance:
+                    $ref: '#/components/schemas/c1.api.policy.v1.ActionTargetClientIdApprovalInstance'
                 denied:
                     $ref: '#/components/schemas/c1.api.policy.v1.ActionOutcomeDenied'
                 error:
@@ -12031,7 +15263,7 @@ components:
                     $ref: '#/components/schemas/c1.api.policy.v1.ActionOutcomeSuccess'
             title: Action Instance
             type: object
-            x-speakeasy-name-override: ActionInstance
+            x-speakeasy-name-override: PolicyActionInstance
         c1.api.policy.v1.ActionOutcomeCancelled:
             description: The ActionOutcomeCancelled message.
             nullable: true
@@ -12151,6 +15383,27 @@ components:
             title: Action Target Baton Resource Action Instance
             type: object
             x-speakeasy-name-override: ActionTargetBatonResourceActionInstance
+        c1.api.policy.v1.ActionTargetClientIdApproval:
+            description: |-
+                ActionTargetClientIdApproval targets administrator review of an external
+                 OAuth client registration (CIMD or DCR) for policy actions.
+            nullable: true
+            title: Action Target Client Id Approval
+            type: object
+            x-speakeasy-name-override: ActionTargetClientIdApproval
+        c1.api.policy.v1.ActionTargetClientIdApprovalInstance:
+            description: |-
+                ActionTargetClientIdApprovalInstance carries the registration key of the
+                 external OAuth client that is being reviewed.
+            nullable: true
+            properties:
+                clientIdUrl:
+                    description: The clientIdUrl field.
+                    readOnly: false
+                    type: string
+            title: Action Target Client Id Approval Instance
+            type: object
+            x-speakeasy-name-override: ActionTargetClientIdApprovalInstance
         c1.api.policy.v1.AgentApproval:
             description: The agent to assign the task to.
             nullable: true
@@ -12590,11 +15843,14 @@ components:
                 policySteps:
                     additionalProperties:
                         $ref: '#/components/schemas/c1.api.policy.v1.PolicySteps'
-                    description: The map of policy type to policy steps. The key is the stringified version of the enum. See other policies for examples.
+                    description: |-
+                        Step sequences for this policy. The map must include a baseline entry keyed
+                         by the lowercased policy type (e.g., "grant"). Additional entries with
+                         opaque keys can be added for conditional routing via the rules array.
                     readOnly: false
                     type: object
                 policyType:
-                    description: The enum of the policy type.
+                    description: The type of policy to create (grant, revoke, or certify).
                     enum:
                         - POLICY_TYPE_UNSPECIFIED
                         - POLICY_TYPE_GRANT
@@ -12606,7 +15862,7 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 postActions:
-                    description: Actions to occur after a policy finishes. As of now this is only valid on a certify policy to remediate a denied certification immediately.
+                    description: Ordered actions to execute after the policy completes processing.
                     items:
                         $ref: '#/components/schemas/c1.api.policy.v1.PolicyPostActions'
                     nullable: true
@@ -12614,11 +15870,11 @@ components:
                     type: array
                 reassignTasksToDelegates:
                     deprecated: true
-                    description: Deprecated. Use setting in policy step instead
+                    description: This field is no longer used. Configure delegate reassignment in the policy step instead.
                     readOnly: false
                     type: boolean
                 rules:
-                    description: The rules field.
+                    description: Conditional routing rules. See the Policy message for details on evaluation order.
                     items:
                         $ref: '#/components/schemas/c1.api.policy.v1.Rule'
                     nullable: true
@@ -12692,7 +15948,7 @@ components:
                     type: string
             title: Editor Validate Request
             type: object
-            x-speakeasy-name-override: EditorValidateRequest
+            x-speakeasy-name-override: PolicyEditorValidateRequest
         c1.api.policy.v1.EditorValidateResponse:
             description: The EditorValidateResponse message.
             properties:
@@ -12705,7 +15961,7 @@ components:
                     type: array
             title: Editor Validate Response
             type: object
-            x-speakeasy-name-override: EditorValidateResponse
+            x-speakeasy-name-override: PolicyEditorValidateResponse
         c1.api.policy.v1.EntitlementOwnerApproval:
             description: The entitlement owner approval allows configuration of the approval step when the target approvers are the entitlement owners.
             nullable: true
@@ -12885,7 +16141,7 @@ components:
             nullable: true
             title: Cancel Ticket
             type: object
-            x-speakeasy-name-override: CancelTicket
+            x-speakeasy-name-override: EscalationInstanceCancelTicket
         c1.api.policy.v1.EscalationInstance.ReassignToApprovers:
             description: The ReassignToApprovers message.
             nullable: true
@@ -12899,7 +16155,7 @@ components:
                     type: array
             title: Reassign To Approvers
             type: object
-            x-speakeasy-name-override: ReassignToApprovers
+            x-speakeasy-name-override: EscalationInstanceReassignToApprovers
         c1.api.policy.v1.EscalationInstance.ReplacePolicy:
             description: The ReplacePolicy message.
             nullable: true
@@ -12910,13 +16166,13 @@ components:
                     type: string
             title: Replace Policy
             type: object
-            x-speakeasy-name-override: ReplacePolicy
+            x-speakeasy-name-override: EscalationInstanceReplacePolicy
         c1.api.policy.v1.EscalationInstance.SkipStep:
             description: The SkipStep message.
             nullable: true
             title: Skip Step
             type: object
-            x-speakeasy-name-override: SkipStep
+            x-speakeasy-name-override: EscalationInstanceSkipStep
         c1.api.policy.v1.ExpressionApproval:
             description: The ExpressionApproval message.
             nullable: true
@@ -13024,7 +16280,7 @@ components:
                     $ref: '#/components/schemas/c1.api.form.v1.Form'
             title: Form
             type: object
-            x-speakeasy-name-override: Form
+            x-speakeasy-name-override: PolicyForm
         c1.api.policy.v1.FormCompletedAction:
             description: The FormCompletedAction message.
             nullable: true
@@ -13227,7 +16483,11 @@ components:
             type: object
             x-speakeasy-name-override: MultiStep
         c1.api.policy.v1.Policy:
-            description: A policy describes the behavior of the ConductorOne system when processing a task. You can describe the type, approvers, fallback behavior, and escalation processes.
+            description: |-
+                A policy defines a workflow (sequence of steps) that runs when processing
+                 access requests, reviews, or revocations. Policies support conditional
+                 routing: different conditions can trigger different step sequences, with a
+                 baseline fallback.
             properties:
                 createdAt:
                     format: date-time
@@ -13252,11 +16512,18 @@ components:
                 policySteps:
                     additionalProperties:
                         $ref: '#/components/schemas/c1.api.policy.v1.PolicySteps'
-                    description: A map of string(policy type) to steps in a policy. This structure is leftover from a previous design, and should only ever have one key->value set.
+                    description: |-
+                        A map from string keys to step sequences. One entry is always the baseline,
+                         keyed by the lowercased policy_type (e.g., "grant", "revoke", "certify").
+                         Additional entries have opaque keys (UUIDs) and are referenced by the rules
+                         array for conditional routing. If no conditional rules are configured, only
+                         the baseline entry exists.
                     readOnly: false
                     type: object
                 policyType:
-                    description: Indicates the type of this policy. Can also be used to get the value from policySteps.
+                    description: |-
+                        The type of this policy (grant, revoke, or certify). The lowercased type
+                         name (e.g., "grant") is also the key for the baseline entry in policy_steps.
                     enum:
                         - POLICY_TYPE_UNSPECIFIED
                         - POLICY_TYPE_GRANT
@@ -13268,7 +16535,7 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 postActions:
-                    description: An array of actions (ordered) to take place after a policy completes processing.
+                    description: Ordered actions to execute after the policy completes processing.
                     items:
                         $ref: '#/components/schemas/c1.api.policy.v1.PolicyPostActions'
                     nullable: true
@@ -13276,11 +16543,14 @@ components:
                     type: array
                 reassignTasksToDelegates:
                     deprecated: true
-                    description: Deprecated. Use setting in policy step instead
+                    description: This field is no longer used. Configure delegate reassignment in the policy step instead.
                     readOnly: false
                     type: boolean
                 rules:
-                    description: The rules field.
+                    description: |-
+                        Ordered conditional routing rules. Evaluated top-to-bottom; the first
+                         matching rule selects a step sequence from policy_steps. If no rule matches
+                         (or if this array is empty), the baseline entry in policy_steps is used.
                     items:
                         $ref: '#/components/schemas/c1.api.policy.v1.Rule'
                     nullable: true
@@ -13324,15 +16594,15 @@ components:
             x-speakeasy-name-override: PolicyInstance
         c1.api.policy.v1.PolicyPostActions:
             description: |
-                These are actions to happen after a policy is complete.
+                Actions to execute after a policy finishes processing.
 
                 This message contains a oneof named action. Only a single field of the following list may be set at a time:
                   - certifyRemediateImmediately
             properties:
                 certifyRemediateImmediately:
                     description: |-
-                        ONLY valid when used in a CERTIFY Ticket Type:
-                         Causes any deprovision or change in a grant to be applied when Certify Ticket is closed.
+                        Only valid on certify policies. When true, any revocations resulting from
+                         the certification are applied immediately when the campaign task closes.
                         This field is part of the `action` oneof.
                         See the documentation for `c1.api.policy.v1.PolicyPostActions` for more details.
                     nullable: true
@@ -13353,7 +16623,7 @@ components:
             x-speakeasy-name-override: PolicyRef
         c1.api.policy.v1.PolicyStep:
             description: |
-                The PolicyStep message.
+                A single step in a policy workflow. Exactly one step type is set.
 
                 This message contains a oneof named step. Only a single field of the following list may be set at a time:
                   - approval
@@ -13429,10 +16699,12 @@ components:
             type: object
             x-speakeasy-name-override: PolicyStepInstance
         c1.api.policy.v1.PolicySteps:
-            description: The PolicySteps message.
+            description: A named sequence of steps that execute in order within a policy.
             properties:
                 steps:
-                    description: An array of policy steps indicating the processing flow of a policy. These steps are oneOfs, and only one property may be set for each array index at a time.
+                    description: |-
+                        Ordered array of steps. Each step is a oneof -- exactly one step type is
+                         set per entry. Steps execute sequentially.
                     items:
                         $ref: '#/components/schemas/c1.api.policy.v1.PolicyStep'
                     nullable: true
@@ -13738,14 +17010,22 @@ components:
             type: object
             x-speakeasy-name-override: RestartAction
         c1.api.policy.v1.Rule:
-            description: The Rule message.
+            description: |-
+                A conditional routing rule that maps a CEL expression to a step sequence.
+                 Rules are evaluated top-to-bottom; the first matching rule's policy_key
+                 selects the step sequence from the policy's policy_steps map. If no rule
+                 matches, the baseline entry is used.
             properties:
                 condition:
-                    description: The condition field.
+                    description: |-
+                        A CEL expression that is evaluated against the request context. If it
+                         returns true, the step sequence identified by policy_key is used.
                     readOnly: false
                     type: string
                 policyKey:
-                    description: This is a reference to a list of policy steps from `policy_steps`
+                    description: |-
+                        A key into the policy's policy_steps map identifying which step sequence
+                         to execute when this rule's condition matches.
                     readOnly: false
                     type: string
             title: Rule
@@ -13880,24 +17160,24 @@ components:
             type: object
             x-speakeasy-name-override: SkippedAction
         c1.api.policy.v1.TestAccountProvisionPolicyRequest:
-            description: The TestAccountProvisionPolicyRequest message.
+            description: TestAccountProvisionPolicyRequest is the request for testing an account provision policy.
             properties:
                 cel:
-                    description: The cel field.
+                    description: The CEL expression to evaluate for the account provision policy.
                     readOnly: false
                     type: string
             title: Test Account Provision Policy Request
             type: object
             x-speakeasy-name-override: TestAccountProvisionPolicyRequest
         c1.api.policy.v1.TestAccountProvisionPolicyResponse:
-            description: The TestAccountProvisionPolicyResponse message.
+            description: TestAccountProvisionPolicyResponse is the response for testing an account provision policy.
             properties:
                 type:
-                    description: The type field.
+                    description: The data type of the computed result value.
                     readOnly: false
                     type: string
                 value:
-                    description: The value field.
+                    description: The computed result value of the CEL expression evaluation.
                     readOnly: false
                     type: string
             title: Test Account Provision Policy Response
@@ -14223,7 +17503,7 @@ components:
             type: object
             x-speakeasy-name-override: ProfileType
         c1.api.request_schema.v1.RequestSchema:
-            description: The RequestSchema message.
+            description: A request schema defines a form template that users fill out when requesting access.
             properties:
                 createdAt:
                     format: date-time
@@ -14236,11 +17516,11 @@ components:
                 form:
                     $ref: '#/components/schemas/c1.api.form.v1.Form'
                 id:
-                    description: The id field.
+                    description: The unique identifier of this request schema.
                     readOnly: false
                     type: string
                 justificationVisibility:
-                    description: The justificationVisibility field.
+                    description: Controls whether the justification field is shown or hidden on the request form.
                     enum:
                         - JUSTIFICATION_VISIBILITY_UNSPECIFIED
                         - JUSTIFICATION_VISIBILITY_SHOW
@@ -14256,59 +17536,59 @@ components:
             type: object
             x-speakeasy-name-override: RequestSchema
         c1.api.request_schema.v1.RequestSchemaServiceCreateEntitlementBindingRequest:
-            description: The RequestSchemaServiceCreateEntitlementBindingRequest message.
+            description: The request message for creating a single entitlement binding on a request schema.
             properties:
                 entitlementRef:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                 requestSchemaId:
-                    description: The requestSchemaId field.
+                    description: The unique identifier of the request schema to bind the entitlement to.
                     readOnly: false
                     type: string
             title: Request Schema Service Create Entitlement Binding Request
             type: object
             x-speakeasy-name-override: RequestSchemaServiceCreateEntitlementBindingRequest
         c1.api.request_schema.v1.RequestSchemaServiceCreateEntitlementBindingResponse:
-            description: The RequestSchemaServiceCreateEntitlementBindingResponse message.
+            description: The response message for creating a single entitlement binding.
             properties:
                 entitlementRef:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                 requestSchemaId:
-                    description: The requestSchemaId field.
+                    description: The unique identifier of the request schema the entitlement was bound to.
                     readOnly: false
                     type: string
             title: Request Schema Service Create Entitlement Binding Response
             type: object
             x-speakeasy-name-override: RequestSchemaServiceCreateEntitlementBindingResponse
         c1.api.request_schema.v1.RequestSchemaServiceCreateRequest:
-            description: The RequestSchemaServiceCreateRequest message.
+            description: The request message for creating a new request schema.
             properties:
                 description:
-                    description: The description field.
+                    description: An optional description of the request schema's purpose.
                     readOnly: false
                     type: string
                 fieldGroups:
-                    description: The fieldGroups field.
+                    description: Logical groupings of fields for display purposes.
                     items:
                         $ref: '#/components/schemas/c1.api.form.v1.FieldGroup'
                     nullable: true
                     readOnly: false
                     type: array
                 fieldRelationships:
-                    description: The fieldRelationships field.
+                    description: Dependencies between fields that control conditional visibility or validation.
                     items:
                         $ref: '#/components/schemas/c1.api.form.v1.FieldRelationship'
                     nullable: true
                     readOnly: false
                     type: array
                 fields:
-                    description: The fields field.
+                    description: The form fields that users must fill out when requesting access.
                     items:
                         $ref: '#/components/schemas/c1.api.form.v1.Field'
                     nullable: true
                     readOnly: false
                     type: array
                 justificationVisibility:
-                    description: The justificationVisibility field.
+                    description: Controls whether the justification field is shown or hidden on the request form.
                     enum:
                         - JUSTIFICATION_VISIBILITY_UNSPECIFIED
                         - JUSTIFICATION_VISIBILITY_SHOW
@@ -14317,14 +17597,14 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 name:
-                    description: The name field.
+                    description: The human-readable name for the request schema.
                     readOnly: false
                     type: string
             title: Request Schema Service Create Request
             type: object
             x-speakeasy-name-override: RequestSchemaServiceCreateRequest
         c1.api.request_schema.v1.RequestSchemaServiceCreateResponse:
-            description: The RequestSchemaServiceCreateResponse message.
+            description: The response message for creating a request schema.
             properties:
                 requestSchema:
                     $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchema'
@@ -14332,17 +17612,17 @@ components:
             type: object
             x-speakeasy-name-override: RequestSchemaServiceCreateResponse
         c1.api.request_schema.v1.RequestSchemaServiceDeleteRequestInput:
-            description: The RequestSchemaServiceDeleteRequest message.
+            description: The request message for deleting a request schema.
             title: Request Schema Service Delete Request
             type: object
             x-speakeasy-name-override: RequestSchemaServiceDeleteRequest
         c1.api.request_schema.v1.RequestSchemaServiceDeleteResponse:
-            description: The RequestSchemaServiceDeleteResponse message.
+            description: The response message for deleting a request schema.
             title: Request Schema Service Delete Response
             type: object
             x-speakeasy-name-override: RequestSchemaServiceDeleteResponse
         c1.api.request_schema.v1.RequestSchemaServiceFindBindingForAppEntitlementRequest:
-            description: The RequestSchemaServiceFindBindingForAppEntitlementRequest message.
+            description: The request message for finding which request schema is bound to a given app entitlement.
             properties:
                 entitlementRef:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
@@ -14350,19 +17630,19 @@ components:
             type: object
             x-speakeasy-name-override: RequestSchemaServiceFindBindingForAppEntitlementRequest
         c1.api.request_schema.v1.RequestSchemaServiceFindBindingForAppEntitlementResponse:
-            description: The RequestSchemaServiceFindBindingForAppEntitlementResponse message.
+            description: The response message containing the binding for the specified app entitlement.
             properties:
                 entitlementRef:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                 requestSchemaId:
-                    description: The requestSchemaId field.
+                    description: The unique identifier of the request schema bound to this entitlement, if any.
                     readOnly: false
                     type: string
             title: Request Schema Service Find Binding For App Entitlement Response
             type: object
             x-speakeasy-name-override: RequestSchemaServiceFindBindingForAppEntitlementResponse
         c1.api.request_schema.v1.RequestSchemaServiceGetResponse:
-            description: The RequestSchemaServiceGetResponse message.
+            description: The response message for retrieving a request schema.
             properties:
                 requestSchema:
                     $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchema'
@@ -14370,24 +17650,24 @@ components:
             type: object
             x-speakeasy-name-override: RequestSchemaServiceGetResponse
         c1.api.request_schema.v1.RequestSchemaServiceRemoveEntitlementBindingRequest:
-            description: The RequestSchemaServiceRemoveEntitlementBindingRequest message.
+            description: The request message for removing a single entitlement binding from a request schema.
             properties:
                 entitlementRef:
                     $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                 requestSchemaId:
-                    description: The requestSchemaId field.
+                    description: The unique identifier of the request schema to remove the binding from.
                     readOnly: false
                     type: string
             title: Request Schema Service Remove Entitlement Binding Request
             type: object
             x-speakeasy-name-override: RequestSchemaServiceRemoveEntitlementBindingRequest
         c1.api.request_schema.v1.RequestSchemaServiceRemoveEntitlementBindingResponse:
-            description: The RequestSchemaServiceRemoveEntitlementBindingResponse message.
+            description: The response message for removing a single entitlement binding.
             title: Request Schema Service Remove Entitlement Binding Response
             type: object
             x-speakeasy-name-override: RequestSchemaServiceRemoveEntitlementBindingResponse
         c1.api.request_schema.v1.RequestSchemaServiceUpdateRequestInput:
-            description: The RequestSchemaServiceUpdateRequest message.
+            description: The request message for updating an existing request schema.
             properties:
                 requestSchema:
                     $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchema'
@@ -14399,7 +17679,7 @@ components:
             type: object
             x-speakeasy-name-override: RequestSchemaServiceUpdateRequest
         c1.api.request_schema.v1.RequestSchemaServiceUpdateResponse:
-            description: The RequestSchemaServiceUpdateResponse message.
+            description: The response message for updating a request schema.
             properties:
                 requestSchema:
                     $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchema'
@@ -14427,7 +17707,10 @@ components:
 
                 This message contains a oneof named conditions. Only a single field of the following list may be set at a time:
                   - entitlements
+                  - cel
             properties:
+                cel:
+                    $ref: '#/components/schemas/c1.api.requestcatalog.v1.BundleAutomationRuleCEL'
                 circuitBreaker:
                     $ref: '#/components/schemas/c1.api.requestcatalog.v1.BundleAutomationCircuitBreaker'
                 createTasks:
@@ -14469,6 +17752,36 @@ components:
             title: Bundle Automation
             type: object
             x-speakeasy-name-override: BundleAutomation
+        c1.api.requestcatalog.v1.BundleAutomationCelEvaluationState:
+            description: The BundleAutomationCelEvaluationState message.
+            properties:
+                errorMessage:
+                    description: The errorMessage field.
+                    readOnly: false
+                    type: string
+                lastEvaluatedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                matchedUsers:
+                    description: The matchedUsers field.
+                    format: int64
+                    readOnly: false
+                    type: string
+                status:
+                    description: The status field.
+                    enum:
+                        - BUNDLE_AUTOMATION_RUN_STATUS_UNSPECIFIED
+                        - BUNDLE_AUTOMATION_RUN_STATUS_SUCCESS
+                        - BUNDLE_AUTOMATION_RUN_STATUS_FAILURE
+                        - BUNDLE_AUTOMATION_RUN_STATUS_IN_PROGRESS
+                        - BUNDLE_AUTOMATION_RUN_STATUS_WAITING_FOR_APPROVAL
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Bundle Automation Cel Evaluation State
+            type: object
+            x-speakeasy-name-override: BundleAutomationCelEvaluationState
         c1.api.requestcatalog.v1.BundleAutomationCircuitBreaker:
             description: The BundleAutomationCircuitBreaker message.
             properties:
@@ -14483,6 +17796,7 @@ components:
                         - CIRCUIT_BREAKER_STATE_UNSPECIFIED
                         - CIRCUIT_BREAKER_STATE_TRIGGERED
                         - CIRCUIT_BREAKER_STATE_BYPASS
+                        - CIRCUIT_BREAKER_STATE_SUPPORT_DISABLED
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -14498,6 +17812,8 @@ components:
         c1.api.requestcatalog.v1.BundleAutomationLastRunState:
             description: The BundleAutomationLastRunState message.
             properties:
+                celEvaluation:
+                    $ref: '#/components/schemas/c1.api.requestcatalog.v1.BundleAutomationCelEvaluationState'
                 errorMessage:
                     description: The errorMessage field.
                     readOnly: false
@@ -14520,6 +17836,17 @@ components:
             title: Bundle Automation Last Run State
             type: object
             x-speakeasy-name-override: BundleAutomationLastRunState
+        c1.api.requestcatalog.v1.BundleAutomationRuleCEL:
+            description: The BundleAutomationRuleCEL message.
+            nullable: true
+            properties:
+                expression:
+                    description: The expression field.
+                    readOnly: false
+                    type: string
+            title: Bundle Automation Rule Cel
+            type: object
+            x-speakeasy-name-override: BundleAutomationRuleCEL
         c1.api.requestcatalog.v1.BundleAutomationRuleEntitlement:
             description: The BundleAutomationRuleEntitlement message.
             nullable: true
@@ -14536,21 +17863,24 @@ components:
             x-speakeasy-name-override: BundleAutomationRuleEntitlement
         c1.api.requestcatalog.v1.CreateBundleAutomationRequestInput:
             description: |
-                The CreateBundleAutomationRequest message.
+                The request message for creating a new bundle automation rule on a catalog.
 
                 This message contains a oneof named conditions. Only a single field of the following list may be set at a time:
                   - entitlements
+                  - cel
             properties:
+                cel:
+                    $ref: '#/components/schemas/c1.api.requestcatalog.v1.BundleAutomationRuleCEL'
                 createTasks:
-                    description: The createTasks field.
+                    description: Whether to create access request tasks for matched users instead of granting directly.
                     readOnly: false
                     type: boolean
                 disableCircuitBreaker:
-                    description: The disableCircuitBreaker field.
+                    description: Whether to disable the circuit breaker that pauses the automation when excessive membership changes are detected.
                     readOnly: false
                     type: boolean
                 enabled:
-                    description: The enabled field.
+                    description: Whether the automation should actively run on its schedule.
                     readOnly: false
                     type: boolean
                 entitlements:
@@ -14559,20 +17889,20 @@ components:
             type: object
             x-speakeasy-name-override: CreateBundleAutomationRequest
         c1.api.requestcatalog.v1.DeleteBundleAutomationRequestInput:
-            description: The DeleteBundleAutomationRequest message.
+            description: The request message for deleting a bundle automation from a catalog.
             title: Delete Bundle Automation Request
             type: object
             x-speakeasy-name-override: DeleteBundleAutomationRequest
         c1.api.requestcatalog.v1.DeleteBundleAutomationResponse:
-            description: The DeleteBundleAutomationResponse message.
+            description: The response message for deleting a bundle automation.
             title: Delete Bundle Automation Response
             type: object
             x-speakeasy-name-override: DeleteBundleAutomationResponse
         c1.api.requestcatalog.v1.ForceRunBundleAutomationRequestInput:
-            description: The ForceRunBundleAutomationRequest message.
+            description: The request message for triggering an immediate bundle automation run.
             properties:
                 refs:
-                    description: The refs field.
+                    description: Optional entitlement references to scope the run to specific entitlements.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                     nullable: true
@@ -14582,7 +17912,7 @@ components:
             type: object
             x-speakeasy-name-override: ForceRunBundleAutomationRequest
         c1.api.requestcatalog.v1.ForceRunBundleAutomationResponse:
-            description: The ForceRunBundleAutomationResponse message.
+            description: The response message for triggering a bundle automation run.
             title: Force Run Bundle Automation Response
             type: object
             x-speakeasy-name-override: ForceRunBundleAutomationResponse
@@ -14625,6 +17955,12 @@ components:
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
+                grantPolicyId:
+                    description: |-
+                        The ID of the policy to use for access requests in this catalog.
+                         This is different from the catalog AppEntitlement's grant_policy_id, which is used for catalog membership grants.
+                    readOnly: false
+                    type: string
                 id:
                     description: The id of the request catalog.
                     readOnly: false
@@ -14753,6 +18089,10 @@ components:
                     x-speakeasy-unknown-values: allow
                 expandMask:
                     $ref: '#/components/schemas/c1.api.requestcatalog.v1.RequestCatalogExpandMask'
+                grantPolicyId:
+                    description: The ID of the grant policy for access requests in this catalog.
+                    readOnly: false
+                    type: string
                 published:
                     description: Whether or not the new catalog should be created as published.
                     readOnly: false
@@ -14864,10 +18204,10 @@ components:
             type: object
             x-speakeasy-name-override: RequestCatalogManagementServiceGetResponse
         c1.api.requestcatalog.v1.RequestCatalogManagementServiceListAllEntitlementIdsPerCatalogResponse:
-            description: The RequestCatalogManagementServiceListAllEntitlementIdsPerCatalogResponse message.
+            description: The response message containing all requestable entitlement references in the catalog.
             properties:
                 refs:
-                    description: The refs field.
+                    description: The complete list of app entitlement references in this catalog.
                     items:
                         $ref: '#/components/schemas/c1.api.app.v1.AppEntitlementRef'
                     nullable: true
@@ -15170,32 +18510,35 @@ components:
             type: object
             x-speakeasy-name-override: RequestableEntry
         c1.api.requestcatalog.v1.ResumePausedBundleAutomationRequestInput:
-            description: The ResumePausedBundleAutomationRequest message.
+            description: The request message for resuming a paused bundle automation.
             title: Resume Paused Bundle Automation Request
             type: object
             x-speakeasy-name-override: ResumePausedBundleAutomationRequest
         c1.api.requestcatalog.v1.ResumePausedBundleAutomationResponse:
-            description: The ResumePausedBundleAutomationResponse message.
+            description: The response message for resuming a paused bundle automation.
             title: Resume Paused Bundle Automation Response
             type: object
             x-speakeasy-name-override: ResumePausedBundleAutomationResponse
         c1.api.requestcatalog.v1.SetBundleAutomationRequestInput:
             description: |
-                The SetBundleAutomationRequest message.
+                The request message for creating or updating a bundle automation rule on a catalog.
 
                 This message contains a oneof named conditions. Only a single field of the following list may be set at a time:
                   - entitlements
+                  - cel
             properties:
+                cel:
+                    $ref: '#/components/schemas/c1.api.requestcatalog.v1.BundleAutomationRuleCEL'
                 createTasks:
-                    description: The createTasks field.
+                    description: Whether to create access request tasks for matched users instead of granting directly.
                     readOnly: false
                     type: boolean
                 disableCircuitBreaker:
-                    description: The disableCircuitBreaker field.
+                    description: Whether to disable the circuit breaker that pauses the automation when excessive membership changes are detected.
                     readOnly: false
                     type: boolean
                 enabled:
-                    description: The enabled field.
+                    description: Whether the automation should actively run on its schedule.
                     readOnly: false
                     type: boolean
                 entitlements:
@@ -15207,16 +18550,16 @@ components:
             description: The CohortHintInput message.
             properties:
                 attribute:
-                    description: The attribute field.
+                    description: The user attribute name to use for cohort grouping (e.g., "department", "job_title").
                     readOnly: false
                     type: string
                 priority:
-                    description: The priority field.
+                    description: Relative priority of this hint. Higher values cause the analysis to weight this attribute more heavily.
                     format: int32
                     readOnly: false
                     type: integer
                 values:
-                    description: The values field.
+                    description: Specific attribute values to focus on. If empty, all values for the attribute are considered.
                     items:
                         type: string
                     nullable: true
@@ -15229,16 +18572,16 @@ components:
             description: The CohortHintView message.
             properties:
                 attribute:
-                    description: The attribute field.
+                    description: The user attribute name used for cohort grouping.
                     readOnly: false
                     type: string
                 priority:
-                    description: The priority field.
+                    description: Relative priority of this hint.
                     format: int32
                     readOnly: false
                     type: integer
                 values:
-                    description: The values field.
+                    description: The specific attribute values targeted by this hint.
                     items:
                         type: string
                     nullable: true
@@ -15247,6 +18590,122 @@ components:
             title: Cohort Hint View
             type: object
             x-speakeasy-name-override: CohortHintView
+        c1.api.role_mining_management.v1.CreateAccessProfileFromCohortRequest:
+            description: The CreateAccessProfileFromCohortRequest message.
+            properties:
+                createTasks:
+                    description: |-
+                        If true, the automation will create JIT tasks for access changes.
+                         If false, users are synced to membership without creating tasks.
+                    readOnly: false
+                    type: boolean
+                description:
+                    description: Description for the access profile.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: Display name for the access profile.
+                    readOnly: false
+                    type: string
+                enableAutomation:
+                    description: If true, enable the dynamic membership automation immediately.
+                    readOnly: false
+                    type: boolean
+                entitlements:
+                    description: Entitlements to add to the access profile.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.CohortEntitlement'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                profileFilters:
+                    description: Profile filters defining the cohort for dynamic membership.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.ProfileFilter'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                suggestionId:
+                    description: Optional suggestion ID to mark as accepted after creating the profile.
+                    readOnly: false
+                    type: string
+            title: Create Access Profile From Cohort Request
+            type: object
+            x-speakeasy-name-override: CreateAccessProfileFromCohortRequest
+        c1.api.role_mining_management.v1.CreateAccessProfileFromCohortResponse:
+            description: The CreateAccessProfileFromCohortResponse message.
+            properties:
+                accessProfileId:
+                    description: The ID of the created access profile.
+                    readOnly: false
+                    type: string
+                celExpression:
+                    description: The CEL expression generated for dynamic membership.
+                    readOnly: false
+                    type: string
+            title: Create Access Profile From Cohort Response
+            type: object
+            x-speakeasy-name-override: CreateAccessProfileFromCohortResponse
+        c1.api.role_mining_management.v1.GetCustomAnalysisResultResponse:
+            description: The GetCustomAnalysisResultResponse message.
+            properties:
+                appsAnalyzed:
+                    description: The appsAnalyzed field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                clusters:
+                    description: Cluster results.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.EntitlementCluster'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                cohortSize:
+                    description: The cohortSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                entitlements:
+                    description: Entitlement coverage results.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.CohortEntitlement'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                errorMessage:
+                    description: The errorMessage field.
+                    readOnly: false
+                    type: string
+                facetUserCount:
+                    description: The facetUserCount field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                facets:
+                    description: Facet results.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.AttributeFacet'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+                status:
+                    description: The status field.
+                    enum:
+                        - RUN_STATUS_UNSPECIFIED
+                        - RUN_STATUS_RUNNING
+                        - RUN_STATUS_COMPLETED
+                        - RUN_STATUS_FAILED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Get Custom Analysis Result Response
+            type: object
+            x-speakeasy-name-override: GetCustomAnalysisResultResponse
         c1.api.role_mining_management.v1.GetLatestRunResponse:
             description: The GetLatestRunResponse message.
             properties:
@@ -15275,14 +18734,14 @@ components:
             description: The ListRunsResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of role mining analysis runs.
                     items:
                         $ref: '#/components/schemas/c1.api.role_mining_management.v1.RoleMiningManagementRun'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page of results, empty if no more results.
                     readOnly: false
                     type: string
             title: List Runs Response
@@ -15292,14 +18751,14 @@ components:
             description: The ListSuggestionsResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of role mining suggestions.
                     items:
                         $ref: '#/components/schemas/c1.api.role_mining_management.v1.RoleMiningManagementSuggestion'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page of results, empty if no more results.
                     readOnly: false
                     type: string
             title: List Suggestions Response
@@ -15309,19 +18768,19 @@ components:
             description: The RoleMiningManagementConfig message.
             properties:
                 cohortHints:
-                    description: The cohortHints field.
+                    description: Configured cohort hints that guide which user attributes the analysis prioritizes.
                     items:
                         $ref: '#/components/schemas/c1.api.role_mining_management.v1.CohortHintView'
                     nullable: true
                     readOnly: false
                     type: array
                 maxSuggestions:
-                    description: The maxSuggestions field.
+                    description: Maximum number of suggestions the analysis will produce per run.
                     format: int32
                     readOnly: false
                     type: integer
                 minCohortSize:
-                    description: The minCohortSize field.
+                    description: Minimum number of users a cohort must contain to generate a suggestion.
                     format: int32
                     readOnly: false
                     type: integer
@@ -15332,7 +18791,7 @@ components:
             description: The RoleMiningManagementRun message.
             properties:
                 cohortsAnalyzed:
-                    description: The cohortsAnalyzed field.
+                    description: Number of user cohorts evaluated during the analysis.
                     format: int32
                     readOnly: false
                     type: integer
@@ -15345,15 +18804,15 @@ components:
                     readOnly: false
                     type: string
                 errorMessage:
-                    description: The errorMessage field.
+                    description: Error message if the run failed, empty on success.
                     readOnly: false
                     type: string
                 id:
-                    description: The id field.
+                    description: Unique identifier for this analysis run.
                     readOnly: false
                     type: string
                 status:
-                    description: The status field.
+                    description: Current execution status of this run (e.g., running, completed, failed).
                     enum:
                         - RUN_STATUS_UNSPECIFIED
                         - RUN_STATUS_RUNNING
@@ -15363,26 +18822,27 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 suggestionsGenerated:
-                    description: The suggestionsGenerated field.
+                    description: Number of role suggestions produced by this run.
                     format: int32
                     readOnly: false
                     type: integer
                 totalUsers:
-                    description: The totalUsers field.
+                    description: Total number of users evaluated during the analysis.
                     format: int32
                     readOnly: false
                     type: integer
                 triggerDetail:
-                    description: The triggerDetail field.
+                    description: Additional detail about the trigger, such as the user or schedule that initiated the run.
                     readOnly: false
                     type: string
                 triggerType:
-                    description: The triggerType field.
+                    description: How this run was initiated (e.g., manual, scheduled).
                     enum:
                         - TRIGGER_TYPE_UNSPECIFIED
                         - TRIGGER_TYPE_MANUAL
                         - TRIGGER_TYPE_UPLIFT_COMPLETION
                         - TRIGGER_TYPE_SCHEDULED
+                        - TRIGGER_TYPE_DIRECTORY_MERGE
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
@@ -15397,23 +18857,23 @@ components:
             description: The RoleMiningManagementSuggestion message.
             properties:
                 avgCoverage:
-                    description: The avgCoverage field.
+                    description: Average fraction of suggested entitlements held by each user in the cohort.
                     readOnly: false
                     type: number
                 cohortFilters:
-                    description: The cohortFilters field.
+                    description: The profile filters that define which users belong to this cohort.
                     items:
                         $ref: '#/components/schemas/c1.mcp.role_mining.v1.ProfileFilter'
                     nullable: true
                     readOnly: false
                     type: array
                 cohortSize:
-                    description: The cohortSize field.
+                    description: Total number of users in the cohort matching the profile filters.
                     format: int32
                     readOnly: false
                     type: integer
                 confidence:
-                    description: The confidence field.
+                    description: Overall confidence score for this suggestion, from 0.0 to 1.0.
                     readOnly: false
                     type: number
                 createdAt:
@@ -15421,38 +18881,38 @@ components:
                     readOnly: false
                     type: string
                 createdCatalogId:
-                    description: The createdCatalogId field.
+                    description: The ID of the access profile created when this suggestion was accepted, empty if not yet accepted.
                     readOnly: false
                     type: string
                 description:
-                    description: The description field.
+                    description: A human-readable description of the proposed role and the cohort it serves.
                     readOnly: false
                     type: string
                 dimensionCount:
-                    description: The dimensionCount field.
+                    description: Number of distinct attribute dimensions used to define the cohort.
                     format: int32
                     readOnly: false
                     type: integer
                 entitlements:
-                    description: The entitlements field.
+                    description: The entitlements that are commonly held by users in this cohort.
                     items:
                         $ref: '#/components/schemas/c1.mcp.role_mining.v1.CohortEntitlement'
                     nullable: true
                     readOnly: false
                     type: array
                 existingProfileMatches:
-                    description: The existingProfileMatches field.
+                    description: Existing access profiles that overlap with this suggestion.
                     items:
                         $ref: '#/components/schemas/c1.mcp.role_mining.v1.AccessProfileMatch'
                     nullable: true
                     readOnly: false
                     type: array
                 id:
-                    description: The id field.
+                    description: Unique identifier for this suggestion.
                     readOnly: false
                     type: string
                 insights:
-                    description: The insights field.
+                    description: Human-readable insights explaining why this role was suggested.
                     items:
                         type: string
                     nullable: true
@@ -15463,15 +18923,15 @@ components:
                     readOnly: false
                     type: string
                 runId:
-                    description: The runId field.
+                    description: The ID of the analysis run that produced this suggestion.
                     readOnly: false
                     type: string
                 suggestedName:
-                    description: The suggestedName field.
+                    description: The suggested display name for the proposed role.
                     readOnly: false
                     type: string
                 suggestionState:
-                    description: The suggestionState field.
+                    description: Current workflow state of this suggestion (e.g., pending, accepted, dismissed).
                     enum:
                         - SUGGESTION_STATE_UNSPECIFIED
                         - SUGGESTION_STATE_NEW
@@ -15485,7 +18945,7 @@ components:
                     readOnly: false
                     type: string
                 usersWithAll:
-                    description: The usersWithAll field.
+                    description: Number of users in the cohort that hold all of the suggested entitlements.
                     format: int32
                     readOnly: false
                     type: integer
@@ -15516,12 +18976,12 @@ components:
                     readOnly: false
                     type: array
                 pageSize:
-                    description: The pageSize field.
+                    description: Maximum number of suggestions to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: Pagination token from a previous response.
                     readOnly: false
                     type: string
                 query:
@@ -15548,19 +19008,58 @@ components:
             description: The RoleMiningSearchSuggestionsResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of matching role mining suggestions.
                     items:
                         $ref: '#/components/schemas/c1.api.role_mining_management.v1.RoleMiningManagementSuggestion'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: Token to retrieve the next page of results, empty if no more results.
                     readOnly: false
                     type: string
             title: Role Mining Search Suggestions Response
             type: object
             x-speakeasy-name-override: RoleMiningSearchSuggestionsResponse
+        c1.api.role_mining_management.v1.SearchCohortUsersRequestInput:
+            description: The SearchCohortUsersRequest message.
+            properties:
+                pageSize:
+                    description: Maximum number of users to return per page.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: Pagination token from a previous response.
+                    readOnly: false
+                    type: string
+                profileFilters:
+                    description: Additional profile filters to narrow the cohort user search.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.ProfileFilter'
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Search Cohort Users Request
+            type: object
+            x-speakeasy-name-override: SearchCohortUsersRequest
+        c1.api.role_mining_management.v1.SearchCohortUsersResponse:
+            description: The SearchCohortUsersResponse message.
+            properties:
+                list:
+                    description: The list of users matching the cohort and optional filters.
+                    items:
+                        $ref: '#/components/schemas/c1.api.user.v1.User'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: Token to retrieve the next page of results, empty if no more results.
+                    readOnly: false
+                    type: string
+            title: Search Cohort Users Response
+            type: object
+            x-speakeasy-name-override: SearchCohortUsersResponse
         c1.api.role_mining_management.v1.TriggerAnalysisRequest:
             description: The TriggerAnalysisRequest message.
             title: Trigger Analysis Request
@@ -15570,29 +19069,52 @@ components:
             description: The TriggerAnalysisResponse message.
             properties:
                 runId:
-                    description: The runId field.
+                    description: The ID of the newly created analysis run.
                     readOnly: false
                     type: string
             title: Trigger Analysis Response
             type: object
             x-speakeasy-name-override: TriggerAnalysisResponse
+        c1.api.role_mining_management.v1.TriggerCustomAnalysisRequest:
+            description: The TriggerCustomAnalysisRequest message.
+            properties:
+                profileFilters:
+                    description: The profileFilters field.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.ProfileFilter'
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Trigger Custom Analysis Request
+            type: object
+            x-speakeasy-name-override: TriggerCustomAnalysisRequest
+        c1.api.role_mining_management.v1.TriggerCustomAnalysisResponse:
+            description: The TriggerCustomAnalysisResponse message.
+            properties:
+                id:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            title: Trigger Custom Analysis Response
+            type: object
+            x-speakeasy-name-override: TriggerCustomAnalysisResponse
         c1.api.role_mining_management.v1.UpdateRoleMiningConfigRequest:
             description: The UpdateRoleMiningConfigRequest message.
             properties:
                 cohortHints:
-                    description: The cohortHints field.
+                    description: Hints that guide the analysis to prioritize specific user attributes and values when forming cohorts.
                     items:
                         $ref: '#/components/schemas/c1.api.role_mining_management.v1.CohortHintInput'
                     nullable: true
                     readOnly: false
                     type: array
                 maxSuggestions:
-                    description: The maxSuggestions field.
+                    description: Maximum number of suggestions the analysis should produce per run.
                     format: int32
                     readOnly: false
                     type: integer
                 minCohortSize:
-                    description: The minCohortSize field.
+                    description: Minimum number of users a cohort must contain to generate a suggestion.
                     format: int32
                     readOnly: false
                     type: integer
@@ -15611,11 +19133,11 @@ components:
             description: The UpdateSuggestionStateRequest message.
             properties:
                 createdCatalogId:
-                    description: The createdCatalogId field.
+                    description: The ID of the access profile created from this suggestion, set when accepting.
                     readOnly: false
                     type: string
                 state:
-                    description: The state field.
+                    description: The new state to transition the suggestion to.
                     enum:
                         - SUGGESTION_STATE_UNSPECIFIED
                         - SUGGESTION_STATE_NEW
@@ -16512,6 +20034,47 @@ components:
             title: Service Principal
             type: object
             x-speakeasy-name-override: ServicePrincipal
+        c1.api.service_principal.v1.ServicePrincipalBinding:
+            description: |-
+                ServicePrincipalBinding is one row in the binding store, naming a
+                 subject's link to a single service principal.
+            properties:
+                createdAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                servicePrincipalId:
+                    description: The servicePrincipalId field.
+                    readOnly: false
+                    type: string
+                updatedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+            title: Service Principal Binding
+            type: object
+            x-speakeasy-name-override: ServicePrincipalBinding
+        c1.api.service_principal.v1.ServicePrincipalBindingSubject:
+            description: |
+                ServicePrincipalBindingSubject identifies the entity that is bound to a
+                 service principal. Open-ended oneof so future subject kinds (workflows,
+                 connectors, etc.) can be added without changing the RPC shape.
+
+                This message contains a oneof named kind. Only a single field of the following list may be set at a time:
+                  - functionId
+            properties:
+                functionId:
+                    description: |-
+                        Function ID. The function authenticates outbound c1-api calls as
+                         user:<service_principal_id> instead of function:<function_id>.
+                        This field is part of the `kind` oneof.
+                        See the documentation for `c1.api.service_principal.v1.ServicePrincipalBindingSubject` for more details.
+                    nullable: true
+                    readOnly: false
+                    type: string
+            title: Service Principal Binding Subject
+            type: object
+            x-speakeasy-name-override: ServicePrincipalBindingSubject
         c1.api.service_principal.v1.ServicePrincipalCredential:
             description: ServicePrincipalCredential represents a client credential for a service principal.
             properties:
@@ -16564,11 +20127,30 @@ components:
             title: Service Principal Credential
             type: object
             x-speakeasy-name-override: ServicePrincipalCredential
+        c1.api.service_principal.v1.ServicePrincipalServiceAddBindingRequest:
+            description: The ServicePrincipalServiceAddBindingRequest message.
+            properties:
+                servicePrincipalId:
+                    description: The servicePrincipalId field.
+                    readOnly: false
+                    type: string
+                subject:
+                    $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalBindingSubject'
+            title: Service Principal Service Add Binding Request
+            type: object
+            x-speakeasy-name-override: ServicePrincipalServiceAddBindingRequest
+        c1.api.service_principal.v1.ServicePrincipalServiceAddBindingResponse:
+            description: The ServicePrincipalServiceAddBindingResponse message.
+            title: Service Principal Service Add Binding Response
+            type: object
+            x-speakeasy-name-override: ServicePrincipalServiceAddBindingResponse
         c1.api.service_principal.v1.ServicePrincipalServiceCreateCredentialRequestInput:
             description: The ServicePrincipalServiceCreateCredentialRequest message.
             properties:
                 allowSourceCidrs:
-                    description: A list of CIDRs to restrict this credential to.
+                    description: |-
+                        A list of CIDRs to restrict this credential to.
+                         Accepts IPv4 (e.g. 10.0.0.0/24) or IPv6 (e.g. 2001:db8::/32) CIDRs.
                     items:
                         type: string
                     nullable: true
@@ -16626,6 +20208,23 @@ components:
             title: Service Principal Service Create Response
             type: object
             x-speakeasy-name-override: ServicePrincipalServiceCreateResponse
+        c1.api.service_principal.v1.ServicePrincipalServiceDeleteBindingRequest:
+            description: The ServicePrincipalServiceDeleteBindingRequest message.
+            properties:
+                servicePrincipalId:
+                    description: The servicePrincipalId field.
+                    readOnly: false
+                    type: string
+                subject:
+                    $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalBindingSubject'
+            title: Service Principal Service Delete Binding Request
+            type: object
+            x-speakeasy-name-override: ServicePrincipalServiceDeleteBindingRequest
+        c1.api.service_principal.v1.ServicePrincipalServiceDeleteBindingResponse:
+            description: The ServicePrincipalServiceDeleteBindingResponse message.
+            title: Service Principal Service Delete Binding Response
+            type: object
+            x-speakeasy-name-override: ServicePrincipalServiceDeleteBindingResponse
         c1.api.service_principal.v1.ServicePrincipalServiceDeleteRequestInput:
             description: The ServicePrincipalServiceDeleteRequest message.
             title: Service Principal Service Delete Request
@@ -16652,6 +20251,42 @@ components:
             title: Service Principal Service Get Response
             type: object
             x-speakeasy-name-override: ServicePrincipalServiceGetResponse
+        c1.api.service_principal.v1.ServicePrincipalServiceListBindingsRequest:
+            description: The ServicePrincipalServiceListBindingsRequest message.
+            properties:
+                pageSize:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+                subject:
+                    $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalBindingSubject'
+            title: Service Principal Service List Bindings Request
+            type: object
+            x-speakeasy-name-override: ServicePrincipalServiceListBindingsRequest
+        c1.api.service_principal.v1.ServicePrincipalServiceListBindingsResponse:
+            description: The ServicePrincipalServiceListBindingsResponse message.
+            properties:
+                bindings:
+                    description: |-
+                        Active bindings held by the subject in this page. Empty when the
+                         subject is unbound. Order is unspecified.
+                    items:
+                        $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalBinding'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: The nextPageToken field.
+                    readOnly: false
+                    type: string
+            title: Service Principal Service List Bindings Response
+            type: object
+            x-speakeasy-name-override: ServicePrincipalServiceListBindingsResponse
         c1.api.service_principal.v1.ServicePrincipalServiceListCredentialsResponse:
             description: The ServicePrincipalServiceListCredentialsResponse message.
             properties:
@@ -16737,21 +20372,46 @@ components:
             type: object
             x-speakeasy-name-override: ServicePrincipalServiceUpdateResponse
         c1.api.settings.v1.AWSExternalID:
-            description: The AWSExternalID message.
+            description: AWSExternalID contains the tenant's external ID for AWS IAM role trust policies.
             properties:
                 externalId:
-                    description: The externalId field.
+                    description: The external ID value to include in the AWS IAM role trust policy condition.
                     readOnly: false
                     type: string
             title: Aws External Id
             type: object
             x-speakeasy-entity: AWS_EXTERNAL_ID
             x-speakeasy-name-override: AWSExternalID
+        c1.api.settings.v1.AWSSESProviderConfig:
+            description: AWSSESProviderConfig configures sending via a customer's AWS SES account.
+            nullable: true
+            properties:
+                configurationSetName:
+                    description: Optional SES configuration set name for tracking/metrics.
+                    readOnly: false
+                    type: string
+                region:
+                    description: AWS region where SES identities are verified (e.g., "us-east-1").
+                    readOnly: false
+                    type: string
+                roleArn:
+                    description: |-
+                        IAM role ARN for sts:AssumeRole. The trust policy should require the
+                         tenant's AWS External ID (GET /api/v1/settings/aws-external-id).
+                    readOnly: false
+                    type: string
+            title: Awsses Provider Config
+            type: object
+            x-speakeasy-name-override: AWSSESProviderConfig
         c1.api.settings.v1.AccessProvisionedPreference:
             description: The AccessProvisionedPreference message.
             properties:
                 enabled:
                     description: The enabled field.
+                    readOnly: false
+                    type: boolean
+                locked:
+                    description: The locked field.
                     readOnly: false
                     type: boolean
             title: Access Provisioned Preference
@@ -16764,18 +20424,34 @@ components:
                     description: The enabled field.
                     readOnly: false
                     type: boolean
+                locked:
+                    description: The locked field.
+                    readOnly: false
+                    type: boolean
             title: Approval Needed Preference
             type: object
             x-speakeasy-name-override: ApprovalNeededPreference
+        c1.api.settings.v1.C1BuiltInProviderConfig:
+            description: |-
+                C1BuiltInProviderConfig selects the ConductorOne built-in email provider.
+                 Emails are sent from no-reply@conductorone.com via the platform SendGrid account.
+                 Only supports sending to C1 users — external email addresses are not supported.
+                 No configuration fields required.
+            nullable: true
+            title: C 1 Built In Provider Config
+            type: object
+            x-speakeasy-name-override: C1BuiltInProviderConfig
         c1.api.settings.v1.CIDRRestriction:
-            description: The CIDRRestriction message.
+            description: CIDRRestriction defines an IP-based access restriction with an enable toggle and a list of allowed CIDRs.
             properties:
                 enabled:
-                    description: The enabled field.
+                    description: Whether this CIDR restriction is enforced.
                     readOnly: false
                     type: boolean
                 sourceCidr:
-                    description: The sourceCidr field.
+                    description: |-
+                        The list of CIDR ranges that are allowed when the restriction is enabled.
+                         Accepts IPv4 (e.g. 10.0.0.0/24) or IPv6 (e.g. 2001:db8::/32) CIDRs.
                     items:
                         type: string
                     nullable: true
@@ -16785,7 +20461,7 @@ components:
             type: object
             x-speakeasy-name-override: CIDRRestriction
         c1.api.settings.v1.ChannelSettings:
-            description: The ChannelSettings message.
+            description: ChannelSettings groups notification preferences for all supported channels.
             properties:
                 email:
                     $ref: '#/components/schemas/c1.api.settings.v1.EmailChannelSettings'
@@ -16803,6 +20479,10 @@ components:
                     description: The enabled field.
                     readOnly: false
                     type: boolean
+                locked:
+                    description: The locked field.
+                    readOnly: false
+                    type: boolean
             title: Comment On Request Preference
             type: object
             x-speakeasy-name-override: CommentOnRequestPreference
@@ -16811,6 +20491,10 @@ components:
             properties:
                 enabled:
                     description: The enabled field.
+                    readOnly: false
+                    type: boolean
+                locked:
+                    description: The locked field.
                     readOnly: false
                     type: boolean
             title: Completion Preference
@@ -16823,14 +20507,53 @@ components:
                     description: The enabled field.
                     readOnly: false
                     type: boolean
+                locked:
+                    description: The locked field.
+                    readOnly: false
+                    type: boolean
             title: Connector Issues Preference
             type: object
             x-speakeasy-name-override: ConnectorIssuesPreference
+        c1.api.settings.v1.Contacts:
+            description: Contacts represents the contact configuration for an organization.
+            properties:
+                billingEmails:
+                    description: Email addresses of billing contacts for this organization.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                createdAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                operationsEmails:
+                    description: Email addresses of operations contacts for this organization.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                securityEmails:
+                    description: Email addresses of security contacts for this organization.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                updatedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+            title: Contacts
+            type: object
+            x-speakeasy-name-override: Contacts
         c1.api.settings.v1.DigestPreference:
-            description: The DigestPreference message.
+            description: DigestPreference controls whether summary digest notifications are sent and how often.
             properties:
                 dayOfWeek:
-                    description: The dayOfWeek field.
+                    description: The day of the week to send weekly digests.
                     enum:
                         - WEEKDAY_UNSPECIFIED
                         - WEEKDAY_MONDAY
@@ -16844,11 +20567,11 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 enabled:
-                    description: The enabled field.
+                    description: Whether digest notifications are enabled.
                     readOnly: false
                     type: boolean
                 frequency:
-                    description: The frequency field.
+                    description: How often digest notifications are sent.
                     enum:
                         - DIGEST_FREQUENCY_UNSPECIFIED
                         - DIGEST_FREQUENCY_DAILY
@@ -16856,6 +20579,10 @@ components:
                     readOnly: false
                     type: string
                     x-speakeasy-unknown-values: allow
+                locked:
+                    description: Whether this preference is locked by org-level settings, preventing users from overriding it.
+                    readOnly: false
+                    type: boolean
             title: Digest Preference
             type: object
             x-speakeasy-name-override: DigestPreference
@@ -16896,6 +20623,10 @@ components:
                     description: The enabled field.
                     readOnly: false
                     type: boolean
+                locked:
+                    description: The locked field.
+                    readOnly: false
+                    type: boolean
             title: Expiring Access Preference
             type: object
             x-speakeasy-name-override: ExpiringAccessPreference
@@ -16907,6 +20638,57 @@ components:
             title: Get Aws External Id Response
             type: object
             x-speakeasy-name-override: GetAWSExternalIDResponse
+        c1.api.settings.v1.GetContactsResponse:
+            description: The GetContactsResponse message.
+            properties:
+                contacts:
+                    $ref: '#/components/schemas/c1.api.settings.v1.Contacts'
+            title: Get Contacts Response
+            type: object
+            x-speakeasy-name-override: GetContactsResponse
+        c1.api.settings.v1.GetEmailCapabilitiesResponse:
+            description: The GetEmailCapabilitiesResponse message.
+            properties:
+                externalEmailSupported:
+                    description: |-
+                        True when external email addresses (outside C1 users) can be used as
+                         recipients in automation email steps. False when only the C1 built-in
+                         provider is configured (C1 users only).
+                    readOnly: false
+                    type: boolean
+            title: Get Email Capabilities Response
+            type: object
+            x-speakeasy-name-override: GetEmailCapabilitiesResponse
+        c1.api.settings.v1.GetOnboardingSettingsResponse:
+            description: The GetOnboardingSettingsResponse message.
+            properties:
+                conversationId:
+                    description: The identifier of the onboarding conversation thread, if one is in progress.
+                    readOnly: false
+                    type: string
+                intents:
+                    description: The intents field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                orgContext:
+                    $ref: '#/components/schemas/c1.api.settings.v1.OnboardingOrgContext'
+                status:
+                    description: The current status of the tenant onboarding process.
+                    enum:
+                        - ONBOARDING_STATUS_UNSPECIFIED
+                        - ONBOARDING_STATUS_NOT_STARTED
+                        - ONBOARDING_STATUS_IN_PROGRESS
+                        - ONBOARDING_STATUS_COMPLETE
+                        - ONBOARDING_STATUS_DISMISSED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Get Onboarding Settings Response
+            type: object
+            x-speakeasy-name-override: GetOnboardingSettingsResponse
         c1.api.settings.v1.GetOrgNotificationSettingsResponse:
             description: The GetOrgNotificationSettingsResponse message.
             properties:
@@ -16923,6 +20705,14 @@ components:
             title: Get Session Settings Response
             type: object
             x-speakeasy-name-override: GetSessionSettingsResponse
+        c1.api.settings.v1.GetTenantEmailProviderResponse:
+            description: The GetTenantEmailProviderResponse message.
+            properties:
+                emailProvider:
+                    $ref: '#/components/schemas/c1.api.settings.v1.TenantEmailProvider'
+            title: Get Tenant Email Provider Response
+            type: object
+            x-speakeasy-name-override: GetTenantEmailProviderResponse
         c1.api.settings.v1.GetUserNotificationSettingsResponse:
             description: The GetUserNotificationSettingsResponse message.
             properties:
@@ -16931,18 +20721,41 @@ components:
             title: Get User Notification Settings Response
             type: object
             x-speakeasy-name-override: GetUserNotificationSettingsResponse
+        c1.api.settings.v1.GoogleWorkspaceProviderConfig:
+            description: |-
+                GoogleWorkspaceProviderConfig configures sending via Google Workspace Gmail API
+                 using domain-wide delegation with a service account.
+                 Requires: customer Workspace super admin grants DWD to the service account's
+                 OAuth client ID for the gmail.send scope.
+            nullable: true
+            properties:
+                delegatedUser:
+                    description: |-
+                        The Workspace user email to impersonate via domain-wide delegation.
+                         Typically a dedicated sender like noreply@customer.com.
+                    readOnly: false
+                    type: string
+                serviceAccountJson:
+                    description: |-
+                        Service account JSON credentials. Write-only: accepted on create/update, never returned in Get.
+                         Empty on update means "keep existing credentials".
+                    readOnly: false
+                    type: string
+            title: Google Workspace Provider Config
+            type: object
+            x-speakeasy-name-override: GoogleWorkspaceProviderConfig
         c1.api.settings.v1.ListOrgDomainsResponse:
             description: The ListOrgDomainsResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of verified domains.
                     items:
                         $ref: '#/components/schemas/c1.api.settings.v1.OrgDomain'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: A token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: List Org Domains Response
@@ -16982,8 +20795,45 @@ components:
             title: Ms Teams Channel Settings
             type: object
             x-speakeasy-name-override: MSTeamsChannelSettings
+        c1.api.settings.v1.MicrosoftGraphProviderConfig:
+            description: |-
+                MicrosoftGraphProviderConfig configures sending via Microsoft Graph sendMail API.
+                 Requires an Azure AD app registration with Mail.Send application permission (admin-consented).
+            nullable: true
+            properties:
+                azureTenantId:
+                    description: Customer's Azure AD tenant ID (directory ID).
+                    readOnly: false
+                    type: string
+                clientId:
+                    description: App registration client ID with Mail.Send application permission.
+                    readOnly: false
+                    type: string
+                clientSecret:
+                    description: |-
+                        Client secret. Write-only: accepted on create/update, never returned in Get.
+                         Empty on update means "keep existing secret".
+                    readOnly: false
+                    type: string
+            title: Microsoft Graph Provider Config
+            type: object
+            x-speakeasy-name-override: MicrosoftGraphProviderConfig
+        c1.api.settings.v1.OnboardingOrgContext:
+            description: The OnboardingOrgContext message.
+            properties:
+                industry:
+                    description: The industry field.
+                    readOnly: false
+                    type: string
+                organizationSize:
+                    description: The organizationSize field.
+                    readOnly: false
+                    type: string
+            title: Onboarding Org Context
+            type: object
+            x-speakeasy-name-override: OnboardingOrgContext
         c1.api.settings.v1.OrgDomain:
-            description: The OrgDomain message.
+            description: OrgDomain represents a verified email domain associated with the tenant.
             properties:
                 createdAt:
                     format: date-time
@@ -16994,11 +20844,11 @@ components:
                     readOnly: true
                     type: string
                 domain:
-                    description: The domain field.
+                    description: The verified domain name (e.g., "example.com").
                     readOnly: false
                     type: string
                 id:
-                    description: The id field.
+                    description: The unique identifier of the domain record.
                     readOnly: false
                     type: string
                 updatedAt:
@@ -17009,7 +20859,7 @@ components:
             type: object
             x-speakeasy-name-override: OrgDomain
         c1.api.settings.v1.OrgNotificationSettings:
-            description: The OrgNotificationSettings message.
+            description: OrgNotificationSettings contains organization-wide notification channel configurations and default preferences.
             properties:
                 channelSettings:
                     $ref: '#/components/schemas/c1.api.settings.v1.ChannelSettings'
@@ -17023,6 +20873,10 @@ components:
                     description: The enabled field.
                     readOnly: false
                     type: boolean
+                locked:
+                    description: The locked field.
+                    readOnly: false
+                    type: boolean
             title: Provisioning Request Preference
             type: object
             x-speakeasy-name-override: ProvisioningRequestPreference
@@ -17033,11 +20887,62 @@ components:
                     description: The enabled field.
                     readOnly: false
                     type: boolean
+                locked:
+                    description: The locked field.
+                    readOnly: false
+                    type: boolean
             title: Reviews Preference
             type: object
             x-speakeasy-name-override: ReviewsPreference
+        c1.api.settings.v1.SearchEmailAuditEventsRequest:
+            description: The SearchEmailAuditEventsRequest message.
+            properties:
+                pageSize:
+                    description: Maximum results per page (0 = server default, max 100).
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: Pagination token from previous response.
+                    readOnly: false
+                    type: string
+            title: Search Email Audit Events Request
+            type: object
+            x-speakeasy-name-override: SearchEmailAuditEventsRequest
+        c1.api.settings.v1.SearchEmailAuditEventsResponse:
+            description: The SearchEmailAuditEventsResponse message.
+            properties:
+                list:
+                    description: OCSF EmailActivity events as Struct for frontend rendering.
+                    items:
+                        additionalProperties: true
+                        readOnly: false
+                        type: object
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: Token for next page. Empty when no more pages.
+                    readOnly: false
+                    type: string
+            title: Search Email Audit Events Response
+            type: object
+            x-speakeasy-name-override: SearchEmailAuditEventsResponse
+        c1.api.settings.v1.SendGridProviderConfig:
+            description: SendGridProviderConfig configures sending via a customer's SendGrid account.
+            nullable: true
+            properties:
+                apiKey:
+                    description: |-
+                        Customer's SendGrid API key. Write-only: accepted on create/update, never returned in Get.
+                         Empty on update means "keep existing key".
+                    readOnly: false
+                    type: string
+            title: Send Grid Provider Config
+            type: object
+            x-speakeasy-name-override: SendGridProviderConfig
         c1.api.settings.v1.SessionSettings:
-            description: The SessionSettings message.
+            description: SessionSettings configures session security for the tenant, including timeouts and per-role IP restrictions.
             properties:
                 clientIdApprovalRequestPolicyId:
                     description: Policy ID for REQUESTABLE mode approval routing.
@@ -17119,21 +21024,78 @@ components:
                     description: The enabled field.
                     readOnly: false
                     type: boolean
+                locked:
+                    description: The locked field.
+                    readOnly: false
+                    type: boolean
             title: Task Reminders Preference
             type: object
             x-speakeasy-name-override: TaskRemindersPreference
+        c1.api.settings.v1.TenantEmailProvider:
+            description: |
+                TenantEmailProvider is the API representation of the tenant's email provider.
+
+                This message contains a oneof named provider. Only a single field of the following list may be set at a time:
+                  - c1Builtin
+                  - awsSes
+                  - sendgrid
+                  - microsoftGraph
+                  - googleWorkspace
+            properties:
+                awsSes:
+                    $ref: '#/components/schemas/c1.api.settings.v1.AWSSESProviderConfig'
+                c1Builtin:
+                    $ref: '#/components/schemas/c1.api.settings.v1.C1BuiltInProviderConfig'
+                createdAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                fromAddress:
+                    description: |-
+                        Sender email address. Must be verified with the provider.
+                         Ignored when using the C1 built-in provider (uses no-reply@conductorone.com).
+                    readOnly: false
+                    type: string
+                fromName:
+                    description: |-
+                        Sender display name shown in the recipient's inbox (e.g., "Acme Corp IT").
+                         Used as the RFC 5322 display-name: "Acme Corp IT" <no-reply@acme.com>.
+                         Ignored when using the C1 built-in provider.
+                    readOnly: false
+                    type: string
+                googleWorkspace:
+                    $ref: '#/components/schemas/c1.api.settings.v1.GoogleWorkspaceProviderConfig'
+                microsoftGraph:
+                    $ref: '#/components/schemas/c1.api.settings.v1.MicrosoftGraphProviderConfig'
+                replyToAddress:
+                    description: Optional reply-to address.
+                    readOnly: false
+                    type: string
+                sendgrid:
+                    $ref: '#/components/schemas/c1.api.settings.v1.SendGridProviderConfig'
+                updatedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+            title: Tenant Email Provider
+            type: object
+            x-speakeasy-name-override: TenantEmailProvider
         c1.api.settings.v1.TestSourceIPRequest:
             description: The TestSourceIPRequest message.
             properties:
                 allowCidr:
-                    description: The allowCidr field.
+                    description: |-
+                        The CIDR allowlist rules to test against. If empty, uses the tenant's current allowlist.
+                         Accepts IPv4 (e.g. 10.0.0.0/24) or IPv6 (e.g. 2001:db8::/32) CIDRs.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 sourceIp:
-                    description: if unset, uses the source IP of the request
+                    description: |-
+                        if unset, uses the source IP of the request.
+                         Accepts IPv4 (e.g. 10.0.0.5) or IPv6 (e.g. 2001:db8::1) addresses, optionally with a CIDR prefix.
                     readOnly: false
                     type: string
             title: Test Source Ip Request
@@ -17143,11 +21105,11 @@ components:
             description: The TestSourceIPResponse message.
             properties:
                 allowed:
-                    description: The allowed field.
+                    description: Whether the tested IP address is allowed by the CIDR rules.
                     readOnly: false
                     type: boolean
                 checkedIp:
-                    description: The checkedIp field.
+                    description: The IP address that was checked, either from the request or inferred from the caller.
                     readOnly: false
                     type: string
                 details:
@@ -17155,11 +21117,93 @@ components:
             title: Test Source Ip Response
             type: object
             x-speakeasy-name-override: TestSourceIPResponse
+        c1.api.settings.v1.TestTenantEmailProviderRequest:
+            description: The TestTenantEmailProviderRequest message.
+            properties:
+                testRecipientEmail:
+                    description: The email address to send the test email to.
+                    readOnly: false
+                    type: string
+            title: Test Tenant Email Provider Request
+            type: object
+            x-speakeasy-name-override: TestTenantEmailProviderRequest
+        c1.api.settings.v1.TestTenantEmailProviderResponse:
+            description: The TestTenantEmailProviderResponse message.
+            properties:
+                message:
+                    description: Human-readable detail about the result.
+                    readOnly: false
+                    type: string
+                success:
+                    description: Whether the test email was sent successfully.
+                    readOnly: false
+                    type: boolean
+            title: Test Tenant Email Provider Response
+            type: object
+            x-speakeasy-name-override: TestTenantEmailProviderResponse
+        c1.api.settings.v1.UpdateContactsRequest:
+            description: The UpdateContactsRequest message.
+            properties:
+                contacts:
+                    $ref: '#/components/schemas/c1.api.settings.v1.Contacts'
+                updateMask:
+                    nullable: true
+                    readOnly: false
+                    type: string
+            title: Update Contacts Request
+            type: object
+            x-speakeasy-name-override: UpdateContactsRequest
+        c1.api.settings.v1.UpdateContactsResponse:
+            description: The UpdateContactsResponse message.
+            properties:
+                contacts:
+                    $ref: '#/components/schemas/c1.api.settings.v1.Contacts'
+            title: Update Contacts Response
+            type: object
+            x-speakeasy-name-override: UpdateContactsResponse
+        c1.api.settings.v1.UpdateOnboardingSettingsRequest:
+            description: The UpdateOnboardingSettingsRequest message.
+            properties:
+                conversationId:
+                    description: The identifier of the onboarding conversation thread to associate.
+                    readOnly: false
+                    type: string
+                status:
+                    description: The new onboarding status to set.
+                    enum:
+                        - ONBOARDING_STATUS_UNSPECIFIED
+                        - ONBOARDING_STATUS_NOT_STARTED
+                        - ONBOARDING_STATUS_IN_PROGRESS
+                        - ONBOARDING_STATUS_COMPLETE
+                        - ONBOARDING_STATUS_DISMISSED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Update Onboarding Settings Request
+            type: object
+            x-speakeasy-name-override: UpdateOnboardingSettingsRequest
+        c1.api.settings.v1.UpdateOnboardingSettingsResponse:
+            description: The UpdateOnboardingSettingsResponse message.
+            properties:
+                status:
+                    description: The updated onboarding status.
+                    enum:
+                        - ONBOARDING_STATUS_UNSPECIFIED
+                        - ONBOARDING_STATUS_NOT_STARTED
+                        - ONBOARDING_STATUS_IN_PROGRESS
+                        - ONBOARDING_STATUS_COMPLETE
+                        - ONBOARDING_STATUS_DISMISSED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Update Onboarding Settings Response
+            type: object
+            x-speakeasy-name-override: UpdateOnboardingSettingsResponse
         c1.api.settings.v1.UpdateOrgDomainRequest:
             description: The UpdateOrgDomainRequest message.
             properties:
                 newDomains:
-                    description: The newDomains field.
+                    description: The complete list of domain names that should be set as the tenant's verified domains.
                     items:
                         type: string
                     nullable: true
@@ -17172,7 +21216,7 @@ components:
             description: The UpdateOrgDomainResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The resulting list of verified domains after the update.
                     items:
                         $ref: '#/components/schemas/c1.api.settings.v1.OrgDomain'
                     nullable: true
@@ -17217,6 +21261,26 @@ components:
             title: Update Session Settings Response
             type: object
             x-speakeasy-name-override: UpdateSessionSettingsResponse
+        c1.api.settings.v1.UpdateTenantEmailProviderRequest:
+            description: The UpdateTenantEmailProviderRequest message.
+            properties:
+                emailProvider:
+                    $ref: '#/components/schemas/c1.api.settings.v1.TenantEmailProvider'
+                updateMask:
+                    nullable: true
+                    readOnly: false
+                    type: string
+            title: Update Tenant Email Provider Request
+            type: object
+            x-speakeasy-name-override: UpdateTenantEmailProviderRequest
+        c1.api.settings.v1.UpdateTenantEmailProviderResponse:
+            description: The UpdateTenantEmailProviderResponse message.
+            properties:
+                emailProvider:
+                    $ref: '#/components/schemas/c1.api.settings.v1.TenantEmailProvider'
+            title: Update Tenant Email Provider Response
+            type: object
+            x-speakeasy-name-override: UpdateTenantEmailProviderResponse
         c1.api.settings.v1.UpdateUserNotificationSettingsRequest:
             description: The UpdateUserNotificationSettingsRequest message.
             properties:
@@ -17234,20 +21298,31 @@ components:
             type: object
             x-speakeasy-name-override: UpdateUserNotificationSettingsResponse
         c1.api.settings.v1.UserNotificationSettings:
-            description: The UserNotificationSettings message.
+            description: UserNotificationSettings contains the calling user's personal notification preferences.
             properties:
                 channelSettings:
                     $ref: '#/components/schemas/c1.api.settings.v1.ChannelSettings'
             title: User Notification Settings
             type: object
             x-speakeasy-name-override: UserNotificationSettings
-        c1.api.stepup.v1.CreateStepUpProviderRequest:
-            description: |
-                The CreateStepUpProviderRequest message.
-
-                This message contains a oneof named settings. Only a single field of the following list may be set at a time:
-                  - oauth2
-                  - microsoft
+        c1.api.ssf_receiver.v1.SSFOutboundAuthBearer:
+            description: |-
+                SSFOutboundAuthBearer is a static bearer token for outbound auth.
+                 Token is write-only: accepted on create/update, never returned.
+            nullable: true
+            properties:
+                token:
+                    description: The token field.
+                    readOnly: false
+                    type: string
+            title: Ssf Outbound Auth Bearer
+            type: object
+            x-speakeasy-name-override: SSFOutboundAuthBearer
+        c1.api.ssf_receiver.v1.SSFOutboundAuthOAuth2:
+            description: |-
+                SSFOutboundAuthOAuth2 uses OAuth2 client credentials for outbound auth.
+                 client_secret is write-only: accepted on create/update, never returned.
+            nullable: true
             properties:
                 clientId:
                     description: The clientId field.
@@ -17257,12 +21332,661 @@ components:
                     description: The clientSecret field.
                     readOnly: false
                     type: string
+                scopes:
+                    description: The scopes field.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                tokenUrl:
+                    description: The tokenUrl field.
+                    readOnly: false
+                    type: string
+            title: Ssf Outbound Auth O Auth 2
+            type: object
+            x-speakeasy-name-override: SSFOutboundAuthOAuth2
+        c1.api.ssf_receiver.v1.SSFReceiverEvent:
+            description: SSFReceiverEvent shows both wire-level data and C1 canonical outcome.
+            properties:
+                canonicalType:
+                    description: |-
+                        C1 canonical outcome (what C1 understood and did).
+                         The normalized event type after mapping from the wire event type.
+                    enum:
+                        - SSF_CANONICAL_EVENT_TYPE_UNSPECIFIED
+                        - SSF_CANONICAL_EVENT_TYPE_UNRECOGNIZED
+                        - SSF_CANONICAL_EVENT_TYPE_SESSION_REVOKED
+                        - SSF_CANONICAL_EVENT_TYPE_CREDENTIAL_CHANGED
+                        - SSF_CANONICAL_EVENT_TYPE_TOKEN_CLAIMS_CHANGED
+                        - SSF_CANONICAL_EVENT_TYPE_ASSURANCE_LEVEL_CHANGED
+                        - SSF_CANONICAL_EVENT_TYPE_DEVICE_COMPLIANCE_CHANGED
+                        - SSF_CANONICAL_EVENT_TYPE_RISK_LEVEL_CHANGED
+                        - SSF_CANONICAL_EVENT_TYPE_SESSION_ESTABLISHED
+                        - SSF_CANONICAL_EVENT_TYPE_SESSION_PRESENTED
+                        - SSF_CANONICAL_EVENT_TYPE_ACCOUNT_DISABLED
+                        - SSF_CANONICAL_EVENT_TYPE_ACCOUNT_ENABLED
+                        - SSF_CANONICAL_EVENT_TYPE_ACCOUNT_PURGED
+                        - SSF_CANONICAL_EVENT_TYPE_CREDENTIAL_COMPROMISE
+                        - SSF_CANONICAL_EVENT_TYPE_RECOVERY_ACTIVATED
+                        - SSF_CANONICAL_EVENT_TYPE_IDENTIFIER_CHANGED
+                        - SSF_CANONICAL_EVENT_TYPE_VERIFICATION
+                        - SSF_CANONICAL_EVENT_TYPE_STREAM_UPDATED
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                id:
+                    description: The unique identifier of this event.
+                    readOnly: false
+                    type: string
+                matchMethod:
+                    description: How the upstream subject was resolved to a ConductorOne user.
+                    enum:
+                        - SSF_SUBJECT_MATCH_METHOD_UNSPECIFIED
+                        - SSF_SUBJECT_MATCH_METHOD_IDP_USER
+                        - SSF_SUBJECT_MATCH_METHOD_EMAIL
+                        - SSF_SUBJECT_MATCH_METHOD_NOT_FOUND
+                        - SSF_SUBJECT_MATCH_METHOD_NOT_APPLICABLE
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                matchedUserId:
+                    description: The ConductorOne user ID that the event subject was resolved to, if any.
+                    readOnly: false
+                    type: string
+                outcome:
+                    description: The action ConductorOne took in response to this event.
+                    enum:
+                        - SSF_EVENT_OUTCOME_UNSPECIFIED
+                        - SSF_EVENT_OUTCOME_SESSIONS_REVOKED
+                        - SSF_EVENT_OUTCOME_LOGGED
+                        - SSF_EVENT_OUTCOME_PRINCIPAL_NOT_FOUND
+                        - SSF_EVENT_OUTCOME_VERIFIED
+                        - SSF_EVENT_OUTCOME_STREAM_STATUS_UPDATED
+                        - SSF_EVENT_OUTCOME_UNRECOGNIZED
+                        - SSF_EVENT_OUTCOME_ERROR
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                outcomeDetail:
+                    description: Human-readable details about the outcome (e.g., error message or revocation summary).
+                    readOnly: false
+                    type: string
+                receivedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                sessionsRevoked:
+                    description: Number of sessions that were revoked as a result of this event.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                setJti:
+                    description: |-
+                        Wire-level data (what the transmitter sent).
+                         The SET (Security Event Token) JWT ID claim, uniquely identifying the token.
+                    readOnly: false
+                    type: string
+                streamId:
+                    description: The SSF receiver stream that received this event.
+                    readOnly: false
+                    type: string
+                wireEventProfile:
+                    description: The event profile URI from the SET, if present.
+                    readOnly: false
+                    type: string
+                wireEventType:
+                    description: The raw event type URI from the SET (e.g., "https://schemas.openid.net/secevent/caep/event-type/session-revoked").
+                    readOnly: false
+                    type: string
+                wireInitiatingEntity:
+                    description: The entity that initiated the event, as reported by the transmitter.
+                    readOnly: false
+                    type: string
+                wireReasonAdmin:
+                    description: The admin-facing reason string from the SET, if provided by the transmitter.
+                    readOnly: false
+                    type: string
+                wireSubjectFormat:
+                    description: The subject identifier format from the SET (e.g., "email", "iss_sub").
+                    readOnly: false
+                    type: string
+                wireSubjectIdentifier:
+                    description: The raw subject identifier value from the SET.
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Event
+            type: object
+            x-speakeasy-name-override: SSFReceiverEvent
+        c1.api.ssf_receiver.v1.SSFReceiverEventSearchServiceSearchRequest:
+            description: SSFReceiverEventSearchServiceSearchRequest carries the search query and optional filters for narrowing results.
+            properties:
+                eventType:
+                    description: Restricts results to events matching this wire event type URI. Optional.
+                    readOnly: false
+                    type: string
+                matchedUserId:
+                    description: Restricts results to events matched to this ConductorOne user ID. Optional.
+                    readOnly: false
+                    type: string
+                outcome:
+                    description: Restricts results to events with this processing outcome. Optional.
+                    enum:
+                        - SSF_EVENT_OUTCOME_UNSPECIFIED
+                        - SSF_EVENT_OUTCOME_SESSIONS_REVOKED
+                        - SSF_EVENT_OUTCOME_LOGGED
+                        - SSF_EVENT_OUTCOME_PRINCIPAL_NOT_FOUND
+                        - SSF_EVENT_OUTCOME_VERIFIED
+                        - SSF_EVENT_OUTCOME_STREAM_STATUS_UPDATED
+                        - SSF_EVENT_OUTCOME_UNRECOGNIZED
+                        - SSF_EVENT_OUTCOME_ERROR
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                pageSize:
+                    description: Maximum number of events to return per page.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                pageToken:
+                    description: Token from a previous SearchResponse to fetch the next page of results.
+                    readOnly: false
+                    type: string
+                query:
+                    description: Full-text search query matched against event fields.
+                    readOnly: false
+                    type: string
+                streamId:
+                    description: Restricts results to events from this SSF receiver stream. Optional.
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Event Search Service Search Request
+            type: object
+            x-speakeasy-name-override: SSFReceiverEventSearchServiceSearchRequest
+        c1.api.ssf_receiver.v1.SSFReceiverEventSearchServiceSearchResponse:
+            description: SSFReceiverEventSearchServiceSearchResponse contains the matching events and a pagination token.
+            properties:
+                list:
+                    description: The SSF events matching the search criteria.
+                    items:
+                        $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverEvent'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: Token to retrieve the next page. Empty when there are no more results.
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Event Search Service Search Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverEventSearchServiceSearchResponse
+        c1.api.ssf_receiver.v1.SSFReceiverEventServiceListResponse:
+            description: SSFReceiverEventServiceListResponse contains a page of received SSF events.
+            properties:
+                list:
+                    description: The SSF events in the current page.
+                    items:
+                        $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverEvent'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: Token to retrieve the next page. Empty when there are no more results.
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Event Service List Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverEventServiceListResponse
+        c1.api.ssf_receiver.v1.SSFReceiverStream:
+            description: |
+                SSFReceiverStream is the public API representation.
+                 Secrets (push_auth_token, outbound credentials) are write-only.
+
+                This message contains a oneof named outbound_auth. Only a single field of the following list may be set at a time:
+                  - outboundAuthBearer
+                  - outboundAuthOauth2
+            properties:
+                accountDisabledAction:
+                    description: Action to take when an account-disabled event is received.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                createdAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                credentialChangeAction:
+                    description: Action to take when a credential-change event is received.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                credentialCompromiseAction:
+                    description: Action to take when a credential-compromise event is received.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                deletedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                deliveryMethod:
+                    description: Controls whether events are received via push (transmitter POSTs to C1) or poll (C1 fetches from transmitter).
+                    enum:
+                        - SSF_DELIVERY_METHOD_UNSPECIFIED
+                        - SSF_DELIVERY_METHOD_PUSH
+                        - SSF_DELIVERY_METHOD_POLL
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                description:
+                    description: Optional description of the stream's purpose or source.
+                    readOnly: false
+                    type: string
                 displayName:
-                    description: The displayName field.
+                    description: Human-readable name for the stream shown in the UI.
+                    readOnly: false
+                    type: string
+                enabled:
+                    description: Controls whether this stream actively processes incoming events. When false, events are ignored.
+                    readOnly: false
+                    type: boolean
+                eventTypesEnabled:
+                    description: SSF/CAEP/RISC event type URIs that this stream is configured to accept.
+                    items:
+                        type: string
+                    nullable: true
+                    readOnly: false
+                    type: array
+                expectedAudience:
+                    description: Expected audience (aud) claim in incoming SETs. Optional.
+                    readOnly: false
+                    type: string
+                id:
+                    description: The unique identifier of this SSF receiver stream.
                     readOnly: false
                     type: string
                 issuerUrl:
-                    description: The issuerUrl field.
+                    description: Upstream IdP identification.
+                    readOnly: false
+                    type: string
+                jwksUrl:
+                    description: The jwksUrl field.
+                    readOnly: false
+                    type: string
+                lastErrorAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                lastErrorMessage:
+                    description: The lastErrorMessage field.
+                    readOnly: false
+                    type: string
+                lastVerifiedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                outboundAuthBearer:
+                    $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFOutboundAuthBearer'
+                outboundAuthOauth2:
+                    $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFOutboundAuthOAuth2'
+                pollEndpointUrl:
+                    description: URL of the transmitter's poll endpoint where C1 fetches events from.
+                    readOnly: false
+                    type: string
+                pollInterval:
+                    format: duration
+                    readOnly: false
+                    type: string
+                pushAuthToken:
+                    description: 'Push auth token: write-only. Accepted on create, never returned in get/list.'
+                    readOnly: false
+                    type: string
+                pushEndpointUrl:
+                    description: 'Push delivery: C1 generates a unique endpoint URL.'
+                    readOnly: true
+                    type: string
+                sessionRevokedAction:
+                    description: |-
+                        Per-canonical-type action configuration.
+                         Event types without a config here default to LOG_ONLY.
+                         Action to take when a session-revoked event is received.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                updatedAt:
+                    format: date-time
+                    readOnly: true
+                    type: string
+            title: Ssf Receiver Stream
+            type: object
+            x-speakeasy-name-override: SSFReceiverStream
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceCreateRequest:
+            description: SSFReceiverStreamServiceCreateRequest contains the configuration for a new SSF receiver stream.
+            properties:
+                accountDisabledAction:
+                    description: Action to take when an account-disabled event is received.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                credentialChangeAction:
+                    description: Action to take when a credential-change event is received.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                credentialCompromiseAction:
+                    description: Action to take when a credential-compromise event is received.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                deliveryMethod:
+                    description: Controls whether events are received via push or poll delivery.
+                    enum:
+                        - SSF_DELIVERY_METHOD_UNSPECIFIED
+                        - SSF_DELIVERY_METHOD_PUSH
+                        - SSF_DELIVERY_METHOD_POLL
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                description:
+                    description: Optional description of the stream's purpose or source.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: Human-readable name for the stream.
+                    readOnly: false
+                    type: string
+                enabled:
+                    description: Controls whether the stream starts processing events immediately after creation.
+                    readOnly: false
+                    type: boolean
+                expectedAudience:
+                    description: Expected audience claim in incoming SETs. If set, SETs with a different audience are rejected.
+                    readOnly: false
+                    type: string
+                issuerUrl:
+                    description: The issuer URL of the upstream SSF transmitter, used for token validation.
+                    readOnly: false
+                    type: string
+                jwksUrl:
+                    description: URL to fetch the transmitter's JSON Web Key Set for SET signature verification.
+                    readOnly: false
+                    type: string
+                pollEndpointUrl:
+                    description: URL of the transmitter's poll endpoint. Required when delivery_method is POLL.
+                    readOnly: false
+                    type: string
+                pollInterval:
+                    format: duration
+                    readOnly: false
+                    type: string
+                sessionRevokedAction:
+                    description: |-
+                        Per-event-type action configuration.
+                         Action to take when a session-revoked event is received.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            required:
+                - displayName
+                - issuerUrl
+            title: Ssf Receiver Stream Service Create Request
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceCreateRequest
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceCreateResponse:
+            description: SSFReceiverStreamServiceCreateResponse returns the created stream and the push auth token in plaintext.
+            properties:
+                pushAuthTokenPlaintext:
+                    description: Push auth token returned in plaintext ONLY on create.
+                    readOnly: false
+                    type: string
+                ssfReceiverStream:
+                    $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStream'
+            title: Ssf Receiver Stream Service Create Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceCreateResponse
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceDeleteRequestInput:
+            description: SSFReceiverStreamServiceDeleteRequest identifies the SSF receiver stream to delete.
+            title: Ssf Receiver Stream Service Delete Request
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceDeleteRequest
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceDeleteResponse:
+            description: SSFReceiverStreamServiceDeleteResponse is empty on success.
+            title: Ssf Receiver Stream Service Delete Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceDeleteResponse
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceGetResponse:
+            description: SSFReceiverStreamServiceGetResponse contains the requested SSF receiver stream.
+            properties:
+                ssfReceiverStream:
+                    $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStream'
+            title: Ssf Receiver Stream Service Get Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceGetResponse
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceGetStatsResponse:
+            description: SSFReceiverStreamServiceGetStatsResponse contains the event processing statistics for the stream.
+            properties:
+                stats:
+                    $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamStats'
+            title: Ssf Receiver Stream Service Get Stats Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceGetStatsResponse
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceListResponse:
+            description: SSFReceiverStreamServiceListResponse contains a page of SSF receiver streams.
+            properties:
+                list:
+                    description: The SSF receiver streams in the current page.
+                    items:
+                        $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStream'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                nextPageToken:
+                    description: Token to retrieve the next page. Empty when there are no more results.
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Stream Service List Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceListResponse
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceTestRequestInput:
+            description: SSFReceiverStreamServiceTestRequest identifies the stream to test and an optional subject for identity resolution validation.
+            properties:
+                testSubject:
+                    description: |-
+                        The upstream identifier to test resolution with. Typically an email address
+                         (e.g., "alice@company.com") — the same value the IdP would send in a SET subject.
+                         The Test RPC runs resolveSubject on this to verify the identity mapping works.
+                         Optional: upstream identifier (email) to test identity resolution.
+                         If empty, only JWKS reachability is tested.
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Stream Service Test Request
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceTestRequest
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceTestResponse:
+            description: SSFReceiverStreamServiceTestResponse reports the results of the stream configuration test across JWKS, identity, and action readiness checks.
+            properties:
+                activeRefreshTokenCount:
+                    description: Number of active refresh tokens for the matched user that would be affected.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                activeSessionCount:
+                    description: Number of active sessions for the matched user that would be affected.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                configuredSessionRevokedAction:
+                    description: |-
+                        Step 3: Action preview.
+                         The action configured for session-revoked events on this stream.
+                    enum:
+                        - SSF_REVOCATION_ACTION_UNSPECIFIED
+                        - SSF_REVOCATION_ACTION_REVOKE_ALL
+                        - SSF_REVOCATION_ACTION_LOG_ONLY
+                    readOnly: false
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                identityLinkFound:
+                    description: |-
+                        Step 2: Identity mapping.
+                         Whether the test subject was resolved to a ConductorOne user.
+                    readOnly: false
+                    type: boolean
+                jwksError:
+                    description: Error message if the JWKS endpoint could not be reached or returned invalid data.
+                    readOnly: false
+                    type: string
+                jwksKeyCount:
+                    description: Number of signing keys found at the JWKS endpoint.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                jwksReachable:
+                    description: |-
+                        Step 1: JWKS reachability.
+                         Whether the JWKS endpoint was reachable and returned valid keys.
+                    readOnly: false
+                    type: boolean
+                matchedUserId:
+                    description: The ConductorOne user ID the test subject maps to, if an identity link was found.
+                    readOnly: false
+                    type: string
+                ready:
+                    description: |-
+                        Overall readiness.
+                         Whether the stream passed all test checks and is ready to process events.
+                    readOnly: false
+                    type: boolean
+                upstreamSubject:
+                    description: The upstream IdP subject identifier (e.g., Okta user ID "00u1234") resolved from the test subject.
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Stream Service Test Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceTestResponse
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceUpdateRequestInput:
+            description: SSFReceiverStreamServiceUpdateRequest carries the stream to update and the mask of fields to modify.
+            properties:
+                ssfReceiverStream:
+                    $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStream'
+                updateMask:
+                    nullable: true
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Stream Service Update Request
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceUpdateRequest
+        c1.api.ssf_receiver.v1.SSFReceiverStreamServiceUpdateResponse:
+            description: SSFReceiverStreamServiceUpdateResponse contains the updated SSF receiver stream.
+            properties:
+                ssfReceiverStream:
+                    $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStream'
+            title: Ssf Receiver Stream Service Update Response
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamServiceUpdateResponse
+        c1.api.ssf_receiver.v1.SSFReceiverStreamStats:
+            description: SSFReceiverStreamStats is a lightweight read-only stats object.
+            properties:
+                eventsActedOnCount:
+                    description: Number of events that triggered an action (e.g., session revocation).
+                    format: int64
+                    readOnly: false
+                    type: string
+                eventsFailedCount:
+                    description: Number of events that failed processing.
+                    format: int64
+                    readOnly: false
+                    type: string
+                eventsReceivedCount:
+                    description: Total number of events received on this stream.
+                    format: int64
+                    readOnly: false
+                    type: string
+                lastErrorAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                lastErrorMessage:
+                    description: Human-readable description of the most recent processing error.
+                    readOnly: false
+                    type: string
+                lastEventReceivedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                lastVerifiedAt:
+                    format: date-time
+                    readOnly: false
+                    type: string
+                streamId:
+                    description: The SSF receiver stream these stats belong to.
+                    readOnly: false
+                    type: string
+                transmitterStatus:
+                    description: Current status reported by the transmitter (e.g., "enabled", "paused").
+                    readOnly: false
+                    type: string
+                transmitterStatusReason:
+                    description: Reason provided by the transmitter for its current status.
+                    readOnly: false
+                    type: string
+            title: Ssf Receiver Stream Stats
+            type: object
+            x-speakeasy-name-override: SSFReceiverStreamStats
+        c1.api.stepup.v1.CreateStepUpProviderRequest:
+            description: |
+                The CreateStepUpProviderRequest message.
+
+                This message contains a oneof named settings. Only a single field of the following list may be set at a time:
+                  - oauth2
+                  - microsoft
+            properties:
+                clientId:
+                    description: The OAuth2 client ID used to authenticate with the step-up provider.
+                    readOnly: false
+                    type: string
+                clientSecret:
+                    description: The OAuth2 client secret. Write-only; never returned in responses.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The human-readable name for the new step-up provider.
+                    readOnly: false
+                    type: string
+                issuerUrl:
+                    description: The OIDC issuer URL for the step-up provider.
                     readOnly: false
                     type: string
                 microsoft:
@@ -17310,14 +22034,14 @@ components:
             description: The ListStepUpProvidersResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of step-up authentication providers.
                     items:
                         $ref: '#/components/schemas/c1.api.stepup.v1.StepUpProvider'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: A token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: List Step Up Providers Response
@@ -17349,7 +22073,7 @@ components:
                     readOnly: false
                     type: string
                 refs:
-                    description: The refs field.
+                    description: Filter to specific providers by their references.
                     items:
                         $ref: '#/components/schemas/c1.api.stepup.v1.StepUpProviderRef'
                     nullable: true
@@ -17498,14 +22222,14 @@ components:
             x-speakeasy-name-override: StepUpOAuth2Settings
         c1.api.stepup.v1.StepUpProvider:
             description: |
-                The StepUpProvider message.
+                StepUpProvider represents a configured step-up authentication integration (e.g., Duo, custom OIDC).
 
                 This message contains a oneof named settings. Only a single field of the following list may be set at a time:
                   - oauth2
                   - microsoft
             properties:
                 clientId:
-                    description: The clientId field.
+                    description: The OAuth2 client ID used to authenticate with the step-up provider.
                     readOnly: false
                     type: string
                 createdAt:
@@ -17513,19 +22237,19 @@ components:
                     readOnly: true
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name of the step-up provider.
                     readOnly: false
                     type: string
                 enabled:
-                    description: The enabled field.
+                    description: Whether the step-up provider is active and available for use.
                     readOnly: false
                     type: boolean
                 id:
-                    description: The id field.
+                    description: The unique identifier of the step-up provider.
                     readOnly: true
                     type: string
                 issuerUrl:
-                    description: The issuerUrl field.
+                    description: The OIDC issuer URL for the step-up provider.
                     readOnly: false
                     type: string
                 lastTestedAt:
@@ -17544,10 +22268,10 @@ components:
             type: object
             x-speakeasy-name-override: StepUpProvider
         c1.api.stepup.v1.StepUpProviderRef:
-            description: The StepUpProviderRef message.
+            description: StepUpProviderRef is a lightweight reference to a step-up authentication provider.
             properties:
                 id:
-                    description: The id field.
+                    description: The unique identifier of the step-up provider.
                     readOnly: false
                     type: string
             title: Step Up Provider Ref
@@ -17670,7 +22394,7 @@ components:
             description: The UpdateStepUpProviderSecretRequest message.
             properties:
                 clientSecret:
-                    description: The clientSecret field.
+                    description: The new OAuth2 client secret. Write-only; never returned in responses.
                     readOnly: false
                     type: string
             title: Update Step Up Provider Secret Request
@@ -17694,7 +22418,7 @@ components:
                 datasource:
                     $ref: '#/components/schemas/c1.api.systemlog.v1.ExportToDatasource'
                 displayName:
-                    description: The display name of the new policy.
+                    description: The display name of the new system log exporter.
                     readOnly: false
                     type: string
             title: Export Service Create Request
@@ -17727,7 +22451,7 @@ components:
             type: object
             x-speakeasy-name-override: ExportServiceGetResponse
         c1.api.systemlog.v1.ExportServiceListEventsRequestInput:
-            description: The ExportServiceListEventsRequest message.
+            description: ExportServiceListEventsRequest is the request for listing audit events within a specific export.
             properties:
                 pageSize:
                     description: The pageSize field.
@@ -17742,7 +22466,7 @@ components:
             type: object
             x-speakeasy-name-override: ExportServiceListEventsRequest
         c1.api.systemlog.v1.ExportServiceListEventsResponse:
-            description: The ExportServiceListEventsResponse message.
+            description: ExportServiceListEventsResponse is the response containing audit events for an export.
             properties:
                 list:
                     description: List contains an array of JSON OCSF events.
@@ -17754,7 +22478,7 @@ components:
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: The token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: Export Service List Events Response
@@ -17878,7 +22602,7 @@ components:
             type: object
             x-speakeasy-name-override: ExporterRef
         c1.api.systemlog.v1.ExportsSearchServiceSearchRequest:
-            description: The ExportsSearchServiceSearchRequest message.
+            description: ExportsSearchServiceSearchRequest is the request for searching system log exports.
             properties:
                 displayName:
                     description: Search for system log exporters with a case insensitive match on the display name.
@@ -17908,17 +22632,17 @@ components:
             type: object
             x-speakeasy-name-override: ExportsSearchServiceSearchRequest
         c1.api.systemlog.v1.ExportsSearchServiceSearchResponse:
-            description: The ExportsSearchServiceSearchResponse message.
+            description: ExportsSearchServiceSearchResponse is the response for searching system log exports.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of system log exports matching the search criteria.
                     items:
                         $ref: '#/components/schemas/c1.api.systemlog.v1.Exporter'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: The token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: Exports Search Service Search Response
@@ -17983,6 +22707,52 @@ components:
             title: System Log Service List Events Response
             type: object
             x-speakeasy-name-override: SystemLogServiceListEventsResponse
+        c1.api.task.v1.ActionInstance:
+            description: |
+                ActionInstance is the API mirror of the internal immutable snapshot of an
+                 Action captured on a TaskTypeAction at ticket-creation time.
+
+                This message contains a oneof named target_ref. Only a single field of the following list may be set at a time:
+                  - connectorActionRef
+            properties:
+                connectorActionRef:
+                    $ref: '#/components/schemas/c1.api.task.v1.ConnectorActionRef'
+                displayName:
+                    description: |-
+                        Display label at ticket-creation time. Same value as
+                         TaskTypeAction.display_name; repeated here so clients that walk the
+                         instance see a self-contained view.
+                    readOnly: true
+                    type: string
+            title: Action Instance
+            type: object
+            x-speakeasy-name-override: TaskActionInstance
+        c1.api.task.v1.ConnectorActionRef:
+            description: |-
+                ConnectorActionRef describes dispatch through a connector's built-in
+                 GrantManagerService Grant / Revoke RPC — i.e. the default connector
+                 operation, used for synthesized tickets like scope-role requests.
+            nullable: true
+            properties:
+                appId:
+                    description: The app whose connector handles the operation.
+                    readOnly: true
+                    type: string
+                connectorId:
+                    description: The connector that will execute the Grant / Revoke.
+                    readOnly: true
+                    type: string
+                operation:
+                    description: Which connector RPC this dispatches to.
+                    enum:
+                        - OPERATION_UNSPECIFIED
+                        - OPERATION_GRANT
+                    readOnly: true
+                    type: string
+                    x-speakeasy-unknown-values: allow
+            title: Connector Action Ref
+            type: object
+            x-speakeasy-name-override: ConnectorActionRef
         c1.api.task.v1.ExternalRef:
             description: A reference to an external source. This value is unused currently, but may be brought back.
             properties:
@@ -18005,6 +22775,36 @@ components:
             title: External Ref
             type: object
             x-speakeasy-name-override: ExternalRef
+        c1.api.task.v1.ScopeRole:
+            description: |-
+                Scope-role variant of TaskTypeAction.target_object. The UI uses the
+                 embedded identifiers to build links and title strings without a separate
+                 Action fetch.
+            nullable: true
+            properties:
+                appId:
+                    description: The IaaS/sparse-ACL app the (scope, role) pair lives on.
+                    readOnly: true
+                    type: string
+                roleResourceId:
+                    description: The roleResourceId field.
+                    readOnly: true
+                    type: string
+                roleResourceTypeId:
+                    description: The roleResourceTypeId field.
+                    readOnly: true
+                    type: string
+                scopeResourceId:
+                    description: The scopeResourceId field.
+                    readOnly: true
+                    type: string
+                scopeResourceTypeId:
+                    description: The scopeResourceTypeId field.
+                    readOnly: true
+                    type: string
+            title: Scope Role
+            type: object
+            x-speakeasy-name-override: ScopeRole
         c1.api.task.v1.Task:
             description: A fully-fleged task object. Includes its policy, references to external apps, its type, its processing history, and more.
             properties:
@@ -18212,10 +23012,10 @@ components:
             type: object
             x-speakeasy-name-override: Task
         c1.api.task.v1.TaskAction:
-            description: The TaskAction message.
+            description: Represents a single action that was performed on a task.
             properties:
                 actionType:
-                    description: The actionType field.
+                    description: The type of action that was performed.
                     enum:
                         - TASK_ACTION_TYPE_UNSPECIFIED
                         - TASK_ACTION_TYPE_CLOSE
@@ -18248,7 +23048,7 @@ components:
                     type: string
                     x-speakeasy-unknown-values: allow
                 bulkActionId:
-                    description: The bulkActionId field.
+                    description: The ID of the bulk action this action belongs to, if it was part of a bulk operation.
                     readOnly: false
                     type: string
                 createdAt:
@@ -18260,11 +23060,11 @@ components:
                     readOnly: true
                     type: string
                 id:
-                    description: The id field.
+                    description: The unique ID of this action.
                     readOnly: false
                     type: string
                 policyStepId:
-                    description: The policyStepId field.
+                    description: The ID of the policy step this action was performed on.
                     readOnly: false
                     type: string
                 updatedAt:
@@ -18272,7 +23072,7 @@ components:
                     readOnly: true
                     type: string
                 userId:
-                    description: The userId field.
+                    description: The ID of the user who performed the action.
                     readOnly: false
                     type: string
             title: Task Action
@@ -18316,7 +23116,7 @@ components:
                 taskView:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskView'
                 ticketActionId:
-                    description: The ID of the ticket (task) approve action created by this request.
+                    description: The ID of the task approve action created by this request.
                     readOnly: true
                     type: string
             title: Task Actions Service Approve Response
@@ -18372,7 +23172,7 @@ components:
                 taskView:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskView'
                 ticketActionId:
-                    description: The ID of the ticket (task) approve action created by this request.
+                    description: The ID of the task approve action created by this request.
                     readOnly: true
                     type: string
             title: Task Actions Service Approve With Step Up Response
@@ -18382,7 +23182,7 @@ components:
             description: The TaskActionsServiceCloseRequest object lets you close or cancel a task.
             properties:
                 comment:
-                    description: The comment field.
+                    description: An optional comment attached to the close action.
                     readOnly: false
                     type: string
                 expandMask:
@@ -18420,7 +23220,7 @@ components:
             description: The TaskActionsServiceCommentRequest object lets you create a new comment on a task.
             properties:
                 comment:
-                    description: The comment to be posted to the ticket
+                    description: The comment to be posted to the task.
                     readOnly: false
                     type: string
                 expandMask:
@@ -18460,7 +23260,7 @@ components:
                 expandMask:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskExpandMask'
                 policyStepId:
-                    description: The ID of the currently policy step. This is the step you want to deny.
+                    description: The ID of the current policy step. This is the step you want to deny.
                     readOnly: false
                     type: string
             title: Task Actions Service Deny Request
@@ -18486,23 +23286,23 @@ components:
                 taskView:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskView'
                 ticketActionId:
-                    description: The ID of the ticket (task) deny action created by this request.
+                    description: The ID of the task deny action created by this request.
                     readOnly: true
                     type: string
             title: Task Actions Service Deny Response
             type: object
             x-speakeasy-name-override: TaskActionsServiceDenyResponse
         c1.api.task.v1.TaskActionsServiceEscalateToEmergencyAccessRequestInput:
-            description: The TaskActionsServiceEscalateToEmergencyAccessRequest message.
+            description: The TaskActionsServiceEscalateToEmergencyAccessRequest object lets you escalate a task to the emergency access workflow.
             properties:
                 comment:
-                    description: The comment field.
+                    description: An optional comment attached to the escalation.
                     readOnly: false
                     type: string
                 expandMask:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskExpandMask'
                 policyStepId:
-                    description: The policyStepId field.
+                    description: The ID of the current policy step being escalated from.
                     readOnly: false
                     type: string
             title: Task Actions Service Escalate To Emergency Access Request
@@ -18521,10 +23321,10 @@ components:
             type: object
             x-speakeasy-name-override: TaskActionsServiceHardResetRequest
         c1.api.task.v1.TaskActionsServiceHardResetResponse:
-            description: The TaskActionsServiceHardResetResponse message.
+            description: The TaskActionsServiceHardResetResponse returns the updated task after a hard reset.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -18540,7 +23340,7 @@ components:
                 taskView:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskView'
                 ticketActionId:
-                    description: The ticketActionId field.
+                    description: The ID of the task reset action created by this request.
                     readOnly: false
                     type: string
             title: Task Actions Service Hard Reset Response
@@ -18555,10 +23355,10 @@ components:
             type: object
             x-speakeasy-name-override: TaskActionsServiceProcessNowRequest
         c1.api.task.v1.TaskActionsServiceProcessNowResponse:
-            description: The TaskActionsServiceProcessNowResponse message.
+            description: The TaskActionsServiceProcessNowResponse returns the task view after triggering immediate processing.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -18577,23 +23377,23 @@ components:
             type: object
             x-speakeasy-name-override: TaskActionsServiceProcessNowResponse
         c1.api.task.v1.TaskActionsServiceReassignRequestInput:
-            description: The TaskActionsServiceReassignRequest message.
+            description: The TaskActionsServiceReassignRequest object lets you reassign a task's current policy step to different users.
             properties:
                 comment:
-                    description: The comment field.
+                    description: An optional comment attached to the reassignment.
                     readOnly: false
                     type: string
                 expandMask:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskExpandMask'
                 newStepUserIds:
-                    description: The newStepUserIds field.
+                    description: The IDs of the users to reassign the current policy step to. Must be from the allowed reassignees list.
                     items:
                         type: string
                     nullable: true
                     readOnly: false
                     type: array
                 policyStepId:
-                    description: The policyStepId field.
+                    description: The ID of the current policy step to reassign. Must match the task's active step.
                     readOnly: false
                     type: string
             title: Task Actions Service Reassign Request
@@ -18619,7 +23419,7 @@ components:
                 taskView:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskView'
                 ticketActionId:
-                    description: The ID of the ticket (task) deny action created by this request.
+                    description: The ID of the task reassign action created by this request.
                     readOnly: true
                     type: string
             title: Task Actions Service Reassign Response
@@ -18635,17 +23435,17 @@ components:
                 expandMask:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskExpandMask'
                 policyStepId:
-                    description: The ID of the policy step on the given task to restart.
+                    description: Deprecated. This field is accepted but does not affect behavior.
                     readOnly: false
                     type: string
             title: Task Actions Service Restart Request
             type: object
             x-speakeasy-name-override: TaskActionsServiceRestartRequest
         c1.api.task.v1.TaskActionsServiceRestartResponse:
-            description: The TaskActionsServiceRestartResponse message.
+            description: The TaskActionsServiceRestartResponse returns the updated task after restarting.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -18661,7 +23461,7 @@ components:
                 taskView:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskView'
                 ticketActionId:
-                    description: The ticketActionId field.
+                    description: The ID of the task restart action created by this request.
                     readOnly: false
                     type: string
             title: Task Actions Service Restart Response
@@ -18686,7 +23486,7 @@ components:
             type: object
             x-speakeasy-name-override: TaskActionsServiceSkipStepRequest
         c1.api.task.v1.TaskActionsServiceUpdateGrantDurationRequestInput:
-            description: The TaskActionsServiceUpdateGrantDurationRequest message.
+            description: The TaskActionsServiceUpdateGrantDurationRequest object lets you change the grant duration on a grant task.
             properties:
                 duration:
                     format: duration
@@ -18700,7 +23500,7 @@ components:
             type: object
             x-speakeasy-name-override: TaskActionsServiceUpdateGrantDurationRequest
         c1.api.task.v1.TaskActionsServiceUpdateRequestDataRequestInput:
-            description: The TaskActionsServiceUpdateRequestDataRequest message.
+            description: The TaskActionsServiceUpdateRequestDataRequest object lets you submit form data for a task that is in a form policy step.
             properties:
                 data:
                     additionalProperties: true
@@ -18934,6 +23734,7 @@ components:
                   - success
                   - error
                   - cancelled
+                  - pending
             nullable: true
             properties:
                 appEntitlementId:
@@ -18956,6 +23757,8 @@ components:
                     type: string
                 error:
                     $ref: '#/components/schemas/c1.api.app.v1.TaskAuditErrorResult'
+                pending:
+                    $ref: '#/components/schemas/c1.api.app.v1.TaskAuditPendingResult'
                 success:
                     $ref: '#/components/schemas/c1.api.app.v1.TaskAuditSuccessResult'
             title: Task Audit Connector Action Result
@@ -19168,23 +23971,23 @@ components:
             description: The TaskAuditListRequest message.
             properties:
                 pageSize:
-                    description: The pageSize field.
+                    description: The maximum number of audit events to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: A pagination token from a previous response to retrieve the next page.
                     readOnly: false
                     type: string
                 refs:
-                    description: The refs field.
+                    description: References to specific audit events to retrieve. If provided, only these events are returned.
                     items:
                         $ref: '#/components/schemas/c1.api.task.v1.TaskAuditViewRef'
                     nullable: true
                     readOnly: false
                     type: array
                 taskId:
-                    description: The taskId field.
+                    description: The ID of the task to list audit events for.
                     readOnly: false
                     type: string
             title: Task Audit List Request
@@ -19194,14 +23997,14 @@ components:
             description: The TaskAuditListResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of audit events for the task.
                     items:
                         $ref: '#/components/schemas/c1.api.task.v1.TaskAuditView'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: A pagination token to retrieve the next page of results.
                     readOnly: false
                     type: string
             title: Task Audit List Response
@@ -19742,7 +24545,7 @@ components:
             description: The TaskAuditViewRef message.
             properties:
                 id:
-                    description: The id field.
+                    description: The ID of the audit event.
                     readOnly: false
                     type: string
             title: Task Audit View Ref
@@ -20053,7 +24856,7 @@ components:
             description: The task expand mask is an array of strings that specifes the related objects the requester wishes to have returned when making a request where the expand mask is part of the input. Use '*' to view all possible responses.
             properties:
                 paths:
-                    description: A list of paths to expand in the response. May be any combination of "*", "access_review_id", "user_id", "created_by_user_id", "app_id", "app_user_id", "app_entitlement_ids", "step_approver_ids", "approver_ids", "identity_user_id", "insight_ids", and "app_user_last_usage".
+                    description: A list of paths to expand in the response. May be any combination of "*", "access_review_id", "user_id", "created_by_user_id", "app_id", "app_user_id", "app_entitlement_ids", "step_approver_ids", "approver_ids", "identity_user_id", "insight_ids", "app_user_last_usage", "entitlement_scope_bindings", and "scope_role_resources".
                     items:
                         type: string
                     nullable: true
@@ -20551,10 +25354,10 @@ components:
             type: object
             x-speakeasy-name-override: TaskSearchResponse
         c1.api.task.v1.TaskServiceActionResponse:
-            description: The TaskServiceActionResponse message.
+            description: A generic response for task action endpoints, containing the updated task and the ID of the action that was created.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -20570,7 +25373,7 @@ components:
                 taskView:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskView'
                 ticketActionId:
-                    description: The ticketActionId field.
+                    description: The ID of the task action created by this request.
                     readOnly: false
                     type: string
             title: Task Service Action Response
@@ -20644,26 +25447,26 @@ components:
             type: object
             x-speakeasy-name-override: TaskServiceCreateGrantResponse
         c1.api.task.v1.TaskServiceCreateOffboardingRequest:
-            description: The TaskServiceCreateOffboardingRequest message.
+            description: Create an offboarding task.
             properties:
                 description:
-                    description: The description field.
+                    description: The description of the offboarding request.
                     readOnly: false
                     type: string
                 expandMask:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskExpandMask'
                 subjectUserId:
-                    description: The subjectUserId field.
+                    description: The ID of the user to offboard.
                     readOnly: false
                     type: string
             title: Task Service Create Offboarding Request
             type: object
             x-speakeasy-name-override: TaskServiceCreateOffboardingRequest
         c1.api.task.v1.TaskServiceCreateOffboardingResponse:
-            description: The TaskServiceCreateOffboardingResponse message.
+            description: The TaskServiceCreateOffboardingResponse returns the created offboarding task with optional expanded related objects.
             properties:
                 expanded:
-                    description: The expanded field.
+                    description: List of serialized related objects.
                     items:
                         additionalProperties: true
                         description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -20766,11 +25569,14 @@ components:
                   - certify
                   - offboarding
                   - action
+                  - finding
             properties:
                 action:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskTypeAction'
                 certify:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskTypeCertify'
+                finding:
+                    $ref: '#/components/schemas/c1.api.task.v1.TaskTypeFinding'
                 grant:
                     $ref: '#/components/schemas/c1.api.task.v1.TaskTypeGrant'
                 offboarding:
@@ -20781,11 +25587,28 @@ components:
             type: object
             x-speakeasy-name-override: TaskType
         c1.api.task.v1.TaskTypeAction:
-            description: The TaskTypeAction message.
+            description: |
+                The TaskTypeAction message.
+
+                This message contains a oneof named target_object. Only a single field of the following list may be set at a time:
+                  - scopeRole
             nullable: true
             properties:
                 actionId:
-                    description: The ID of the action to execute.
+                    description: |-
+                        The ID of the admin-authored action to execute. Empty for synthesized
+                         action tickets (e.g. scope-role grants) — those carry dispatch
+                         configuration on action_instance and target_object instead.
+                    readOnly: true
+                    type: string
+                actionInstance:
+                    $ref: '#/components/schemas/c1.api.task.v1.ActionInstance'
+                displayName:
+                    description: |-
+                        Display label captured on the action snapshot at ticket-creation time.
+                         Stable under admin renames to a referenced Action row and populated for
+                         synthesized tickets that have no Action row at all. UI reads this to
+                         render the task title without an Action fetch.
                     readOnly: true
                     type: string
                 formValues:
@@ -20807,6 +25630,20 @@ components:
                     format: date-time
                     readOnly: true
                     type: string
+                scopeRole:
+                    $ref: '#/components/schemas/c1.api.task.v1.ScopeRole'
+                type:
+                    description: |-
+                        Flavor of action the ticket represents — mirrors the snapshot's
+                         target_ref variant.
+                    enum:
+                        - TYPE_UNSPECIFIED
+                        - TYPE_GRANT
+                        - TYPE_WORKFLOW
+                        - TYPE_RESOURCE_ACTION
+                    readOnly: true
+                    type: string
+                    x-speakeasy-unknown-values: allow
             title: Task Type Action
             type: object
             x-speakeasy-name-override: TaskTypeAction
@@ -20857,6 +25694,35 @@ components:
             title: Task Type Certify
             type: object
             x-speakeasy-name-override: TaskTypeCertify
+        c1.api.task.v1.TaskTypeFinding:
+            description: The TaskTypeFinding message.
+            nullable: true
+            properties:
+                findingId:
+                    description: Reference to the source finding.
+                    readOnly: true
+                    type: string
+                findingType:
+                    description: The finding type discriminator.
+                    readOnly: true
+                    type: string
+                outcome:
+                    description: The outcome field.
+                    enum:
+                        - FINDING_TASK_OUTCOME_UNSPECIFIED
+                        - FINDING_TASK_OUTCOME_REMEDIATED
+                        - FINDING_TASK_OUTCOME_RISK_ACCEPTED
+                        - FINDING_TASK_OUTCOME_CANCELLED
+                    readOnly: true
+                    type: string
+                    x-speakeasy-unknown-values: allow
+                outcomeTime:
+                    format: date-time
+                    readOnly: true
+                    type: string
+            title: Task Type Finding
+            type: object
+            x-speakeasy-name-override: TaskTypeFinding
         c1.api.task.v1.TaskTypeGrant:
             description: The TaskTypeGrant message indicates that a task is a grant task and all related details.
             nullable: true
@@ -21008,6 +25874,18 @@ components:
                     description: JSONPATH expression indicating the location of the Insights objects in the expanded array
                     readOnly: true
                     type: string
+                resourceBindingsPath:
+                    description: JSONPATH expression indicating the location of the EntitlementScopeBindingList object in the expanded array.
+                    readOnly: true
+                    type: string
+                roleResourcePath:
+                    description: JSONPATH expression indicating the location of the role AppResource for a scope-role action task in the expanded array.
+                    readOnly: true
+                    type: string
+                scopeResourcePath:
+                    description: JSONPATH expression indicating the location of the scope AppResource for a scope-role action task in the expanded array.
+                    readOnly: true
+                    type: string
                 stepApproversPath:
                     description: JSONPATH expression indicating the location of the StepApproverUsers objects in the expanded array
                     readOnly: true
@@ -21056,10 +25934,10 @@ components:
             type: object
             x-speakeasy-name-override: ExpiringUserDelegationBinding
         c1.api.user.v1.GetUserProfileTypesResponse:
-            description: The GetUserProfileTypesResponse message.
+            description: GetUserProfileTypesResponse is the response containing the profile types for a user.
             properties:
                 profileTypes:
-                    description: The profileTypes field.
+                    description: The list of profile types associated with the user across their connected apps.
                     items:
                         $ref: '#/components/schemas/c1.api.profiletype.v1.ProfileType'
                     nullable: true
@@ -21247,10 +26125,10 @@ components:
             type: object
             x-speakeasy-name-override: SearchUsersResponse
         c1.api.user.v1.SetExpiringUserDelegationBindingByAdminRequestInput:
-            description: The SetExpiringUserDelegationBindingByAdminRequest message.
+            description: SetExpiringUserDelegationBindingByAdminRequest is the request for an admin to set a temporary delegation binding for a user.
             properties:
                 delegatedUserId:
-                    description: The delegatedUserId field.
+                    description: The ID of the user who will act as delegate. Empty string removes the delegation.
                     readOnly: false
                     type: string
                 delegationExpireAt:
@@ -21265,7 +26143,7 @@ components:
             type: object
             x-speakeasy-name-override: SetExpiringUserDelegationBindingByAdminRequest
         c1.api.user.v1.SetExpiringUserDelegationBindingByAdminResponse:
-            description: The SetExpiringUserDelegationBindingByAdminResponse message.
+            description: SetExpiringUserDelegationBindingByAdminResponse is the response containing the created or updated delegation binding.
             properties:
                 item:
                     $ref: '#/components/schemas/c1.api.user.v1.ExpiringUserDelegationBinding'
@@ -21608,21 +26486,21 @@ components:
             type: object
             x-speakeasy-name-override: UserView
         c1.api.vault.v1.GroupAuthzVault:
-            description: The GroupAuthzVault message.
+            description: GroupAuthzVault configures a vault that uses group-based authorization to control access to stored credentials.
             nullable: true
             title: Group Authz Vault
             type: object
             x-speakeasy-name-override: GroupAuthzVault
         c1.api.vault.v1.MagicVault:
-            description: The MagicVault message.
+            description: MagicVault configures a vault that grants time-limited credential access via magic links.
             nullable: true
             properties:
                 allowUnauthedViews:
-                    description: The allowUnauthedViews field.
+                    description: Controls whether unauthenticated users can view credentials via a magic link.
                     readOnly: false
                     type: boolean
                 allowedViews:
-                    description: The allowedViews field.
+                    description: The maximum number of times a credential in this vault may be viewed.
                     format: uint32
                     readOnly: false
                     type: integer
@@ -21631,7 +26509,7 @@ components:
             x-speakeasy-name-override: MagicVault
         c1.api.vault.v1.Vault:
             description: |
-                The Vault message.
+                Vault represents an external secret storage integration used to store connector credentials securely.
 
                 This message contains a oneof named vault. Only a single field of the following list may be set at a time:
                   - groupAuthzVault
@@ -21650,17 +26528,17 @@ components:
                     readOnly: true
                     type: string
                 description:
-                    description: The description field.
+                    description: A free-text description of the vault's purpose or configuration.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name of the vault.
                     readOnly: false
                     type: string
                 groupAuthzVault:
                     $ref: '#/components/schemas/c1.api.vault.v1.GroupAuthzVault'
                 id:
-                    description: The id field.
+                    description: The unique identifier of the vault.
                     readOnly: false
                     type: string
                 magicVault:
@@ -21675,18 +26553,18 @@ components:
             x-speakeasy-name-override: Vault
         c1.api.vault.v1.VaultServiceCreateRequest:
             description: |
-                The VaultServiceCreateRequest message.
+                VaultServiceCreateRequest is the request message for creating a new vault.
 
                 This message contains a oneof named vault. Only a single field of the following list may be set at a time:
                   - groupAuthzVault
                   - magicVault
             properties:
                 description:
-                    description: The description field.
+                    description: A free-text description of the vault's purpose or configuration.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name for the new vault.
                     readOnly: false
                     type: string
                 groupAuthzVault:
@@ -21694,7 +26572,7 @@ components:
                 magicVault:
                     $ref: '#/components/schemas/c1.api.vault.v1.MagicVault'
                 ownerIds:
-                    description: The ownerIds field.
+                    description: The IDs of users to assign as owners of this vault.
                     items:
                         type: string
                     nullable: true
@@ -21706,7 +26584,7 @@ components:
             type: object
             x-speakeasy-name-override: VaultServiceCreateRequest
         c1.api.vault.v1.VaultServiceCreateResponse:
-            description: The VaultServiceCreateResponse message.
+            description: VaultServiceCreateResponse is the response message for creating a new vault.
             properties:
                 vault:
                     $ref: '#/components/schemas/c1.api.vault.v1.Vault'
@@ -21714,7 +26592,7 @@ components:
             type: object
             x-speakeasy-name-override: VaultServiceCreateResponse
         c1.api.vault.v1.VaultServiceDeleteRequestInput:
-            description: The VaultServiceDeleteRequest message.
+            description: VaultServiceDeleteRequest is the request message for deleting a vault.
             title: Vault Service Delete Request
             type: object
             x-speakeasy-name-override: VaultServiceDeleteRequest
@@ -21724,7 +26602,7 @@ components:
             type: object
             x-speakeasy-name-override: VaultServiceDeleteResponse
         c1.api.vault.v1.VaultServiceGetResponse:
-            description: The VaultServiceGetResponse message.
+            description: VaultServiceGetResponse is the response message containing the requested vault.
             properties:
                 vault:
                     $ref: '#/components/schemas/c1.api.vault.v1.Vault'
@@ -21744,7 +26622,7 @@ components:
             type: object
             x-speakeasy-name-override: VaultServiceUpdateRequest
         c1.api.vault.v1.VaultServiceUpdateResponse:
-            description: The VaultServiceUpdateResponse message.
+            description: VaultServiceUpdateResponse is the response message containing the updated vault.
             properties:
                 vault:
                     $ref: '#/components/schemas/c1.api.vault.v1.Vault'
@@ -21767,15 +26645,15 @@ components:
                     readOnly: true
                     type: string
                 description:
-                    description: The description field.
+                    description: An optional description of the webhook's purpose.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name of the webhook.
                     readOnly: false
                     type: string
                 id:
-                    description: The id field.
+                    description: The unique identifier of the webhook.
                     readOnly: false
                     type: string
                 updatedAt:
@@ -21783,7 +26661,7 @@ components:
                     readOnly: true
                     type: string
                 url:
-                    description: The url field.
+                    description: The destination URL that receives event notification HTTP callbacks.
                     readOnly: false
                     type: string
             title: Webhook
@@ -21851,7 +26729,7 @@ components:
             description: The WebhookRef message.
             properties:
                 id:
-                    description: The id field.
+                    description: The ID of the referenced webhook.
                     readOnly: false
                     type: string
             title: Webhook Ref
@@ -21950,20 +26828,20 @@ components:
             description: The WebhooksSearchRequest message.
             properties:
                 pageSize:
-                    description: The pageSize field.
+                    description: The maximum number of webhooks to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 pageToken:
-                    description: The pageToken field.
+                    description: The pagination token from a previous search response to fetch the next page.
                     readOnly: false
                     type: string
                 query:
-                    description: The query field.
+                    description: A text query to match against webhook names and descriptions.
                     readOnly: false
                     type: string
                 refs:
-                    description: The refs field.
+                    description: Optional set of webhook references to restrict the search to specific webhooks.
                     items:
                         $ref: '#/components/schemas/c1.api.webhooks.v1.WebhookRef'
                     nullable: true
@@ -21976,14 +26854,14 @@ components:
             description: The WebhooksSearchResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of webhooks matching the search criteria.
                     items:
                         $ref: '#/components/schemas/c1.api.webhooks.v1.Webhook'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: A token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: Webhooks Search Response
@@ -21997,15 +26875,15 @@ components:
                     readOnly: false
                     type: string
                 description:
-                    description: The description field.
+                    description: An optional description of the webhook's purpose.
                     readOnly: false
                     type: string
                 displayName:
-                    description: The displayName field.
+                    description: The human-readable name for the new webhook.
                     readOnly: false
                     type: string
                 url:
-                    description: The url field.
+                    description: The destination URL that will receive event notification HTTP callbacks.
                     readOnly: false
                     type: string
             required:
@@ -22044,14 +26922,14 @@ components:
             description: The WebhooksServiceListResponse message.
             properties:
                 list:
-                    description: The list field.
+                    description: The list of webhooks for the current page.
                     items:
                         $ref: '#/components/schemas/c1.api.webhooks.v1.Webhook'
                     nullable: true
                     readOnly: false
                     type: array
                 nextPageToken:
-                    description: The nextPageToken field.
+                    description: A token to retrieve the next page of results, or empty if there are no more results.
                     readOnly: false
                     type: string
             title: Webhooks Service List Response
@@ -22214,7 +27092,9 @@ components:
             description: The WorkloadFederationServiceCreateTrustRequest message.
             properties:
                 allowSourceCidrs:
-                    description: IP allowlist for token exchange requests matching this trust.
+                    description: |-
+                        IP allowlist for token exchange requests matching this trust.
+                         Accepts IPv4 (e.g. 10.0.0.0/24) or IPv6 (e.g. 2001:db8::/32) CIDRs.
                     items:
                         type: string
                     nullable: true
@@ -22418,6 +27298,7 @@ components:
                     description: |-
                         Optional: override source IP for CIDR testing.
                          If empty, uses the request's source IP.
+                         Accepts IPv4 (e.g. 10.0.0.5) or IPv6 (e.g. 2001:db8::1) addresses, optionally with a CIDR prefix.
                     readOnly: false
                     type: string
                 subjectToken:
@@ -22605,6 +27486,46 @@ components:
             title: Access Profile Match
             type: object
             x-speakeasy-name-override: AccessProfileMatch
+        c1.mcp.role_mining.v1.AttributeFacet:
+            description: AttributeFacet represents a filterable user profile attribute with its available values.
+            properties:
+                attribute:
+                    description: The attribute field.
+                    readOnly: false
+                    type: string
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                values:
+                    description: The values field.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.AttributeValue'
+                    nullable: true
+                    readOnly: false
+                    type: array
+            title: Attribute Facet
+            type: object
+            x-speakeasy-name-override: AttributeFacet
+        c1.mcp.role_mining.v1.AttributeValue:
+            description: AttributeValue represents a single value within a facet.
+            properties:
+                displayName:
+                    description: The displayName field.
+                    readOnly: false
+                    type: string
+                userCount:
+                    description: The userCount field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                value:
+                    description: The value field.
+                    readOnly: false
+                    type: string
+            title: Attribute Value
+            type: object
+            x-speakeasy-name-override: RoleMiningAttributeValue
         c1.mcp.role_mining.v1.CohortEntitlement:
             description: The CohortEntitlement message.
             properties:
@@ -22644,6 +27565,32 @@ components:
             title: Cohort Entitlement
             type: object
             x-speakeasy-name-override: CohortEntitlement
+        c1.mcp.role_mining.v1.EntitlementCluster:
+            description: The EntitlementCluster message.
+            properties:
+                avgCoverage:
+                    description: The avgCoverage field.
+                    readOnly: false
+                    type: number
+                avgSimilarity:
+                    description: The avgSimilarity field.
+                    readOnly: false
+                    type: number
+                entitlements:
+                    description: The entitlements field.
+                    items:
+                        $ref: '#/components/schemas/c1.mcp.role_mining.v1.CohortEntitlement'
+                    nullable: true
+                    readOnly: false
+                    type: array
+                userCount:
+                    description: The userCount field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+            title: Entitlement Cluster
+            type: object
+            x-speakeasy-name-override: EntitlementCluster
         c1.mcp.role_mining.v1.ProfileFilter:
             description: |-
                 ProfileFilter defines a filter on a user profile attribute.
@@ -24542,8 +29489,8 @@ components:
                     tokenUrl: /auth/v1/token
             type: oauth2
 info:
-    description: The ConductorOne API is a HTTP API for managing ConductorOne resources.
-    title: ConductorOne API
+    description: The C1 API is a HTTP API for managing C1 resources.
+    title: C1 API
     version: 0.1.0-alpha
 openapi: 3.1.0
 paths:
@@ -24654,7 +29601,7 @@ paths:
             x-speakeasy-name-override: CreateSurfaceFeedback
     /api/v1/access_review:
         post:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewService.Create method.
+            description: Create creates a new access review campaign with the specified name, policy, and owners.
             operationId: c1.api.accessreview.v1.AccessReviewService.Create
             requestBody:
                 content:
@@ -24680,14 +29627,14 @@ paths:
             x-stability-level: draft
     /api/v1/access_review/{access_review_id}/scope_and_entitlements:
         get:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewSetupEntitlementService.GetCampaignScopeAndEntitlements method.
+            description: GetCampaignScopeAndEntitlements retrieves the current scope configuration and selected entitlements for an access review campaign.
             operationId: c1.api.accessreview.v1.AccessReviewSetupEntitlementService.GetCampaignScopeAndEntitlements
             parameters:
                 - in: path
                   name: access_review_id
                   required: true
                   schema:
-                    description: The accessReviewId field.
+                    description: The ID of the access review campaign to retrieve scope and entitlements for.
                     readOnly: false
                     type: string
             responses:
@@ -24709,14 +29656,14 @@ paths:
             x-speakeasy-name-override: GetCampaignScopeAndEntitlements
             x-stability-level: stable
         post:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewSetupEntitlementService.SetCampaignScopeAndEntitlements method.
+            description: SetCampaignScopeAndEntitlements replaces the scope configuration and selected entitlements for an access review campaign.
             operationId: c1.api.accessreview.v1.AccessReviewSetupEntitlementService.SetCampaignScopeAndEntitlements
             parameters:
                 - in: path
                   name: access_review_id
                   required: true
                   schema:
-                    description: The accessReviewId field.
+                    description: The ID of the access review campaign to configure.
                     readOnly: false
                     type: string
             requestBody:
@@ -24745,14 +29692,14 @@ paths:
             x-stability-level: stable
     /api/v1/access_review/{access_review_id}/scope_by_resource_type:
         post:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewSetupEntitlementService.SetCampaignScopeByResourceType method.
+            description: SetCampaignScopeByResourceType sets the campaign scope by selecting specific resource types to include in the review.
             operationId: c1.api.accessreview.v1.AccessReviewSetupEntitlementService.SetCampaignScopeByResourceType
             parameters:
                 - in: path
                   name: access_review_id
                   required: true
                   schema:
-                    description: The accessReviewId field.
+                    description: The ID of the access review campaign to configure.
                     readOnly: false
                     type: string
             requestBody:
@@ -24775,14 +29722,14 @@ paths:
             x-stability-level: draft
     /api/v1/access_review/{id}:
         delete:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewService.Delete method.
+            description: Delete transitions an access review campaign to the deleted state, along with its dependent objects.
             operationId: c1.api.accessreview.v1.AccessReviewService.Delete
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the access review campaign to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -24808,14 +29755,14 @@ paths:
             x-speakeasy-name-override: Delete
             x-stability-level: draft
         get:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewService.Get method.
+            description: Get retrieves a single access review campaign by ID.
             operationId: c1.api.accessreview.v1.AccessReviewService.Get
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the access review campaign to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -24837,14 +29784,14 @@ paths:
             x-speakeasy-name-override: Get
             x-stability-level: draft
         post:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewService.Update method.
+            description: Update modifies an existing access review campaign. Use the update_mask to specify which fields to change.
             operationId: c1.api.accessreview.v1.AccessReviewService.Update
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of this access review campaign.
                     readOnly: false
                     type: string
             requestBody:
@@ -24871,7 +29818,7 @@ paths:
             x-stability-level: draft
     /api/v1/access_review_template:
         post:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewTemplateService.Create method.
+            description: Create creates a new access review template that defines a reusable configuration for launching campaigns.
             operationId: c1.api.accessreview.v1.AccessReviewTemplateService.Create
             requestBody:
                 content:
@@ -24897,14 +29844,14 @@ paths:
             x-stability-level: draft
     /api/v1/access_review_template/{access_review_template_id}/scope_and_entitlements:
         get:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementService.GetScopeAndEntitlements method.
+            description: GetScopeAndEntitlements retrieves the current scope configuration and selected entitlements for an access review template.
             operationId: c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementService.GetScopeAndEntitlements
             parameters:
                 - in: path
                   name: access_review_template_id
                   required: true
                   schema:
-                    description: The accessReviewTemplateId field.
+                    description: The ID of the access review template to retrieve scope and entitlements for.
                     readOnly: false
                     type: string
             responses:
@@ -24926,14 +29873,14 @@ paths:
             x-speakeasy-name-override: GetScopeAndEntitlements
             x-stability-level: stable
         post:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementService.SetScopeAndEntitlements method.
+            description: SetScopeAndEntitlements replaces the scope configuration and selected entitlements for an access review template.
             operationId: c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementService.SetScopeAndEntitlements
             parameters:
                 - in: path
                   name: access_review_template_id
                   required: true
                   schema:
-                    description: The accessReviewTemplateId field.
+                    description: The ID of the access review template to configure.
                     readOnly: false
                     type: string
             requestBody:
@@ -24962,14 +29909,14 @@ paths:
             x-stability-level: stable
     /api/v1/access_review_template/{access_review_template_id}/scope_by_resource_type:
         post:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementService.SetScopeByResourceType method.
+            description: SetScopeByResourceType sets the template scope by selecting specific resource types to include in campaigns created from this template.
             operationId: c1.api.accessreview.v1.AccessReviewTemplateSetupEntitlementService.SetScopeByResourceType
             parameters:
                 - in: path
                   name: access_review_template_id
                   required: true
                   schema:
-                    description: The accessReviewTemplateId field.
+                    description: The ID of the access review template to configure.
                     readOnly: false
                     type: string
             requestBody:
@@ -24992,14 +29939,14 @@ paths:
             x-stability-level: draft
     /api/v1/access_review_template/{id}:
         delete:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewTemplateService.Delete method.
+            description: Delete an access review template. The template can no longer be used to create campaigns.
             operationId: c1.api.accessreview.v1.AccessReviewTemplateService.Delete
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the access review template to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -25025,14 +29972,14 @@ paths:
             x-speakeasy-name-override: Delete
             x-stability-level: draft
         get:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewTemplateService.Get method.
+            description: Get retrieves a single access review template by ID.
             operationId: c1.api.accessreview.v1.AccessReviewTemplateService.Get
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the access review template to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -25054,14 +30001,14 @@ paths:
             x-speakeasy-name-override: Get
             x-stability-level: draft
         post:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewTemplateService.Update method.
+            description: Update modifies an existing access review template. Use the update_mask to specify which fields to change.
             operationId: c1.api.accessreview.v1.AccessReviewTemplateService.Update
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of this template.
                     readOnly: false
                     type: string
             requestBody:
@@ -25088,20 +30035,20 @@ paths:
             x-stability-level: draft
     /api/v1/access_reviews:
         get:
-            description: Invokes the c1.api.accessreview.v1.AccessReviewService.List method.
+            description: List returns a paginated list of access review campaigns.
             operationId: c1.api.accessreview.v1.AccessReviewService.List
             parameters:
                 - in: query
                   name: page_size
                   schema:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page. Maximum 100.
                     format: int32
                     readOnly: false
                     type: integer
                 - in: query
                   name: page_token
                   schema:
-                    description: The pageToken field.
+                    description: Pagination token from a previous List response to fetch the next page.
                     readOnly: false
                     type: string
             responses:
@@ -25124,7 +30071,7 @@ paths:
             x-stability-level: draft
     /api/v1/accessconflict:
         post:
-            description: Invokes the c1.api.accessconflict.v1.AccessConflictService.CreateMonitor method.
+            description: Create a new conflict monitor for defining a Separation of Duty rule. Entitlement sets are bound separately via AppEntitlementMonitorBindingService.
             operationId: c1.api.accessconflict.v1.AccessConflictService.CreateMonitor
             requestBody:
                 content:
@@ -25137,7 +30084,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.accessconflict.v1.ConflictMonitor'
-                    description: Successful response
+                    description: |-
+                        A conflict monitor defines a Separation of Duty rule between two entitlement sets.
+                         It detects when any user holds entitlements from both set A and set B simultaneously.
             summary: Create Monitor
             tags:
                 - Access Conflict
@@ -25149,14 +30098,14 @@ paths:
             x-speakeasy-name-override: CreateMonitor
     /api/v1/accessconflict/{id}:
         delete:
-            description: Invokes the c1.api.accessconflict.v1.AccessConflictService.DeleteMonitor method.
+            description: Delete a conflict monitor and its associated entitlement set bindings.
             operationId: c1.api.accessconflict.v1.AccessConflictService.DeleteMonitor
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the conflict monitor to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -25170,7 +30119,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.accessconflict.v1.ConflictMonitorDeleteResponse'
-                    description: Successful response
+                    description: The response message for deleting a conflict monitor.
             summary: Delete Monitor
             tags:
                 - Access Conflict
@@ -25181,14 +30130,14 @@ paths:
             x-speakeasy-group: AccessConflict
             x-speakeasy-name-override: DeleteMonitor
         get:
-            description: Invokes the c1.api.accessconflict.v1.AccessConflictService.GetMonitor method.
+            description: Retrieve a single conflict monitor by ID.
             operationId: c1.api.accessconflict.v1.AccessConflictService.GetMonitor
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the conflict monitor to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -25197,7 +30146,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.accessconflict.v1.ConflictMonitor'
-                    description: Successful response
+                    description: |-
+                        A conflict monitor defines a Separation of Duty rule between two entitlement sets.
+                         It detects when any user holds entitlements from both set A and set B simultaneously.
             summary: Get Monitor
             tags:
                 - Access Conflict
@@ -25209,14 +30160,14 @@ paths:
             x-speakeasy-group: AccessConflict
             x-speakeasy-name-override: GetMonitor
         post:
-            description: Invokes the c1.api.accessconflict.v1.AccessConflictService.UpdateMonitor method.
+            description: Update the display name, description, or notification settings of a conflict monitor.
             operationId: c1.api.accessconflict.v1.AccessConflictService.UpdateMonitor
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the conflict monitor to update.
                     readOnly: false
                     type: string
             requestBody:
@@ -25230,7 +30181,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.accessconflict.v1.ConflictMonitor'
-                    description: Successful response
+                    description: |-
+                        A conflict monitor defines a Separation of Duty rule between two entitlement sets.
+                         It detects when any user holds entitlements from both set A and set B simultaneously.
             summary: Update Monitor
             tags:
                 - Access Conflict
@@ -25242,7 +30195,7 @@ paths:
             x-speakeasy-name-override: UpdateMonitor
     /api/v1/appentitlementmonitorbinding:
         delete:
-            description: Invokes the c1.api.accessconflict.v1.AppEntitlementMonitorBindingService.DeleteAppEntitlementMonitorBinding method.
+            description: Remove an app entitlement from a conflict monitor's entitlement set.
             operationId: c1.api.accessconflict.v1.AppEntitlementMonitorBindingService.DeleteAppEntitlementMonitorBinding
             requestBody:
                 content:
@@ -25255,7 +30208,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.accessconflict.v1.DeleteAppEntitlementMonitorBindingResponse'
-                    description: Successful response
+                    description: The response message for deleting an app entitlement monitor binding.
             summary: Delete App Entitlement Monitor Binding
             tags:
                 - App Entitlement Monitor Binding
@@ -25266,7 +30219,7 @@ paths:
             x-speakeasy-group: AppEntitlementMonitorBinding
             x-speakeasy-name-override: DeleteAppEntitlementMonitorBinding
         post:
-            description: Invokes the c1.api.accessconflict.v1.AppEntitlementMonitorBindingService.CreateAppEntitlementMonitorBinding method.
+            description: Bind an app entitlement to one side (A or B) of a conflict monitor.
             operationId: c1.api.accessconflict.v1.AppEntitlementMonitorBindingService.CreateAppEntitlementMonitorBinding
             requestBody:
                 content:
@@ -25279,7 +30232,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.accessconflict.v1.AppEntitlementMonitorBinding'
-                    description: Successful response
+                    description: Represents the association of an app entitlement with one side (A or B) of a conflict monitor.
             summary: Create App Entitlement Monitor Binding
             tags:
                 - App Entitlement Monitor Binding
@@ -25291,7 +30244,7 @@ paths:
             x-speakeasy-name-override: CreateAppEntitlementMonitorBinding
     /api/v1/appentitlementmonitorbinding/get:
         post:
-            description: Invokes the c1.api.accessconflict.v1.AppEntitlementMonitorBindingService.GetAppEntitlementMonitorBinding method.
+            description: Retrieve a single binding that associates an app entitlement with one side of a conflict monitor.
             operationId: c1.api.accessconflict.v1.AppEntitlementMonitorBindingService.GetAppEntitlementMonitorBinding
             requestBody:
                 content:
@@ -25304,7 +30257,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.accessconflict.v1.AppEntitlementMonitorBinding'
-                    description: Successful response
+                    description: Represents the association of an app entitlement with one side (A or B) of a conflict monitor.
             summary: Get App Entitlement Monitor Binding
             tags:
                 - App Entitlement Monitor Binding
@@ -25371,14 +30324,14 @@ paths:
             x-speakeasy-name-override: Create
     /api/v1/apps/{app_id}/access_request_defaults:
         get:
-            description: Invokes the c1.api.app.v1.AppAccessRequestsDefaultsService.GetAppAccessRequestsDefaults method.
+            description: Retrieve the current access request default settings for an app.
             operationId: c1.api.app.v1.AppAccessRequestsDefaultsService.GetAppAccessRequestsDefaults
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app to retrieve access request defaults for.
                     readOnly: false
                     type: string
             responses:
@@ -25394,7 +30347,7 @@ paths:
             x-speakeasy-group: AppAccessRequestsDefaults
             x-speakeasy-name-override: GetAppAccessRequestsDefaults
         post:
-            description: Invokes the c1.api.app.v1.AppAccessRequestsDefaultsService.CreateAppAccessRequestsDefaults method.
+            description: Create or replace the access request default settings for an app.
             operationId: c1.api.app.v1.AppAccessRequestsDefaultsService.CreateAppAccessRequestsDefaults
             parameters:
                 - in: path
@@ -25423,14 +30376,14 @@ paths:
             x-speakeasy-name-override: CreateAppAccessRequestsDefaults
     /api/v1/apps/{app_id}/access_request_defaults/cancel:
         post:
-            description: Invokes the c1.api.app.v1.AppAccessRequestsDefaultsService.CancelAppAccessRequestsDefaults method.
+            description: Cancel an in-progress apply operation for the app's access request defaults.
             operationId: c1.api.app.v1.AppAccessRequestsDefaultsService.CancelAppAccessRequestsDefaults
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app whose access request defaults apply operation should be cancelled.
                     readOnly: false
                     type: string
             requestBody:
@@ -25452,27 +30405,27 @@ paths:
             x-speakeasy-name-override: CancelAppAccessRequestsDefaults
     /api/v1/apps/{app_id}/app_users:
         get:
-            description: Invokes the c1.api.app.v1.AppUserService.List method.
+            description: List app user accounts within a specific app, with pagination support.
             operationId: c1.api.app.v1.AppUserService.List
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app to list users for.
                     readOnly: false
                     type: string
                 - in: query
                   name: page_size
                   schema:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 - in: query
                   name: page_token
                   schema:
-                    description: The pageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             responses:
@@ -25481,7 +30434,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.AppUserServiceListResponse'
-                    description: Successful response
+                    description: The response message for listing app users.
             summary: List
             tags:
                 - AppUsers
@@ -25489,34 +30442,34 @@ paths:
             x-speakeasy-name-override: List
     /api/v1/apps/{app_id}/app_users/{app_user_id}/credentials:
         get:
-            description: Invokes the c1.api.app.v1.AppUserService.ListAppUserCredentials method.
+            description: List credentials associated with a specific app user account.
             operationId: c1.api.app.v1.AppUserService.ListAppUserCredentials
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that the user belongs to.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_user_id
                   required: true
                   schema:
-                    description: The appUserId field.
+                    description: The ID of the app user whose credentials to list.
                     readOnly: false
                     type: string
                 - in: query
                   name: page_size
                   schema:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 - in: query
                   name: page_token
                   schema:
-                    description: The pageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             responses:
@@ -25525,7 +30478,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.AppUserServiceListCredentialsResponse'
-                    description: Successful response
+                    description: The response message for listing credentials of an app user.
             summary: List App User Credentials
             tags:
                 - AppUsers
@@ -25598,7 +30551,7 @@ paths:
             x-speakeasy-name-override: CreateDelegated
     /api/v1/apps/{app_id}/connectors/{connector_id}/confirm_sync_valid/{sync_lifecycle_id}:
         post:
-            description: Invokes the c1.api.app.v1.ConnectorService.ConfirmSyncValid method.
+            description: Confirm that a sync which errored due to a data drop is valid, overriding the error and triggering a new sync. Only applicable when the sync status is ERRORED_NO_DATA.
             operationId: c1.api.app.v1.ConnectorService.ConfirmSyncValid
             parameters:
                 - in: path
@@ -25633,7 +30586,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.ConfirmSyncValidResponse'
-                    description: Successful response
+                    description: Empty response body. Status code indicates success.
             summary: Confirm Sync Valid
             tags:
                 - Connector
@@ -25730,7 +30683,7 @@ paths:
             x-speakeasy-name-override: RevokeCredential
     /api/v1/apps/{app_id}/connectors/{connector_id}/force_sync:
         post:
-            description: Invokes the c1.api.app.v1.ConnectorService.ForceSync method.
+            description: Trigger an immediate sync for a connector. The sync is queued and may not start instantly.
             operationId: c1.api.app.v1.ConnectorService.ForceSync
             parameters:
                 - in: path
@@ -25758,7 +30711,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.ForceSyncResponse'
-                    description: Successful response
+                    description: Empty response body. Status code indicates success.
             summary: Force Sync
             tags:
                 - Connector
@@ -25766,7 +30719,7 @@ paths:
             x-speakeasy-name-override: ForceSync
     /api/v1/apps/{app_id}/connectors/{connector_id}/pause:
         post:
-            description: Invokes the c1.api.app.v1.ConnectorService.PauseSync method.
+            description: Pause syncing and provisioning for a connector. No new syncs or grant/revoke operations will run until the connector is resumed.
             operationId: c1.api.app.v1.ConnectorService.PauseSync
             parameters:
                 - in: path
@@ -25794,7 +30747,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.PauseSyncResponse'
-                    description: Successful response
+                    description: Empty response body. Status code indicates success.
             summary: Pause Sync
             tags:
                 - Connector
@@ -25802,7 +30755,7 @@ paths:
             x-speakeasy-name-override: PauseSync
     /api/v1/apps/{app_id}/connectors/{connector_id}/resume:
         post:
-            description: Invokes the c1.api.app.v1.ConnectorService.ResumeSync method.
+            description: Resume syncing and provisioning for a connector that was previously paused. Clears the paused state and triggers a new sync.
             operationId: c1.api.app.v1.ConnectorService.ResumeSync
             parameters:
                 - in: path
@@ -25830,7 +30783,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.ResumeSyncResponse'
-                    description: Successful response
+                    description: Empty response body. Status code indicates success.
             summary: Resume Sync
             tags:
                 - Connector
@@ -25838,21 +30791,21 @@ paths:
             x-speakeasy-name-override: ResumeSync
     /api/v1/apps/{app_id}/connectors/{connector_id}/schedule:
         post:
-            description: Invokes the c1.api.app.v1.ConnectorService.UpdateConnectorSchedule method.
+            description: Update the sync schedule for a connector.
             operationId: c1.api.app.v1.ConnectorService.UpdateConnectorSchedule
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The appId of the app the connector is attached to.
                     readOnly: false
                     type: string
                 - in: path
                   name: connector_id
                   required: true
                   schema:
-                    description: The connectorId field.
+                    description: The connectorId of the connector whose schedule is being updated.
                     readOnly: false
                     type: string
             requestBody:
@@ -25866,7 +30819,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.UpdateConnectorScheduleResponse'
-                    description: Successful response
+                    description: Empty response body. Status code indicates success.
             summary: Update Connector Schedule
             tags:
                 - Connector
@@ -26079,14 +31032,14 @@ paths:
             x-speakeasy-group: AppEntitlements
             x-speakeasy-name-override: List
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlements.Create method.
+            description: Create a new app entitlement for an app. This is used to define a custom permission, group, or role within the app.
             operationId: c1.api.app.v1.AppEntitlements.Create
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app to create the entitlement in.
                     readOnly: false
                     type: string
             requestBody:
@@ -26112,21 +31065,21 @@ paths:
             x-speakeasy-name-override: Create
     /api/v1/apps/{app_id}/entitlements/{app_entitlement_id}/add-manual-user:
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlements.AddManuallyManagedMembers method.
+            description: Add users as manually managed members of an app entitlement. These memberships are tracked directly by ConductorOne rather than synced from the app.
             operationId: c1.api.app.v1.AppEntitlements.AddManuallyManagedMembers
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement to add manually managed members to.
                     readOnly: false
                     type: string
             requestBody:
@@ -26148,21 +31101,21 @@ paths:
             x-speakeasy-name-override: AddManuallyManagedMembers
     /api/v1/apps/{app_id}/entitlements/{app_entitlement_id}/automation:
         delete:
-            description: Invokes the c1.api.app.v1.AppEntitlements.DeleteAutomation method.
+            description: Delete the automation rule for an app entitlement.
             operationId: c1.api.app.v1.AppEntitlements.DeleteAutomation
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement whose automation to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -26187,7 +31140,7 @@ paths:
             x-speakeasy-group: AppEntitlements
             x-speakeasy-name-override: DeleteAutomation
         get:
-            description: Invokes the c1.api.app.v1.AppEntitlements.GetAutomation method.
+            description: Get the automation rule for an app entitlement.
             operationId: c1.api.app.v1.AppEntitlements.GetAutomation
             parameters:
                 - in: path
@@ -26223,21 +31176,21 @@ paths:
             x-speakeasy-name-override: GetAutomation
     /api/v1/apps/{app_id}/entitlements/{app_entitlement_id}/automation/create:
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlements.CreateAutomation method.
+            description: Create an automation rule for an app entitlement. Automations automatically provision or revoke access based on defined conditions.
             operationId: c1.api.app.v1.AppEntitlements.CreateAutomation
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement to create an automation for.
                     readOnly: false
                     type: string
             requestBody:
@@ -26263,21 +31216,21 @@ paths:
             x-speakeasy-name-override: CreateAutomation
     /api/v1/apps/{app_id}/entitlements/{app_entitlement_id}/automation/exclusions:
         delete:
-            description: Invokes the c1.api.app.v1.AppEntitlements.RemoveAutomationExclusion method.
+            description: Remove users from the automation exclusion list for an app entitlement.
             operationId: c1.api.app.v1.AppEntitlements.RemoveAutomationExclusion
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement whose automation exclusion list to update.
                     readOnly: false
                     type: string
             requestBody:
@@ -26298,21 +31251,21 @@ paths:
             x-speakeasy-group: AppEntitlements
             x-speakeasy-name-override: RemoveAutomationExclusion
         get:
-            description: Invokes the c1.api.app.v1.AppEntitlements.ListAutomationExclusions method.
+            description: List users who are excluded from the automation rule for an app entitlement.
             operationId: c1.api.app.v1.AppEntitlements.ListAutomationExclusions
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement to list exclusions for.
                     readOnly: false
                     type: string
             responses:
@@ -26328,21 +31281,21 @@ paths:
             x-speakeasy-group: AppEntitlements
             x-speakeasy-name-override: ListAutomationExclusions
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlements.AddAutomationExclusion method.
+            description: Add users to the automation exclusion list for an app entitlement. Excluded users are not affected by the automation rule.
             operationId: c1.api.app.v1.AppEntitlements.AddAutomationExclusion
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement whose automation exclusion list to update.
                     readOnly: false
                     type: string
             requestBody:
@@ -26364,7 +31317,7 @@ paths:
             x-speakeasy-name-override: AddAutomationExclusion
     /api/v1/apps/{app_id}/entitlements/{app_entitlement_id}/automation/update:
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlements.UpdateAutomation method.
+            description: Update the automation rule for an app entitlement, including its display name, description, and conditions.
             operationId: c1.api.app.v1.AppEntitlements.UpdateAutomation
             parameters:
                 - in: path
@@ -26448,21 +31401,21 @@ paths:
             x-speakeasy-name-override: SearchAppEntitlementsWithExpired
     /api/v1/apps/{app_id}/entitlements/{app_entitlement_id}/remove-membership:
         delete:
-            description: Invokes the c1.api.app.v1.AppEntitlements.RemoveEntitlementMembership method.
+            description: Remove a user from a ConductorOne-managed entitlement (catalog, group, or profile type). For access profiles, this creates a revoke task to deprovision access.
             operationId: c1.api.app.v1.AppEntitlements.RemoveEntitlementMembership
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the app entitlement to remove the membership from.
                     readOnly: false
                     type: string
             requestBody:
@@ -26534,28 +31487,28 @@ paths:
             x-speakeasy-name-override: ListUsers
     /api/v1/apps/{app_id}/entitlements/{app_entitlement_id}/users/{app_user_id}/remove-grant-duration:
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlementUserBindingService.RemoveGrantDuration method.
+            description: Remove the expiration time from a grant, converting it to an indefinite (standing) grant.
             operationId: c1.api.app.v1.AppEntitlementUserBindingService.RemoveGrantDuration
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that owns the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the entitlement whose grant duration is being removed.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_user_id
                   required: true
                   schema:
-                    description: The appUserId field.
+                    description: The ID of the app user whose grant expiration is being removed.
                     readOnly: false
                     type: string
             requestBody:
@@ -26569,7 +31522,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.RemoveGrantDurationResponse'
-                    description: Successful response
+                    description: The response message for removing the expiration time from a grant.
             summary: Remove Grant Duration
             tags:
                 - App Entitlement User Binding
@@ -26577,28 +31530,28 @@ paths:
             x-speakeasy-name-override: RemoveGrantDuration
     /api/v1/apps/{app_id}/entitlements/{app_entitlement_id}/users/{app_user_id}/update-grant-duration:
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlementUserBindingService.UpdateGrantDuration method.
+            description: Update the expiration time of an existing grant, changing when automatic revocation will occur.
             operationId: c1.api.app.v1.AppEntitlementUserBindingService.UpdateGrantDuration
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that owns the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_entitlement_id
                   required: true
                   schema:
-                    description: The appEntitlementId field.
+                    description: The ID of the entitlement whose grant duration is being updated.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_user_id
                   required: true
                   schema:
-                    description: The appUserId field.
+                    description: The ID of the app user whose grant is being updated.
                     readOnly: false
                     type: string
             requestBody:
@@ -26612,7 +31565,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.UpdateGrantDurationResponse'
-                    description: Successful response
+                    description: The response message for updating the duration of a grant.
             summary: Update Grant Duration
             tags:
                 - App Entitlement User Binding
@@ -26899,21 +31852,21 @@ paths:
             x-speakeasy-name-override: Remove
     /api/v1/apps/{app_id}/entitlements/{id}:
         delete:
-            description: Invokes the c1.api.app.v1.AppEntitlements.Delete method.
+            description: Delete an app entitlement by ID.
             operationId: c1.api.app.v1.AppEntitlements.Delete
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that contains the entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the app entitlement to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -27415,14 +32368,14 @@ paths:
             x-speakeasy-group: AppResourceType
             x-speakeasy-name-override: List
         post:
-            description: Invokes the c1.api.app.v1.AppResourceTypeService.CreateManuallyManagedResourceType method.
+            description: Create a manually managed resource type that classifies resources within an app.
             operationId: c1.api.app.v1.AppResourceTypeService.CreateManuallyManagedResourceType
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app to create the resource type under.
                     readOnly: false
                     type: string
             requestBody:
@@ -27436,7 +32389,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.CreateManuallyManagedResourceTypeResponse'
-                    description: Successful response
+                    description: The response message for creating a manually managed resource type.
             summary: Create Manually Managed Resource Type
             tags:
                 - App Resource Type
@@ -27448,34 +32401,34 @@ paths:
             x-speakeasy-name-override: CreateManuallyManagedResourceType
     /api/v1/apps/{app_id}/resource_types/{app_resource_type_id}/resources:
         get:
-            description: Invokes the c1.api.app.v1.AppResourceService.List method.
+            description: List app resources for a given app and optionally filter by resource type.
             operationId: c1.api.app.v1.AppResourceService.List
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app to list resources for.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_resource_type_id
                   required: true
                   schema:
-                    description: The appResourceTypeId field.
+                    description: Optional resource type ID to filter results by. If empty, resources of all types are returned.
                     readOnly: false
                     type: string
                 - in: query
                   name: page_size
                   schema:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 - in: query
                   name: page_token
                   schema:
-                    description: The pageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             responses:
@@ -27491,21 +32444,21 @@ paths:
             x-speakeasy-group: AppResource
             x-speakeasy-name-override: List
         post:
-            description: Invokes the c1.api.app.v1.AppResourceService.CreateManuallyManagedAppResource method.
+            description: Create a manually managed app resource tracked directly by ConductorOne under an existing resource type.
             operationId: c1.api.app.v1.AppResourceService.CreateManuallyManagedAppResource
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app to create the resource under.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_resource_type_id
                   required: true
                   schema:
-                    description: The appResourceTypeId field.
+                    description: The resource type ID that classifies this resource.
                     readOnly: false
                     type: string
             requestBody:
@@ -27519,7 +32472,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.CreateManuallyManagedAppResourceResponse'
-                    description: Successful response
+                    description: The response message for creating a manually managed app resource.
             summary: Create Manually Managed App Resource
             tags:
                 - App Resource
@@ -27531,28 +32484,28 @@ paths:
             x-speakeasy-name-override: CreateManuallyManagedAppResource
     /api/v1/apps/{app_id}/resource_types/{app_resource_type_id}/resources/{id}:
         delete:
-            description: Invokes the c1.api.app.v1.AppResourceService.DeleteManuallyManagedAppResource method.
+            description: Delete a manually managed app resource and its associated entitlements from an app.
             operationId: c1.api.app.v1.AppResourceService.DeleteManuallyManagedAppResource
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that owns the resource.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_resource_type_id
                   required: true
                   schema:
-                    description: The appResourceTypeId field.
+                    description: The ID of the resource type that classifies the resource.
                     readOnly: false
                     type: string
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The appResourceId field.
+                    description: The ID of the app resource to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -27566,7 +32519,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.DeleteManuallyManagedAppResourceResponse'
-                    description: Successful response
+                    description: The empty response message for deleting a manually managed app resource.
             summary: Delete Manually Managed App Resource
             tags:
                 - App Resource
@@ -27577,28 +32530,28 @@ paths:
             x-speakeasy-group: AppResource
             x-speakeasy-name-override: DeleteManuallyManagedAppResource
         get:
-            description: Invokes the c1.api.app.v1.AppResourceService.Get method.
+            description: Retrieve a single app resource by its app, resource type, and resource ID.
             operationId: c1.api.app.v1.AppResourceService.Get
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that owns the resource.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_resource_type_id
                   required: true
                   schema:
-                    description: The appResourceTypeId field.
+                    description: The ID of the resource type that classifies this resource.
                     readOnly: false
                     type: string
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique ID of the app resource to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -27619,7 +32572,7 @@ paths:
             x-speakeasy-group: AppResource
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.app.v1.AppResourceService.Update method.
+            description: Update an app resource's fields. Only the fields specified in the update mask are modified.
             operationId: c1.api.app.v1.AppResourceService.Update
             parameters:
                 - in: path
@@ -27654,7 +32607,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.AppResourceServiceUpdateResponse'
-                    description: Successful response
+                    description: The response message for updating an app resource.
             summary: Update
             tags:
                 - App Resource
@@ -27666,21 +32619,21 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/apps/{app_id}/resource_types/{id}:
         delete:
-            description: Invokes the c1.api.app.v1.AppResourceTypeService.DeleteManuallyManagedResourceType method.
+            description: Delete a manually managed resource type and all its associated resources from an app.
             operationId: c1.api.app.v1.AppResourceTypeService.DeleteManuallyManagedResourceType
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that owns the resource type.
                     readOnly: false
                     type: string
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The resourceTypeId field.
+                    description: The ID of the resource type to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -27694,7 +32647,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.DeleteManuallyManagedResourceTypeResponse'
-                    description: Successful response
+                    description: The empty response message for deleting a manually managed resource type.
             summary: Delete Manually Managed Resource Type
             tags:
                 - App Resource Type
@@ -27742,7 +32695,7 @@ paths:
             x-speakeasy-group: AppResourceType
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.app.v1.AppResourceTypeService.UpdateManuallyManagedResourceType method.
+            description: Update a manually managed resource type's fields. Only the fields specified in the update mask are modified.
             operationId: c1.api.app.v1.AppResourceTypeService.UpdateManuallyManagedResourceType
             parameters:
                 - in: path
@@ -27770,7 +32723,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.UpdateManuallyManagedResourceTypeResponse'
-                    description: Successful response
+                    description: The response message for updating a manually managed resource type.
             summary: Update Manually Managed Resource Type
             tags:
                 - App Resource Type
@@ -27871,28 +32824,28 @@ paths:
             x-speakeasy-name-override: ListOwnerIDs
     /api/v1/apps/{app_id}/resource_types/{resource_type_id}/resource/{resource_id}/owners:
         delete:
-            description: Invokes the c1.api.app.v1.AppResourceOwners.Remove method.
+            description: Remove a user from the owners of an app resource.
             operationId: c1.api.app.v1.AppResourceOwners.Remove
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that owns the resource.
                     readOnly: false
                     type: string
                 - in: path
                   name: resource_type_id
                   required: true
                   schema:
-                    description: The resourceTypeId field.
+                    description: The ID of the resource type that classifies the resource.
                     readOnly: false
                     type: string
                 - in: path
                   name: resource_id
                   required: true
                   schema:
-                    description: The resourceId field.
+                    description: The ID of the app resource to remove an owner from.
                     readOnly: false
                     type: string
             requestBody:
@@ -27906,7 +32859,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.RemoveAppResourceOwnerResponse'
-                    description: Successful response
+                    description: The empty response message for removing an owner from an app resource.
             summary: Remove
             tags:
                 - App Resource Owner
@@ -27968,28 +32921,28 @@ paths:
             x-speakeasy-group: AppResourceOwners
             x-speakeasy-name-override: List
         post:
-            description: Invokes the c1.api.app.v1.AppResourceOwners.Add method.
+            description: Add a user as an owner of an app resource.
             operationId: c1.api.app.v1.AppResourceOwners.Add
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app that owns the resource.
                     readOnly: false
                     type: string
                 - in: path
                   name: resource_type_id
                   required: true
                   schema:
-                    description: The resourceTypeId field.
+                    description: The ID of the resource type that classifies the resource.
                     readOnly: false
                     type: string
                 - in: path
                   name: resource_id
                   required: true
                   schema:
-                    description: The resourceId field.
+                    description: The ID of the app resource to add an owner to.
                     readOnly: false
                     type: string
             requestBody:
@@ -28003,7 +32956,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.AddAppResourceOwnerResponse'
-                    description: Successful response
+                    description: The empty response message for adding an owner to an app resource.
             summary: Add
             tags:
                 - App Resource Owner
@@ -28109,34 +33062,34 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/apps/{app_id}/users/{user_id}/app_users:
         get:
-            description: Invokes the c1.api.app.v1.AppUserService.ListAppUsersForUser method.
+            description: List app user accounts within a specific app that are correlated to a given C1 user.
             operationId: c1.api.app.v1.AppUserService.ListAppUsersForUser
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app to list users for.
                     readOnly: false
                     type: string
                 - in: path
                   name: user_id
                   required: true
                   schema:
-                    description: The userId field.
+                    description: The C1 user ID to filter app users by identity correlation.
                     readOnly: false
                     type: string
                 - in: query
                   name: page_size
                   schema:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 - in: query
                   name: page_token
                   schema:
-                    description: The pageToken field.
+                    description: The token for fetching the next page of results.
                     readOnly: false
                     type: string
             responses:
@@ -28145,7 +33098,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.AppUsersForUserServiceListResponse'
-                    description: Successful response
+                    description: The response message for listing app users correlated to a specific C1 user.
             summary: List App Users For User
             tags:
                 - AppUsers
@@ -28320,35 +33273,35 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/apps/{src_app_id}/{src_app_entitlement_id}/bindings/{dst_app_id}/{dst_app_entitlement_id}:
         delete:
-            description: Invokes the c1.api.app.v1.AppEntitlementsProxy.Delete method.
+            description: Delete a proxy binding between a source and destination entitlement.
             operationId: c1.api.app.v1.AppEntitlementsProxy.Delete
             parameters:
                 - in: path
                   name: src_app_id
                   required: true
                   schema:
-                    description: The srcAppId field.
+                    description: The ID of the app that owns the source entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: src_app_entitlement_id
                   required: true
                   schema:
-                    description: The srcAppEntitlementId field.
+                    description: The ID of the source (parent) entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: dst_app_id
                   required: true
                   schema:
-                    description: The dstAppId field.
+                    description: The ID of the app that owns the destination entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: dst_app_entitlement_id
                   required: true
                   schema:
-                    description: The dstAppEntitlementId field.
+                    description: The ID of the destination (child) entitlement.
                     readOnly: false
                     type: string
             requestBody:
@@ -28362,7 +33315,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.DeleteAppEntitlementProxyResponse'
-                    description: Successful response
+                    description: The empty response message for deleting an entitlement proxy binding.
             summary: Delete
             tags:
                 - App Entitlement Proxy Binding
@@ -28373,35 +33326,35 @@ paths:
             x-speakeasy-group: AppEntitlementsProxy
             x-speakeasy-name-override: Delete
         get:
-            description: Invokes the c1.api.app.v1.AppEntitlementsProxy.Get method.
+            description: Retrieve a specific proxy binding between a source and destination entitlement.
             operationId: c1.api.app.v1.AppEntitlementsProxy.Get
             parameters:
                 - in: path
                   name: src_app_id
                   required: true
                   schema:
-                    description: The srcAppId field.
+                    description: The ID of the app that owns the source entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: src_app_entitlement_id
                   required: true
                   schema:
-                    description: The srcAppEntitlementId field.
+                    description: The ID of the source (parent) entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: dst_app_id
                   required: true
                   schema:
-                    description: The dstAppId field.
+                    description: The ID of the app that owns the destination entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: dst_app_entitlement_id
                   required: true
                   schema:
-                    description: The dstAppEntitlementId field.
+                    description: The ID of the destination (child) entitlement.
                     readOnly: false
                     type: string
             responses:
@@ -28410,7 +33363,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.GetAppEntitlementProxyResponse'
-                    description: Successful response
+                    description: The response message for getting a specific entitlement proxy binding.
             summary: Get
             tags:
                 - App Entitlement Proxy Binding
@@ -28422,35 +33375,35 @@ paths:
             x-speakeasy-group: AppEntitlementsProxy
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlementsProxy.Create method.
+            description: Create a proxy binding between a source and destination entitlement, establishing a hierarchical relationship.
             operationId: c1.api.app.v1.AppEntitlementsProxy.Create
             parameters:
                 - in: path
                   name: src_app_id
                   required: true
                   schema:
-                    description: The srcAppId field.
+                    description: The ID of the app that owns the source entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: src_app_entitlement_id
                   required: true
                   schema:
-                    description: The srcAppEntitlementId field.
+                    description: The ID of the source (parent) entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: dst_app_id
                   required: true
                   schema:
-                    description: The dstAppId field.
+                    description: The ID of the app that owns the destination entitlement.
                     readOnly: false
                     type: string
                 - in: path
                   name: dst_app_entitlement_id
                   required: true
                   schema:
-                    description: The dstAppEntitlementId field.
+                    description: The ID of the destination (child) entitlement.
                     readOnly: false
                     type: string
             requestBody:
@@ -28464,7 +33417,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.CreateAppEntitlementProxyResponse'
-                    description: Successful response
+                    description: The response message for creating an entitlement proxy binding.
             summary: Create
             tags:
                 - App Entitlement Proxy Binding
@@ -28501,7 +33454,7 @@ paths:
             x-speakeasy-name-override: RotateCredential
     /api/v1/apps/connectors/validate_config/http:
         post:
-            description: Invokes the c1.api.app.v1.ConnectorService.ValidateHTTPConnectorConfig method.
+            description: Validate an HTTP connector configuration and return any diagnostics or errors found.
             operationId: c1.api.app.v1.ConnectorService.ValidateHTTPConnectorConfig
             requestBody:
                 content:
@@ -28514,7 +33467,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.EditorValidateResponse'
-                    description: Successful response
+                    description: The EditorValidateResponse message contains validation results.
             summary: Validate Http Connector Config
             tags:
                 - Connector
@@ -28596,7 +33549,7 @@ paths:
             x-speakeasy-name-override: GetAttributeValue
     /api/v1/attributes/compliance_frameworks:
         get:
-            description: Invokes the c1.api.attribute.v1.Attributes.ListComplianceFrameworks method.
+            description: List all compliance framework attribute values (e.g., SOC 2, HIPAA) with pagination.
             operationId: c1.api.attribute.v1.Attributes.ListComplianceFrameworks
             parameters:
                 - in: query
@@ -28618,7 +33571,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.attribute.v1.ListComplianceFrameworksResponse'
-                    description: Successful response
+                    description: ListComplianceFrameworksResponse is the response for listing compliance framework attribute values.
             summary: List Compliance Frameworks
             tags:
                 - Compliance Framework
@@ -28716,7 +33669,7 @@ paths:
             x-speakeasy-name-override: GetComplianceFrameworkAttributeValue
     /api/v1/attributes/risk_levels:
         get:
-            description: Invokes the c1.api.attribute.v1.Attributes.ListRiskLevels method.
+            description: List all risk level attribute values with pagination.
             operationId: c1.api.attribute.v1.Attributes.ListRiskLevels
             parameters:
                 - in: query
@@ -28738,7 +33691,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.attribute.v1.ListRiskLevelsResponse'
-                    description: Successful response
+                    description: ListRiskLevelsResponse is the response for listing risk level attribute values.
             summary: List Risk Levels
             tags:
                 - Risk Level
@@ -28901,6 +33854,136 @@ paths:
                 - Attribute
             x-speakeasy-group: Attributes
             x-speakeasy-name-override: ListAttributeValues
+    /api/v1/auth-configs:
+        get:
+            description: List returns all authentication provider configurations for the tenant.
+            operationId: c1.api.auth_config.v1.TenantAuthConfigService.List
+            parameters:
+                - in: query
+                  name: page_size
+                  schema:
+                    description: The maximum number of results to return per page.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: A pagination token returned from a previous List call.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfigServiceListResponse'
+                    description: Successful response
+            summary: List
+            tags:
+                - Auth Config
+            x-speakeasy-group: TenantAuthConfig
+            x-speakeasy-name-override: List
+        post:
+            description: Create registers a new authentication provider configuration for the tenant.
+            operationId: c1.api.auth_config.v1.TenantAuthConfigService.Create
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfigServiceCreateRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfigServiceCreateResponse'
+                    description: Successful response
+            summary: Create
+            tags:
+                - Auth Config
+            x-speakeasy-group: TenantAuthConfig
+            x-speakeasy-name-override: Create
+    /api/v1/auth-configs/{id}:
+        delete:
+            description: Delete removes an authentication provider configuration from the tenant.
+            operationId: c1.api.auth_config.v1.TenantAuthConfigService.Delete
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The unique identifier of the authentication provider configuration to delete.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfigServiceDeleteRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfigServiceDeleteResponse'
+                    description: Successful response
+            summary: Delete
+            tags:
+                - Auth Config
+            x-speakeasy-group: TenantAuthConfig
+            x-speakeasy-name-override: Delete
+        get:
+            description: Get retrieves a single authentication provider configuration by its ID.
+            operationId: c1.api.auth_config.v1.TenantAuthConfigService.Get
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The unique identifier of the authentication provider configuration to retrieve.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfigServiceGetResponse'
+                    description: Successful response
+            summary: Get
+            tags:
+                - Auth Config
+            x-speakeasy-group: TenantAuthConfig
+            x-speakeasy-name-override: Get
+        post:
+            description: Update modifies an existing authentication provider configuration. Use the update mask to specify which fields to change.
+            operationId: c1.api.auth_config.v1.TenantAuthConfigService.Update
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfigServiceUpdateRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.auth_config.v1.TenantAuthConfigServiceUpdateResponse'
+                    description: Successful response
+            summary: Update
+            tags:
+                - Auth Config
+            x-speakeasy-group: TenantAuthConfig
+            x-speakeasy-name-override: Update
     /api/v1/auth/introspect:
         get:
             description: Introspect returns the current user's principle_id, user_id and a list of roles, permissions, and enabled features.
@@ -28919,7 +34002,7 @@ paths:
             x-speakeasy-name-override: Introspect
     /api/v1/automation_executions:
         get:
-            description: Invokes the c1.api.automations.v1.AutomationExecutionService.ListAutomationExecutions method.
+            description: List all automation executions in the tenant with pagination support.
             operationId: c1.api.automations.v1.AutomationExecutionService.ListAutomationExecutions
             responses:
                 "200":
@@ -28935,14 +34018,14 @@ paths:
             x-speakeasy-name-override: ListAutomationExecutions
     /api/v1/automation_executions/{id}:
         get:
-            description: Invokes the c1.api.automations.v1.AutomationExecutionService.GetAutomationExecution method.
+            description: Retrieve a single automation execution by its unique identifier, with optional expanded related objects.
             operationId: c1.api.automations.v1.AutomationExecutionService.GetAutomationExecution
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the automation execution to retrieve.
                     format: int64
                     readOnly: false
                     type: string
@@ -28960,14 +34043,14 @@ paths:
             x-speakeasy-name-override: GetAutomationExecution
     /api/v1/automation_executions/{id}/actions/terminate:
         post:
-            description: Invokes the c1.api.automations.v1.AutomationExecutionActionsService.TerminateAutomation method.
+            description: Terminate a running automation execution asynchronously, stopping it and marking it as terminated.
             operationId: c1.api.automations.v1.AutomationExecutionActionsService.TerminateAutomation
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the automation execution to terminate.
                     format: int64
                     readOnly: false
                     type: string
@@ -28990,7 +34073,7 @@ paths:
             x-speakeasy-name-override: TerminateAutomation
     /api/v1/automations:
         get:
-            description: Invokes the c1.api.automations.v1.AutomationService.ListAutomations method.
+            description: List all automations in the tenant with pagination support.
             operationId: c1.api.automations.v1.AutomationService.ListAutomations
             responses:
                 "200":
@@ -29005,7 +34088,7 @@ paths:
             x-speakeasy-group: Automation
             x-speakeasy-name-override: ListAutomations
         post:
-            description: Invokes the c1.api.automations.v1.AutomationService.CreateAutomation method.
+            description: Create a new automation with the specified steps, triggers, and configuration.
             operationId: c1.api.automations.v1.AutomationService.CreateAutomation
             requestBody:
                 content:
@@ -29030,14 +34113,14 @@ paths:
             x-speakeasy-name-override: CreateAutomation
     /api/v1/automations/{id}:
         delete:
-            description: Invokes the c1.api.automations.v1.AutomationService.DeleteAutomation method.
+            description: Delete an automation by its unique identifier, removing it and its associated triggers.
             operationId: c1.api.automations.v1.AutomationService.DeleteAutomation
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the automation to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -29062,14 +34145,14 @@ paths:
             x-speakeasy-group: Automation
             x-speakeasy-name-override: DeleteAutomation
         get:
-            description: Invokes the c1.api.automations.v1.AutomationService.GetAutomation method.
+            description: Retrieve a single automation by its unique identifier.
             operationId: c1.api.automations.v1.AutomationService.GetAutomation
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the automation to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -29090,7 +34173,7 @@ paths:
             x-speakeasy-group: Automation
             x-speakeasy-name-override: GetAutomation
         post:
-            description: Invokes the c1.api.automations.v1.AutomationService.UpdateAutomation method.
+            description: Update an existing automation's properties, steps, or triggers using a field mask.
             operationId: c1.api.automations.v1.AutomationService.UpdateAutomation
             parameters:
                 - in: path
@@ -29123,14 +34206,14 @@ paths:
             x-speakeasy-name-override: UpdateAutomation
     /api/v1/automations/{id}/execute:
         post:
-            description: Invokes the c1.api.automations.v1.AutomationService.ExecuteAutomation method.
+            description: Trigger an on-demand execution of an automation, returning the new execution's identifier.
             operationId: c1.api.automations.v1.AutomationService.ExecuteAutomation
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the automation to execute.
                     readOnly: false
                     type: string
             requestBody:
@@ -29211,14 +34294,14 @@ paths:
             x-speakeasy-name-override: Create
     /api/v1/catalogs/{catalog_id}/requestable_entitlementIDs:
         get:
-            description: Invokes the c1.api.requestcatalog.v1.RequestCatalogManagementService.ListAllEntitlementIdsPerApp method.
+            description: List all requestable entitlement IDs in a catalog without pagination.
             operationId: c1.api.requestcatalog.v1.RequestCatalogManagementService.ListAllEntitlementIdsPerApp
             parameters:
                 - in: path
                   name: catalog_id
                   required: true
                   schema:
-                    description: The catalogId field.
+                    description: The unique identifier of the access profile.
                     readOnly: false
                     type: string
             responses:
@@ -29227,7 +34310,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.requestcatalog.v1.RequestCatalogManagementServiceListAllEntitlementIdsPerCatalogResponse'
-                    description: Successful response
+                    description: The response message containing all requestable entitlement references in the catalog.
             summary: List All Entitlement Ids Per App
             tags:
                 - Request Catalog
@@ -29277,7 +34360,7 @@ paths:
             x-speakeasy-name-override: ListEntitlementsPerCatalog
     /api/v1/catalogs/{catalog_id}/requestable_entitlements/update:
         post:
-            description: Invokes the c1.api.requestcatalog.v1.RequestCatalogManagementService.UpdateAppEntitlements method.
+            description: Replace the full set of requestable entitlements in a catalog with the provided list.
             operationId: c1.api.requestcatalog.v1.RequestCatalogManagementService.UpdateAppEntitlements
             parameters:
                 - in: path
@@ -29510,7 +34593,7 @@ paths:
             x-speakeasy-name-override: CreateRequestableEntry
     /api/v1/catalogs/{catalog_id}/visibility_bindings:
         delete:
-            description: Remove visibility bindings (access entitlements) to a catalog.
+            description: Remove visibility bindings (access entitlements) from a catalog.
             operationId: c1.api.requestcatalog.v1.RequestCatalogManagementService.RemoveAccessEntitlements
             parameters:
                 - in: path
@@ -29705,14 +34788,14 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/catalogs/{request_catalog_id}/bundle_automation:
         delete:
-            description: Invokes the c1.api.requestcatalog.v1.RequestCatalogManagementService.DeleteBundleAutomation method.
+            description: Delete the bundle automation rule for a catalog, stopping automatic membership syncing.
             operationId: c1.api.requestcatalog.v1.RequestCatalogManagementService.DeleteBundleAutomation
             parameters:
                 - in: path
                   name: request_catalog_id
                   required: true
                   schema:
-                    description: The requestCatalogId field.
+                    description: The unique identifier of the access profile whose automation should be deleted.
                     readOnly: false
                     type: string
             requestBody:
@@ -29726,7 +34809,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.requestcatalog.v1.DeleteBundleAutomationResponse'
-                    description: Successful response
+                    description: The response message for deleting a bundle automation.
             summary: Delete Bundle Automation
             tags:
                 - Request Catalog
@@ -29765,14 +34848,14 @@ paths:
             x-speakeasy-group: RequestCatalogManagement
             x-speakeasy-name-override: GetBundleAutomation
         post:
-            description: Invokes the c1.api.requestcatalog.v1.RequestCatalogManagementService.SetBundleAutomation method.
+            description: Create or update the bundle automation rule for a catalog that automatically syncs catalog membership.
             operationId: c1.api.requestcatalog.v1.RequestCatalogManagementService.SetBundleAutomation
             parameters:
                 - in: path
                   name: request_catalog_id
                   required: true
                   schema:
-                    description: The requestCatalogId field.
+                    description: The unique identifier of the access profile to set the automation on.
                     readOnly: false
                     type: string
             requestBody:
@@ -29798,14 +34881,14 @@ paths:
             x-speakeasy-name-override: SetBundleAutomation
     /api/v1/catalogs/{request_catalog_id}/bundle_automation/create:
         post:
-            description: Invokes the c1.api.requestcatalog.v1.RequestCatalogManagementService.CreateBundleAutomation method.
+            description: Create a new bundle automation rule for a catalog that automatically syncs catalog membership from a query.
             operationId: c1.api.requestcatalog.v1.RequestCatalogManagementService.CreateBundleAutomation
             parameters:
                 - in: path
                   name: request_catalog_id
                   required: true
                   schema:
-                    description: The requestCatalogId field.
+                    description: The unique identifier of the access profile to create the automation for.
                     readOnly: false
                     type: string
             requestBody:
@@ -29831,14 +34914,14 @@ paths:
             x-speakeasy-name-override: CreateBundleAutomation
     /api/v1/catalogs/{request_catalog_id}/bundle_automation/resume:
         post:
-            description: Invokes the c1.api.requestcatalog.v1.RequestCatalogManagementService.ResumePausedBundleAutomation method.
+            description: Resume a bundle automation that was paused by the circuit breaker after detecting excessive membership changes.
             operationId: c1.api.requestcatalog.v1.RequestCatalogManagementService.ResumePausedBundleAutomation
             parameters:
                 - in: path
                   name: request_catalog_id
                   required: true
                   schema:
-                    description: The requestCatalogId field.
+                    description: The unique identifier of the access profile whose automation should be resumed.
                     readOnly: false
                     type: string
             requestBody:
@@ -29852,7 +34935,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.requestcatalog.v1.ResumePausedBundleAutomationResponse'
-                    description: Successful response
+                    description: The response message for resuming a paused bundle automation.
             summary: Resume Paused Bundle Automation
             tags:
                 - Request Catalog
@@ -29860,14 +34943,14 @@ paths:
             x-speakeasy-name-override: ResumePausedBundleAutomation
     /api/v1/catalogs/{request_catalog_id}/bundle_automation/run:
         post:
-            description: Invokes the c1.api.requestcatalog.v1.RequestCatalogManagementService.ForceRunBundleAutomation method.
+            description: Trigger an immediate execution of a catalog's bundle automation, bypassing the normal schedule.
             operationId: c1.api.requestcatalog.v1.RequestCatalogManagementService.ForceRunBundleAutomation
             parameters:
                 - in: path
                   name: request_catalog_id
                   required: true
                   schema:
-                    description: The requestCatalogId field.
+                    description: The unique identifier of the access profile whose automation should be run.
                     readOnly: false
                     type: string
             requestBody:
@@ -29881,7 +34964,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.requestcatalog.v1.ForceRunBundleAutomationResponse'
-                    description: Successful response
+                    description: The response message for triggering a bundle automation run.
             summary: Force Run Bundle Automation
             tags:
                 - Request Catalog
@@ -29889,7 +34972,7 @@ paths:
             x-speakeasy-name-override: ForceRunBundleAutomation
     /api/v1/connectorcatalog:
         post:
-            description: Invokes the c1.api.integration.connector.v1.ConnectorCatalogService.ConfigurationSchema method.
+            description: Return the configuration schema describing the fields required to set up a connector of the specified type.
             operationId: c1.api.integration.connector.v1.ConnectorCatalogService.ConfigurationSchema
             requestBody:
                 content:
@@ -29902,7 +34985,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.integration.connector.v1.ConnectorCatalogServiceConfigurationSchemaResponse'
-                    description: Successful response
+                    description: ConnectorCatalogServiceConfigurationSchemaResponse is the response containing the connector's configuration schema.
             summary: Configuration Schema
             tags:
                 - Connector Catalog
@@ -30060,6 +35143,268 @@ paths:
                 terraform-resource: Directory#update
             x-speakeasy-group: Directory
             x-speakeasy-name-override: Update
+    /api/v1/findings/{finding_id}/state:
+        post:
+            description: Update finding workflow state (snooze, accept risk, suppress, reopen, resolve).
+            operationId: c1.api.finding.v1.FindingService.UpdateFindingState
+            parameters:
+                - in: path
+                  name: finding_id
+                  required: true
+                  schema:
+                    description: The ID of the finding whose state to update.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.finding.v1.UpdateFindingStateRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.UpdateFindingStateResponse'
+                    description: Successful response
+            summary: Update Finding State
+            tags:
+                - Findings
+            x-speakeasy-group: Finding
+            x-speakeasy-name-override: UpdateFindingState
+    /api/v1/findings/{finding_id}/task:
+        post:
+            description: Create a task for a finding.
+            operationId: c1.api.finding.v1.FindingService.CreateFindingTask
+            parameters:
+                - in: path
+                  name: finding_id
+                  required: true
+                  schema:
+                    description: The ID of the finding to create a remediation task for.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.finding.v1.CreateFindingTaskRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.CreateFindingTaskResponse'
+                    description: Successful response
+            summary: Create Finding Task
+            tags:
+                - Findings
+            x-speakeasy-group: Finding
+            x-speakeasy-name-override: CreateFindingTask
+    /api/v1/findings/{id}:
+        get:
+            description: Get a single finding by ID.
+            operationId: c1.api.finding.v1.FindingService.GetFinding
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The ID of the finding to retrieve.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.GetFindingResponse'
+                    description: Successful response
+            summary: Get Finding
+            tags:
+                - Findings
+            x-speakeasy-group: Finding
+            x-speakeasy-name-override: GetFinding
+    /api/v1/findings/bulk/state:
+        post:
+            description: Bulk update finding states.
+            operationId: c1.api.finding.v1.FindingService.BulkUpdateFindingState
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.finding.v1.BulkUpdateFindingStateRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.BulkUpdateFindingStateResponse'
+                    description: Successful response
+            summary: Bulk Update Finding State
+            tags:
+                - Findings
+            x-speakeasy-group: Finding
+            x-speakeasy-name-override: BulkUpdateFindingState
+    /api/v1/findings/bulk/tasks:
+        post:
+            description: Bulk create tasks for findings.
+            operationId: c1.api.finding.v1.FindingService.BulkCreateFindingTasks
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.finding.v1.BulkCreateFindingTasksRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.BulkCreateFindingTasksResponse'
+                    description: Successful response
+            summary: Bulk Create Finding Tasks
+            tags:
+                - Findings
+            x-speakeasy-group: Finding
+            x-speakeasy-name-override: BulkCreateFindingTasks
+    /api/v1/findings/routing-rules:
+        get:
+            description: List finding routing rules, optionally filtered to a specific app.
+            operationId: c1.api.finding.v1.FindingRoutingRuleService.ListFindingRoutingRules
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.ListFindingRoutingRulesResponse'
+                    description: Successful response
+            summary: List Finding Routing Rules
+            tags:
+                - Finding Routing Rules
+            x-speakeasy-group: FindingRoutingRule
+            x-speakeasy-name-override: ListFindingRoutingRules
+        post:
+            description: Create a new finding routing rule that defines which policy to use for auto-routing matching findings.
+            operationId: c1.api.finding.v1.FindingRoutingRuleService.CreateFindingRoutingRule
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.finding.v1.CreateFindingRoutingRuleRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.CreateFindingRoutingRuleResponse'
+                    description: Successful response
+            summary: Create Finding Routing Rule
+            tags:
+                - Finding Routing Rules
+            x-speakeasy-group: FindingRoutingRule
+            x-speakeasy-name-override: CreateFindingRoutingRule
+    /api/v1/findings/routing-rules/{id}:
+        delete:
+            description: Delete a finding routing rule. Findings already routed by this rule are not affected.
+            operationId: c1.api.finding.v1.FindingRoutingRuleService.DeleteFindingRoutingRule
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The ID of the finding routing rule to delete.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.finding.v1.DeleteFindingRoutingRuleRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.DeleteFindingRoutingRuleResponse'
+                    description: Successful response
+            summary: Delete Finding Routing Rule
+            tags:
+                - Finding Routing Rules
+            x-speakeasy-group: FindingRoutingRule
+            x-speakeasy-name-override: DeleteFindingRoutingRule
+        get:
+            description: Retrieve a single finding routing rule by ID.
+            operationId: c1.api.finding.v1.FindingRoutingRuleService.GetFindingRoutingRule
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The ID of the finding routing rule to retrieve.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.GetFindingRoutingRuleResponse'
+                    description: Successful response
+            summary: Get Finding Routing Rule
+            tags:
+                - Finding Routing Rules
+            x-speakeasy-group: FindingRoutingRule
+            x-speakeasy-name-override: GetFindingRoutingRule
+    /api/v1/findings/routing-rules/{routing_rule_id}/update:
+        post:
+            description: Update an existing finding routing rule's match criteria or target policy.
+            operationId: c1.api.finding.v1.FindingRoutingRuleService.UpdateFindingRoutingRule
+            parameters:
+                - in: path
+                  name: routing_rule_id
+                  required: true
+                  schema:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.finding.v1.UpdateFindingRoutingRuleRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.UpdateFindingRoutingRuleResponse'
+                    description: Successful response
+            summary: Update Finding Routing Rule
+            tags:
+                - Finding Routing Rules
+            x-speakeasy-group: FindingRoutingRule
+            x-speakeasy-name-override: UpdateFindingRoutingRule
+    /api/v1/findings/search:
+        post:
+            description: Search findings using full-text query and filters for severity, state, type, and app.
+            operationId: c1.api.finding.v1.FindingSearchService.Search
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.finding.v1.FindingSearchRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.finding.v1.FindingSearchResponse'
+                    description: Successful response
+            summary: Search
+            tags:
+                - Findings
+            x-speakeasy-group: FindingSearch
+            x-speakeasy-name-override: Search
     /api/v1/functions:
         get:
             description: List retrieves all functions with pagination
@@ -30078,7 +35423,7 @@ paths:
             x-speakeasy-name-override: ListFunctions
             x-stability-level: draft
         post:
-            description: Invokes the c1.api.functions.v1.FunctionsService.CreateFunction method.
+            description: CreateFunction registers a new serverless function and creates its initial code commit.
             operationId: c1.api.functions.v1.FunctionsService.CreateFunction
             requestBody:
                 content:
@@ -30125,6 +35470,138 @@ paths:
                 - Function Commit
             x-speakeasy-group: Functions
             x-speakeasy-name-override: ListCommits
+            x-stability-level: draft
+        post:
+            description: CreateInitialCommit starts a new commit and returns upload URLs for files
+            operationId: c1.api.functions.v1.FunctionsService.CreateInitialCommit
+            parameters:
+                - in: path
+                  name: function_id
+                  required: true
+                  schema:
+                    description: The functionId field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.functions.v1.FunctionsServiceCreateInitialCommitRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.functions.v1.FunctionsServiceCreateInitialCommitResponse'
+                    description: Successful response
+            summary: Create Initial Commit
+            tags:
+                - Function Commit
+            x-speakeasy-group: Functions
+            x-speakeasy-name-override: CreateInitialCommit
+            x-stability-level: draft
+    /api/v1/functions/{function_id}/commits/{commit_id}/finalize:
+        post:
+            description: CreateFinalCommit completes a commit after files are uploaded
+            operationId: c1.api.functions.v1.FunctionsService.CreateFinalCommit
+            parameters:
+                - in: path
+                  name: function_id
+                  required: true
+                  schema:
+                    description: The functionId field.
+                    readOnly: false
+                    type: string
+                - in: path
+                  name: commit_id
+                  required: true
+                  schema:
+                    description: The commitId field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.functions.v1.FunctionsServiceCreateFinalCommitRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.functions.v1.FunctionsServiceCreateFinalCommitResponse'
+                    description: Successful response
+            summary: Create Final Commit
+            tags:
+                - Function Commit
+            x-speakeasy-group: Functions
+            x-speakeasy-name-override: CreateFinalCommit
+            x-stability-level: draft
+    /api/v1/functions/{function_id}/commits/{commit_id}/lockfile:
+        get:
+            description: GetLockFile retrieves the deno lock file for a specific commit, if it exists.
+            operationId: c1.api.functions.v1.FunctionsService.GetLockFile
+            parameters:
+                - in: path
+                  name: function_id
+                  required: true
+                  schema:
+                    description: The functionId field.
+                    readOnly: false
+                    type: string
+                - in: path
+                  name: commit_id
+                  required: true
+                  schema:
+                    description: The commitId field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.functions.v1.FunctionsServiceGetLockFileResponse'
+                    description: FunctionsServiceGetLockFileResponse returns the deno lock file content for a commit.
+            summary: Get Lock File
+            tags:
+                - Function Commit
+            x-speakeasy-group: Functions
+            x-speakeasy-name-override: GetLockFile
+            x-stability-level: draft
+    /api/v1/functions/{function_id}/commits/{id}:
+        get:
+            description: |-
+                GetCommitContent retrieves a commit and all its file contents in a single unary response.
+                 This is a non-streaming alternative to GetCommit for REST API consumers.
+            operationId: c1.api.functions.v1.FunctionsService.GetCommitContent
+            parameters:
+                - in: path
+                  name: function_id
+                  required: true
+                  schema:
+                    description: The function ID (KSUID).
+                    readOnly: false
+                    type: string
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The commit reference to retrieve. Accepts a KSUID, "HEAD", or a tag reference like "refs/tags/v1.0".
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.functions.v1.FunctionsServiceGetCommitContentResponse'
+                    description: FunctionsServiceGetCommitContentResponse contains a commit and all its file contents.
+            summary: Get Commit Content
+            tags:
+                - Function Commit
+            x-speakeasy-group: Functions
+            x-speakeasy-name-override: GetCommitContent
             x-stability-level: draft
     /api/v1/functions/{function_id}/invocations:
         get:
@@ -30215,14 +35692,14 @@ paths:
             x-stability-level: draft
     /api/v1/functions/{function_id}/invoke:
         post:
-            description: Invokes the c1.api.functions.v1.FunctionsService.Invoke method.
+            description: Invoke executes a function at a specific commit with the provided input data.
             operationId: c1.api.functions.v1.FunctionsService.Invoke
             parameters:
                 - in: path
                   name: function_id
                   required: true
                   schema:
-                    description: The functionId field.
+                    description: The ID of the function to invoke.
                     readOnly: false
                     type: string
             requestBody:
@@ -30308,7 +35785,7 @@ paths:
             x-stability-level: draft
     /api/v1/functions/{function_id}/test:
         post:
-            description: Invokes the c1.api.functions.v1.FunctionsService.Test method.
+            description: Test runs a function's test suite in a sandboxed environment and returns the results.
             operationId: c1.api.functions.v1.FunctionsService.Test
             parameters:
                 - in: path
@@ -30427,7 +35904,7 @@ paths:
             x-stability-level: draft
     /api/v1/grants/feed:
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlementUserBindingService.SearchGrantFeed method.
+            description: Search a chronological feed of grant and revoke events, filtered by app user, entitlement, or time range.
             operationId: c1.api.app.v1.AppEntitlementUserBindingService.SearchGrantFeed
             requestBody:
                 content:
@@ -30446,9 +35923,139 @@ paths:
                 - App Entitlement User Binding Feed
             x-speakeasy-group: AppEntitlementUserBinding
             x-speakeasy-name-override: SearchGrantFeed
+    /api/v1/hooks:
+        get:
+            description: Invokes the c1.api.hooks.v1.HooksService.List method.
+            operationId: c1.api.hooks.v1.HooksService.List
+            parameters:
+                - in: query
+                  name: page_size
+                  schema:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.hooks.v1.HooksServiceListResponse'
+                    description: Successful response
+            summary: List
+            tags:
+                - Hook
+            x-speakeasy-group: Hooks
+            x-speakeasy-name-override: List
+        post:
+            description: Invokes the c1.api.hooks.v1.HooksService.Create method.
+            operationId: c1.api.hooks.v1.HooksService.Create
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.hooks.v1.HooksServiceCreateRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.hooks.v1.HooksServiceCreateResponse'
+                    description: Successful response
+            summary: Create
+            tags:
+                - Hook
+            x-speakeasy-group: Hooks
+            x-speakeasy-name-override: Create
+    /api/v1/hooks/{id}:
+        delete:
+            description: Invokes the c1.api.hooks.v1.HooksService.Delete method.
+            operationId: c1.api.hooks.v1.HooksService.Delete
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.hooks.v1.HooksServiceDeleteRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.hooks.v1.HooksServiceDeleteResponse'
+                    description: Successful response
+            summary: Delete
+            tags:
+                - Hook
+            x-speakeasy-group: Hooks
+            x-speakeasy-name-override: Delete
+        get:
+            description: Invokes the c1.api.hooks.v1.HooksService.Get method.
+            operationId: c1.api.hooks.v1.HooksService.Get
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.hooks.v1.HooksServiceGetResponse'
+                    description: Successful response
+            summary: Get
+            tags:
+                - Hook
+            x-speakeasy-group: Hooks
+            x-speakeasy-name-override: Get
+        post:
+            description: Invokes the c1.api.hooks.v1.HooksService.Update method.
+            operationId: c1.api.hooks.v1.HooksService.Update
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.hooks.v1.HooksServiceUpdateRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.hooks.v1.HooksServiceUpdateResponse'
+                    description: Successful response
+            summary: Update
+            tags:
+                - Hook
+            x-speakeasy-group: Hooks
+            x-speakeasy-name-override: Update
     /api/v1/iam/personal_clients:
         get:
-            description: Invokes the c1.api.iam.v1.PersonalClientService.List method.
+            description: List returns all personal client credentials owned by the calling user.
             operationId: c1.api.iam.v1.PersonalClientService.List
             responses:
                 "200":
@@ -30484,14 +36091,14 @@ paths:
             x-speakeasy-name-override: Create
     /api/v1/iam/personal_clients/{id}:
         delete:
-            description: Invokes the c1.api.iam.v1.PersonalClientService.Delete method.
+            description: Delete a personal client credential, revoking it and preventing further API access.
             operationId: c1.api.iam.v1.PersonalClientService.Delete
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The human-readable name of the personal client credential to delete (e.g., blue-whale-12345).
                     readOnly: false
                     type: string
             requestBody:
@@ -30512,14 +36119,14 @@ paths:
             x-speakeasy-group: PersonalClient
             x-speakeasy-name-override: Delete
         get:
-            description: Invokes the c1.api.iam.v1.PersonalClientService.Get method.
+            description: Get retrieves a single personal client credential by its ID.
             operationId: c1.api.iam.v1.PersonalClientService.Get
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The human-readable name of the personal client credential to retrieve (e.g., blue-whale-12345).
                     readOnly: false
                     type: string
             responses:
@@ -30535,7 +36142,7 @@ paths:
             x-speakeasy-group: PersonalClient
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.iam.v1.PersonalClientService.Update method.
+            description: Update modifies an existing personal client credential. Use the update mask to specify which fields to change.
             operationId: c1.api.iam.v1.PersonalClientService.Update
             parameters:
                 - in: path
@@ -30660,6 +36267,232 @@ paths:
                 terraform-resource: Role#update
             x-speakeasy-group: Roles
             x-speakeasy-name-override: Update
+    /api/v1/local-directory-configs:
+        get:
+            description: List local directory configs for the tenant.
+            operationId: c1.api.local_directory.v1.LocalDirectoryConfigService.List
+            parameters:
+                - in: query
+                  name: page_size
+                  schema:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfigServiceListResponse'
+                    description: Successful response
+            summary: List
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalDirectoryConfig
+            x-speakeasy-name-override: List
+        post:
+            description: Create a new local directory config backed by an existing App.
+            operationId: c1.api.local_directory.v1.LocalDirectoryConfigService.Create
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfigServiceCreateRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfigServiceCreateResponse'
+                    description: Successful response
+            summary: Create
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalDirectoryConfig
+            x-speakeasy-name-override: Create
+    /api/v1/local-directory-configs/{app_id}:
+        delete:
+            description: Delete a local directory config. Does not delete the underlying App.
+            operationId: c1.api.local_directory.v1.LocalDirectoryConfigService.Delete
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfigServiceDeleteRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfigServiceDeleteResponse'
+                    description: Successful response
+            summary: Delete
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalDirectoryConfig
+            x-speakeasy-name-override: Delete
+        get:
+            description: Get a local directory config by app_id.
+            operationId: c1.api.local_directory.v1.LocalDirectoryConfigService.Get
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfigServiceGetResponse'
+                    description: Successful response
+            summary: Get
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalDirectoryConfig
+            x-speakeasy-name-override: Get
+        post:
+            description: Update a local directory config.
+            operationId: c1.api.local_directory.v1.LocalDirectoryConfigService.Update
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: app_id is the identifier for this config and its linked App. Read-only after creation.
+                    readOnly: true
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfigServiceUpdateRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalDirectoryConfigServiceUpdateResponse'
+                    description: Successful response
+            summary: Update
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalDirectoryConfig
+            x-speakeasy-name-override: Update
+    /api/v1/local-directory-configs/{directory_app_id}/invitations:
+        post:
+            description: Create (send) a new invitation to a user.
+            operationId: c1.api.local_directory.v1.LocalUserInvitationService.Create
+            parameters:
+                - in: path
+                  name: directory_app_id
+                  required: true
+                  schema:
+                    description: FK to the LocalDirectoryConfig (app_id) this invitation belongs to.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitationServiceCreateRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitationServiceCreateResponse'
+                    description: Successful response
+            summary: Create
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalUserInvitation
+            x-speakeasy-name-override: Create
+    /api/v1/local-directory-configs/{directory_app_id}/invitations/{id}:
+        get:
+            description: Get a specific invitation by id.
+            operationId: c1.api.local_directory.v1.LocalUserInvitationService.Get
+            parameters:
+                - in: path
+                  name: directory_app_id
+                  required: true
+                  schema:
+                    description: The directoryAppId field.
+                    readOnly: false
+                    type: string
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitationServiceGetResponse'
+                    description: Successful response
+            summary: Get
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalUserInvitation
+            x-speakeasy-name-override: Get
+    /api/v1/local-directory-configs/{directory_app_id}/invitations/{id}/revoke:
+        post:
+            description: Revoke a pending invitation.
+            operationId: c1.api.local_directory.v1.LocalUserInvitationService.Revoke
+            parameters:
+                - in: path
+                  name: directory_app_id
+                  required: true
+                  schema:
+                    description: The directoryAppId field.
+                    readOnly: false
+                    type: string
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitationServiceRevokeRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitationServiceRevokeResponse'
+                    description: Successful response
+            summary: Revoke
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalUserInvitation
+            x-speakeasy-name-override: Revoke
     /api/v1/policies:
         get:
             description: List policies.
@@ -30809,7 +36642,7 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/policies/test-account-provision-policy:
         post:
-            description: Invokes the c1.api.policy.v1.AccountProvisionPolicyTest.Test method.
+            description: Test an account provision policy by evaluating a CEL expression and returning the computed result.
             operationId: c1.api.policy.v1.AccountProvisionPolicyTest.Test
             requestBody:
                 content:
@@ -30822,7 +36655,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.policy.v1.TestAccountProvisionPolicyResponse'
-                    description: Successful response
+                    description: TestAccountProvisionPolicyResponse is the response for testing an account provision policy.
             summary: Test
             tags:
                 - Policy
@@ -30851,7 +36684,7 @@ paths:
             x-speakeasy-name-override: ValidateCEL
     /api/v1/request_schema_entitlement_binding:
         delete:
-            description: Invokes the c1.api.request_schema.v1.RequestSchemaService.RemoveEntitlementBinding method.
+            description: Remove the link between a request schema and a single app entitlement.
             operationId: c1.api.request_schema.v1.RequestSchemaService.RemoveEntitlementBinding
             requestBody:
                 content:
@@ -30864,7 +36697,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchemaServiceRemoveEntitlementBindingResponse'
-                    description: Successful response
+                    description: The response message for removing a single entitlement binding.
             summary: Remove Entitlement Binding
             tags:
                 - Request Schema Entitlement Binding
@@ -30875,7 +36708,7 @@ paths:
             x-speakeasy-group: RequestSchema
             x-speakeasy-name-override: RemoveEntitlementBinding
         post:
-            description: Invokes the c1.api.request_schema.v1.RequestSchemaService.CreateEntitlementBinding method.
+            description: Link a request schema to a single app entitlement so the form is shown when requesting that entitlement.
             operationId: c1.api.request_schema.v1.RequestSchemaService.CreateEntitlementBinding
             requestBody:
                 content:
@@ -30888,7 +36721,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchemaServiceCreateEntitlementBindingResponse'
-                    description: Successful response
+                    description: The response message for creating a single entitlement binding.
             summary: Create Entitlement Binding
             tags:
                 - Request Schema Entitlement Binding
@@ -30899,7 +36732,7 @@ paths:
             x-speakeasy-group: RequestSchema
             x-speakeasy-name-override: CreateEntitlementBinding
         put:
-            description: Invokes the c1.api.request_schema.v1.RequestSchemaService.FindBindingForAppEntitlement method.
+            description: Look up which request schema is bound to a given app entitlement.
             operationId: c1.api.request_schema.v1.RequestSchemaService.FindBindingForAppEntitlement
             requestBody:
                 content:
@@ -30912,7 +36745,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchemaServiceFindBindingForAppEntitlementResponse'
-                    description: Successful response
+                    description: The response message containing the binding for the specified app entitlement.
             summary: Find Binding For App Entitlement
             tags:
                 - Request Schema Entitlement Binding
@@ -30925,7 +36758,7 @@ paths:
             x-speakeasy-name-override: FindBindingForAppEntitlement
     /api/v1/request_schemas:
         post:
-            description: Invokes the c1.api.request_schema.v1.RequestSchemaService.Create method.
+            description: Create a new request schema that defines a form template for access requests.
             operationId: c1.api.request_schema.v1.RequestSchemaService.Create
             requestBody:
                 content:
@@ -30938,7 +36771,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchemaServiceCreateResponse'
-                    description: Successful response
+                    description: The response message for creating a request schema.
             summary: Create
             tags:
                 - Request Schema
@@ -30950,14 +36783,14 @@ paths:
             x-speakeasy-name-override: Create
     /api/v1/request_schemas/{request_schema_id}:
         delete:
-            description: Invokes the c1.api.request_schema.v1.RequestSchemaService.Delete method.
+            description: Delete a request schema by ID. Associated entitlement bindings are also deleted.
             operationId: c1.api.request_schema.v1.RequestSchemaService.Delete
             parameters:
                 - in: path
                   name: request_schema_id
                   required: true
                   schema:
-                    description: The requestSchemaId field.
+                    description: The unique identifier of the request schema to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -30971,7 +36804,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchemaServiceDeleteResponse'
-                    description: Successful response
+                    description: The response message for deleting a request schema.
             summary: Delete
             tags:
                 - Request Schema
@@ -30982,14 +36815,14 @@ paths:
             x-speakeasy-group: RequestSchema
             x-speakeasy-name-override: Delete
         get:
-            description: Invokes the c1.api.request_schema.v1.RequestSchemaService.Get method.
+            description: Retrieve a single request schema by ID.
             operationId: c1.api.request_schema.v1.RequestSchemaService.Get
             parameters:
                 - in: path
                   name: request_schema_id
                   required: true
                   schema:
-                    description: The requestSchemaId field.
+                    description: The unique identifier of the request schema to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -30998,7 +36831,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchemaServiceGetResponse'
-                    description: Successful response
+                    description: The response message for retrieving a request schema.
             summary: Get
             tags:
                 - Request Schema
@@ -31010,14 +36843,14 @@ paths:
             x-speakeasy-group: RequestSchema
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.request_schema.v1.RequestSchemaService.Update method.
+            description: Update an existing request schema's form definition or settings.
             operationId: c1.api.request_schema.v1.RequestSchemaService.Update
             parameters:
                 - in: path
                   name: request_schema_id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of this request schema.
                     readOnly: false
                     type: string
             requestBody:
@@ -31031,7 +36864,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.request_schema.v1.RequestSchemaServiceUpdateResponse'
-                    description: Successful response
+                    description: The response message for updating a request schema.
             summary: Update
             tags:
                 - Request Schema
@@ -31041,9 +36874,33 @@ paths:
                 terraform-resource: Request_Schema#update
             x-speakeasy-group: RequestSchema
             x-speakeasy-name-override: Update
+    /api/v1/role-mining/access-profiles:
+        post:
+            description: |-
+                CreateAccessProfileFromCohort creates an access profile from a cohort definition,
+                 adds the specified entitlements, and sets up dynamic membership automation using
+                 a CEL expression derived from the profile filters.
+            operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.CreateAccessProfileFromCohort
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.role_mining_management.v1.CreateAccessProfileFromCohortRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.role_mining_management.v1.CreateAccessProfileFromCohortResponse'
+                    description: Successful response
+            summary: Create Access Profile From Cohort
+            tags:
+                - Role Mining
+            x-speakeasy-group: RoleMiningManagement
+            x-speakeasy-name-override: CreateAccessProfileFromCohort
     /api/v1/role-mining/config:
         get:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.GetRoleMiningConfig method.
+            description: Retrieve the current role mining configuration, including cohort hints and threshold settings.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.GetRoleMiningConfig
             responses:
                 "200":
@@ -31058,7 +36915,7 @@ paths:
             x-speakeasy-group: RoleMiningManagement
             x-speakeasy-name-override: GetRoleMiningConfig
         post:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.UpdateRoleMiningConfig method.
+            description: Update the role mining configuration, such as cohort hints, max suggestions, and minimum cohort size.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.UpdateRoleMiningConfig
             requestBody:
                 content:
@@ -31077,9 +36934,54 @@ paths:
                 - Role Mining
             x-speakeasy-group: RoleMiningManagement
             x-speakeasy-name-override: UpdateRoleMiningConfig
+    /api/v1/role-mining/custom-analysis/{id}:
+        get:
+            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.GetCustomAnalysisResult method.
+            operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.GetCustomAnalysisResult
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The id field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.role_mining_management.v1.GetCustomAnalysisResultResponse'
+                    description: Successful response
+            summary: Get Custom Analysis Result
+            tags:
+                - Role Mining
+            x-speakeasy-group: RoleMiningManagement
+            x-speakeasy-name-override: GetCustomAnalysisResult
+    /api/v1/role-mining/custom-analysis/trigger:
+        post:
+            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.TriggerCustomAnalysis method.
+            operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.TriggerCustomAnalysis
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.role_mining_management.v1.TriggerCustomAnalysisRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.role_mining_management.v1.TriggerCustomAnalysisResponse'
+                    description: Successful response
+            summary: Trigger Custom Analysis
+            tags:
+                - Role Mining
+            x-speakeasy-group: RoleMiningManagement
+            x-speakeasy-name-override: TriggerCustomAnalysis
     /api/v1/role-mining/runs:
         get:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.ListRuns method.
+            description: List role mining analysis runs in reverse chronological order.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.ListRuns
             responses:
                 "200":
@@ -31095,7 +36997,7 @@ paths:
             x-speakeasy-name-override: ListRuns
     /api/v1/role-mining/runs/latest:
         get:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.GetLatestRun method.
+            description: Retrieve the most recent role mining analysis run, including its status and results summary.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.GetLatestRun
             responses:
                 "200":
@@ -31111,7 +37013,7 @@ paths:
             x-speakeasy-name-override: GetLatestRun
     /api/v1/role-mining/suggestions:
         get:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.ListSuggestions method.
+            description: List role suggestions generated by analysis runs, optionally filtered by state.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.ListSuggestions
             responses:
                 "200":
@@ -31127,14 +37029,14 @@ paths:
             x-speakeasy-name-override: ListSuggestions
     /api/v1/role-mining/suggestions/{id}:
         get:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.GetSuggestion method.
+            description: Retrieve a single role suggestion by ID, including its cohort filters, entitlements, and confidence score.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.GetSuggestion
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the role mining suggestion to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -31151,14 +37053,14 @@ paths:
             x-speakeasy-name-override: GetSuggestion
     /api/v1/role-mining/suggestions/{id}/state:
         post:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.UpdateSuggestionState method.
+            description: Transition a role suggestion to a new state, such as accepted, rejected, or dismissed.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.UpdateSuggestionState
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the role mining suggestion to update.
                     readOnly: false
                     type: string
             requestBody:
@@ -31178,9 +37080,38 @@ paths:
                 - Role Mining
             x-speakeasy-group: RoleMiningManagement
             x-speakeasy-name-override: UpdateSuggestionState
+    /api/v1/role-mining/suggestions/{suggestion_id}/users:
+        post:
+            description: Search for users that belong to a suggestion's cohort, with optional additional profile filters.
+            operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.SearchCohortUsers
+            parameters:
+                - in: path
+                  name: suggestion_id
+                  required: true
+                  schema:
+                    description: The ID of the suggestion whose cohort to search within.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.role_mining_management.v1.SearchCohortUsersRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.role_mining_management.v1.SearchCohortUsersResponse'
+                    description: Successful response
+            summary: Search Cohort Users
+            tags:
+                - Role Mining
+            x-speakeasy-group: RoleMiningManagement
+            x-speakeasy-name-override: SearchCohortUsers
     /api/v1/role-mining/trigger:
         post:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementService.TriggerAnalysis method.
+            description: Start a new role mining analysis job that scans existing access patterns to generate role suggestions.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementService.TriggerAnalysis
             requestBody:
                 content:
@@ -31199,6 +37130,27 @@ paths:
                 - Role Mining
             x-speakeasy-group: RoleMiningManagement
             x-speakeasy-name-override: TriggerAnalysis
+    /api/v1/search/all_automation_executions:
+        post:
+            description: Search across all automation executions in the tenant, with filters for state, template, app, and subject user.
+            operationId: c1.api.automations.v1.AutomationExecutionSearchService.SearchAllAutomationExecutions
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.automations.v1.SearchAllAutomationExecutionsRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.automations.v1.SearchAllAutomationExecutionsResponse'
+                    description: Successful response
+            summary: Search All Automation Executions
+            tags:
+                - Automations
+            x-speakeasy-group: AutomationExecutionSearch
+            x-speakeasy-name-override: SearchAllAutomationExecutions
     /api/v1/search/app_resource_types:
         post:
             description: Search app resources based on filters specified in the request body.
@@ -31237,7 +37189,7 @@ paths:
                 type: cursor
     /api/v1/search/app_resources:
         post:
-            description: Invokes the c1.api.app.v1.AppResourceSearch.SearchAppResources method.
+            description: Search app resources based on filters specified in the request body.
             operationId: c1.api.app.v1.AppResourceSearch.SearchAppResources
             requestBody:
                 content:
@@ -31250,7 +37202,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.app.v1.SearchAppResourcesResponse'
-                    description: Successful response
+                    description: The SearchAppResourcesResponse message contains a list of results and a nextPageToken if applicable.
             summary: Search App Resources
             tags:
                 - App Resource
@@ -31328,21 +37280,21 @@ paths:
                 type: cursor
     /api/v1/search/apps/{app_id}/entitlements/users/{app_user_id}:
         get:
-            description: Invokes the c1.api.app.v1.AppEntitlementSearchService.SearchAppEntitlementsForAppUser method.
+            description: Search for app entitlements associated with a specific app user, with optional resource type trait filtering.
             operationId: c1.api.app.v1.AppEntitlementSearchService.SearchAppEntitlementsForAppUser
             parameters:
                 - in: path
                   name: app_id
                   required: true
                   schema:
-                    description: The appId field.
+                    description: The ID of the app to search entitlements within.
                     readOnly: false
                     type: string
                 - in: path
                   name: app_user_id
                   required: true
                   schema:
-                    description: The appUserId field.
+                    description: The ID of the app user to search entitlements for.
                     readOnly: false
                     type: string
                 - in: query
@@ -31393,7 +37345,7 @@ paths:
             x-speakeasy-name-override: SearchAttributeValues
     /api/v1/search/automation_executions:
         post:
-            description: Invokes the c1.api.automations.v1.AutomationExecutionSearchService.SearchAutomationExecutions method.
+            description: Search for automation executions with optional filters for automation_template_id, state, and query.
             operationId: c1.api.automations.v1.AutomationExecutionSearchService.SearchAutomationExecutions
             requestBody:
                 content:
@@ -31414,7 +37366,7 @@ paths:
             x-speakeasy-name-override: SearchAutomationExecutions
     /api/v1/search/automation_versions:
         post:
-            description: Invokes the c1.api.automations.v1.AutomationSearchService.SearchAutomationTemplateVersions method.
+            description: Search for versioned snapshots of an automation template's steps and triggers.
             operationId: c1.api.automations.v1.AutomationSearchService.SearchAutomationTemplateVersions
             requestBody:
                 content:
@@ -31435,7 +37387,7 @@ paths:
             x-speakeasy-name-override: SearchAutomationTemplateVersions
     /api/v1/search/automations:
         post:
-            description: Invokes the c1.api.automations.v1.AutomationSearchService.SearchAutomations method.
+            description: Search for automations matching the provided filters, including query text, template refs, app, and trigger types.
             operationId: c1.api.automations.v1.AutomationSearchService.SearchAutomations
             requestBody:
                 content:
@@ -31519,7 +37471,7 @@ paths:
             x-stability-level: draft
     /api/v1/search/grants:
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlementSearchService.SearchGrants method.
+            description: Search grants (user-to-entitlement bindings) across apps, with filters for app, user, resource type, and entitlement.
             operationId: c1.api.app.v1.AppEntitlementSearchService.SearchGrants
             requestBody:
                 content:
@@ -31538,6 +37490,27 @@ paths:
                 - App Entitlement
             x-speakeasy-group: AppEntitlementSearch
             x-speakeasy-name-override: SearchGrants
+    /api/v1/search/hooks:
+        post:
+            description: Invokes the c1.api.hooks.v1.HooksSearch.Search method.
+            operationId: c1.api.hooks.v1.HooksSearch.Search
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.hooks.v1.HooksSearchRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.hooks.v1.HooksSearchResponse'
+                    description: Successful response
+            summary: Search
+            tags:
+                - Hook
+            x-speakeasy-group: HooksSearch
+            x-speakeasy-name-override: Search
     /api/v1/search/iam/external_clients:
         post:
             description: Search returns external client grants for all users in the tenant.
@@ -31561,7 +37534,7 @@ paths:
             x-speakeasy-name-override: Search
     /api/v1/search/iam/personal_clients:
         post:
-            description: Invokes the c1.api.iam.v1.PersonalClientSearchService.Search method.
+            description: Search finds personal client credentials across all users, with optional filtering by query text or user.
             operationId: c1.api.iam.v1.PersonalClientSearchService.Search
             requestBody:
                 content:
@@ -31580,9 +37553,32 @@ paths:
                 - Personal Client
             x-speakeasy-group: PersonalClientSearch
             x-speakeasy-name-override: Search
+    /api/v1/search/local-directory-invitations:
+        post:
+            description: |-
+                List invitations for a directory, with optional status filter.
+                 Search invitations with filters (directory, status).
+            operationId: c1.api.local_directory.v1.LocalUserInvitationService.Search
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitationServiceSearchRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.local_directory.v1.LocalUserInvitationServiceSearchResponse'
+                    description: Successful response
+            summary: Search
+            tags:
+                - Local Directory
+            x-speakeasy-group: LocalUserInvitation
+            x-speakeasy-name-override: Search
     /api/v1/search/past-grants:
         post:
-            description: Invokes the c1.api.app.v1.AppEntitlementUserBindingService.SearchPastGrants method.
+            description: Search historical grants that have been revoked, filtered by app user or entitlement.
             operationId: c1.api.app.v1.AppEntitlementUserBindingService.SearchPastGrants
             requestBody:
                 content:
@@ -31660,7 +37656,7 @@ paths:
             x-speakeasy-name-override: SearchEntitlements
     /api/v1/search/role-mining/suggestions:
         post:
-            description: Invokes the c1.api.role_mining_management.v1.RoleMiningManagementSearchService.Search method.
+            description: Search role mining suggestions by name, description, or cohort filter values with optional state and type filters.
             operationId: c1.api.role_mining_management.v1.RoleMiningManagementSearchService.Search
             requestBody:
                 content:
@@ -31777,6 +37773,27 @@ paths:
             x-speakeasy-group: PaperSecret
             x-speakeasy-name-override: SearchMySecrets
             x-stability-level: beta
+    /api/v1/search/ssf-receiver-events:
+        post:
+            description: Search performs a full-text search across received SSF events with optional filters for stream, event type, outcome, and matched user.
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverEventSearchService.Search
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverEventSearchServiceSearchRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverEventSearchServiceSearchResponse'
+                    description: SSFReceiverEventSearchServiceSearchResponse contains the matching events and a pagination token.
+            summary: Search
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverEventSearch
+            x-speakeasy-name-override: Search
     /api/v1/search/step-up/providers:
         post:
             description: Search allows searching for step-up providers with various filters
@@ -31821,7 +37838,7 @@ paths:
             x-speakeasy-name-override: Search
     /api/v1/search/systemlog/exports:
         post:
-            description: Invokes the c1.api.systemlog.v1.ExportsSearchService.Search method.
+            description: Search for system log exports matching the specified filters.
             operationId: c1.api.systemlog.v1.ExportsSearchService.Search
             requestBody:
                 content:
@@ -31834,7 +37851,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.systemlog.v1.ExportsSearchServiceSearchResponse'
-                    description: Successful response
+                    description: ExportsSearchServiceSearchResponse is the response for searching system log exports.
             summary: Search
             tags:
                 - System Log Exporter
@@ -31861,6 +37878,27 @@ paths:
                 - Task
             x-speakeasy-group: TaskSearch
             x-speakeasy-name-override: Search
+    /api/v1/search/user-ownership:
+        post:
+            description: Search all ownership assignments for a given user across apps, resources, and entitlements.
+            operationId: c1.api.app.v1.AppSearch.SearchUserOwnership
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.app.v1.SearchUserOwnershipRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.app.v1.SearchUserOwnershipResponse'
+                    description: The SearchUserOwnershipResponse message contains a paginated list of ownership entries.
+            summary: Search User Ownership
+            tags:
+                - App
+            x-speakeasy-group: AppSearch
+            x-speakeasy-name-override: SearchUserOwnership
     /api/v1/search/users:
         post:
             description: Search users based on filters specified in the request body.
@@ -31899,7 +37937,7 @@ paths:
                 type: cursor
     /api/v1/search/webhooks:
         post:
-            description: Invokes the c1.api.webhooks.v1.WebhooksSearch.Search method.
+            description: Search for webhook subscriptions by query string or specific webhook references.
             operationId: c1.api.webhooks.v1.WebhooksSearch.Search
             requestBody:
                 content:
@@ -32675,9 +38713,91 @@ paths:
                 - Workload Federation
             x-speakeasy-group: WorkloadFederation
             x-speakeasy-name-override: TestToken
+    /api/v1/service_principals/bindings:
+        post:
+            description: |-
+                AddBinding links a tenant-scoped subject (a function today; future kinds
+                 tomorrow) to a service principal. Outbound c1-api calls made on the
+                 subject's behalf can then be minted as user:<service_principal_id> via
+                 an RFC 8693 token-exchange (act-as) flow. Many-aware: a subject may
+                 hold multiple bindings at the storage layer. Idempotent on
+                 (subject, service_principal_id) — adds the row if missing,
+                 resurrects it if soft-deleted, no-op if already active. Consumers
+                 that need 0-or-1 cardinality (Functions today) enforce it
+                 client-side via ListBindings + DeleteBinding. Requires the
+                 SERVICE_PRINCIPALS feature flag.
+            operationId: c1.api.service_principal.v1.ServicePrincipalService.AddBinding
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalServiceAddBindingRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalServiceAddBindingResponse'
+                    description: Successful response
+            summary: Add Binding
+            tags:
+                - Service Principal Binding
+            x-speakeasy-group: Principal
+            x-speakeasy-name-override: AddBinding
+            x-stability-level: draft
+    /api/v1/service_principals/bindings/delete:
+        post:
+            description: |-
+                DeleteBinding removes a single (subject, service_principal_id) binding
+                 row. At-most-one delete — does not touch other bindings the subject
+                 may hold against different service principals. Idempotent — succeeds
+                 even if no matching row exists.
+            operationId: c1.api.service_principal.v1.ServicePrincipalService.DeleteBinding
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalServiceDeleteBindingRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalServiceDeleteBindingResponse'
+                    description: Successful response
+            summary: Delete Binding
+            tags:
+                - Service Principal Binding
+            x-speakeasy-group: Principal
+            x-speakeasy-name-override: DeleteBinding
+            x-stability-level: draft
+    /api/v1/service_principals/bindings/list:
+        post:
+            description: |-
+                ListBindings returns every active binding held by a subject. Empty
+                 list when the subject is unbound. The response is unordered.
+            operationId: c1.api.service_principal.v1.ServicePrincipalService.ListBindings
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalServiceListBindingsRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.service_principal.v1.ServicePrincipalServiceListBindingsResponse'
+                    description: Successful response
+            summary: List Bindings
+            tags:
+                - Service Principal Binding
+            x-speakeasy-group: Principal
+            x-speakeasy-name-override: ListBindings
+            x-stability-level: draft
     /api/v1/settings/aws-external-id:
         get:
-            description: Invokes the c1.api.settings.v1.AWSExternalIDSettings.Get method.
+            description: Get retrieves the AWS external ID for the tenant, used in IAM role trust policies for AWS connectors.
             operationId: c1.api.settings.v1.AWSExternalIDSettings.Get
             responses:
                 "200":
@@ -32696,22 +38816,58 @@ paths:
                 terraform-resource: AWS_EXTERNAL_ID#read
             x-speakeasy-group: AWSExternalIDSettings
             x-speakeasy-name-override: Get
+    /api/v1/settings/contacts:
+        get:
+            description: Invokes the c1.api.settings.v1.ContactsService.GetContacts method.
+            operationId: c1.api.settings.v1.ContactsService.GetContacts
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.GetContactsResponse'
+                    description: Successful response
+            summary: Get Contacts
+            tags:
+                - Contacts
+            x-speakeasy-group: Contacts
+            x-speakeasy-name-override: GetContacts
+        post:
+            description: Invokes the c1.api.settings.v1.ContactsService.UpdateContacts method.
+            operationId: c1.api.settings.v1.ContactsService.UpdateContacts
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.settings.v1.UpdateContactsRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.UpdateContactsResponse'
+                    description: Successful response
+            summary: Update Contacts
+            tags:
+                - Contacts
+            x-speakeasy-group: Contacts
+            x-speakeasy-name-override: UpdateContacts
     /api/v1/settings/domains:
         get:
-            description: Invokes the c1.api.settings.v1.OrgDomainService.List method.
+            description: List returns all verified domains configured for the tenant.
             operationId: c1.api.settings.v1.OrgDomainService.List
             parameters:
                 - in: query
                   name: page_size
                   schema:
-                    description: The pageSize field.
+                    description: The maximum number of results to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 - in: query
                   name: page_token
                   schema:
-                    description: The pageToken field.
+                    description: A pagination token returned from a previous List call.
                     readOnly: false
                     type: string
             responses:
@@ -32732,7 +38888,7 @@ paths:
             x-speakeasy-group: OrgDomain
             x-speakeasy-name-override: List
         put:
-            description: Invokes the c1.api.settings.v1.OrgDomainService.Update method.
+            description: Update replaces the tenant's set of verified domains with the provided list.
             operationId: c1.api.settings.v1.OrgDomainService.Update
             requestBody:
                 content:
@@ -32755,9 +38911,107 @@ paths:
                 terraform-resource: OrgDomains#update
             x-speakeasy-group: OrgDomain
             x-speakeasy-name-override: Update
+    /api/v1/settings/email-capabilities:
+        get:
+            description: |-
+                GetEmailCapabilities returns a lightweight summary of email capabilities
+                 for the current tenant. Intended for non-admin users (automation builders,
+                 secret sharers) to check if external email is available without exposing
+                 provider configuration details.
+            operationId: c1.api.settings.v1.TenantEmailProviderService.GetEmailCapabilities
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.GetEmailCapabilitiesResponse'
+                    description: Successful response
+            summary: Get Email Capabilities
+            tags:
+                - Tenant Email Provider
+            x-speakeasy-group: TenantEmailProvider
+            x-speakeasy-name-override: GetEmailCapabilities
+    /api/v1/settings/email-provider:
+        get:
+            description: Get retrieves the current tenant email provider configuration.
+            operationId: c1.api.settings.v1.TenantEmailProviderService.Get
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.GetTenantEmailProviderResponse'
+                    description: Successful response
+            summary: Get
+            tags:
+                - Tenant Email Provider
+            x-speakeasy-group: TenantEmailProvider
+            x-speakeasy-name-override: Get
+        post:
+            description: Update creates or updates the tenant email provider configuration.
+            operationId: c1.api.settings.v1.TenantEmailProviderService.Update
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.settings.v1.UpdateTenantEmailProviderRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.UpdateTenantEmailProviderResponse'
+                    description: Successful response
+            summary: Update
+            tags:
+                - Tenant Email Provider
+            x-speakeasy-group: TenantEmailProvider
+            x-speakeasy-name-override: Update
+    /api/v1/settings/email-provider/audit-events:
+        post:
+            description: SearchAuditEvents returns email audit events for the tenant.
+            operationId: c1.api.settings.v1.TenantEmailProviderService.SearchAuditEvents
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.settings.v1.SearchEmailAuditEventsRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.SearchEmailAuditEventsResponse'
+                    description: Successful response
+            summary: Search Audit Events
+            tags:
+                - Tenant Email Provider
+            x-speakeasy-group: TenantEmailProvider
+            x-speakeasy-name-override: SearchAuditEvents
+    /api/v1/settings/email-provider/test:
+        post:
+            description: Test sends a test email to verify the provider configuration works end-to-end.
+            operationId: c1.api.settings.v1.TenantEmailProviderService.Test
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.settings.v1.TestTenantEmailProviderRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.TestTenantEmailProviderResponse'
+                    description: Successful response
+            summary: Test
+            tags:
+                - Tenant Email Provider
+            x-speakeasy-group: TenantEmailProvider
+            x-speakeasy-name-override: Test
     /api/v1/settings/notifications/org:
         get:
-            description: Invokes the c1.api.settings.v1.OrgNotificationSettingsService.Get method.
+            description: Get retrieves the organization-level notification settings, including per-channel preferences and admin-locked defaults.
             operationId: c1.api.settings.v1.OrgNotificationSettingsService.Get
             responses:
                 "200":
@@ -32772,7 +39026,7 @@ paths:
             x-speakeasy-group: OrgNotificationSettings
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.settings.v1.OrgNotificationSettingsService.Update method.
+            description: Update modifies the organization-level notification settings, such as enabling channels and locking preferences for users.
             operationId: c1.api.settings.v1.OrgNotificationSettingsService.Update
             requestBody:
                 content:
@@ -32793,7 +39047,7 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/settings/notifications/user:
         get:
-            description: Invokes the c1.api.settings.v1.UserNotificationSettingsService.Get method.
+            description: Get retrieves the calling user's notification preferences, merged with organization-level defaults.
             operationId: c1.api.settings.v1.UserNotificationSettingsService.Get
             responses:
                 "200":
@@ -32808,7 +39062,7 @@ paths:
             x-speakeasy-group: UserNotificationSettings
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.settings.v1.UserNotificationSettingsService.Update method.
+            description: Update modifies the calling user's personal notification preferences for each channel.
             operationId: c1.api.settings.v1.UserNotificationSettingsService.Update
             requestBody:
                 content:
@@ -32827,9 +39081,45 @@ paths:
                 - User Notification Settings
             x-speakeasy-group: UserNotificationSettings
             x-speakeasy-name-override: Update
+    /api/v1/settings/onboarding:
+        get:
+            description: Get retrieves the current onboarding progress for the tenant.
+            operationId: c1.api.settings.v1.OnboardingSettingsService.Get
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.GetOnboardingSettingsResponse'
+                    description: Successful response
+            summary: Get
+            tags:
+                - Onboarding Settings
+            x-speakeasy-group: OnboardingSettings
+            x-speakeasy-name-override: Get
+        post:
+            description: Update modifies the onboarding progress, such as marking steps complete or dismissing the wizard.
+            operationId: c1.api.settings.v1.OnboardingSettingsService.Update
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.settings.v1.UpdateOnboardingSettingsRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.settings.v1.UpdateOnboardingSettingsResponse'
+                    description: Successful response
+            summary: Update
+            tags:
+                - Onboarding Settings
+            x-speakeasy-group: OnboardingSettings
+            x-speakeasy-name-override: Update
     /api/v1/settings/session:
         get:
-            description: Invokes the c1.api.settings.v1.SessionSettingsService.Get method.
+            description: Get retrieves the current session security settings for the tenant.
             operationId: c1.api.settings.v1.SessionSettingsService.Get
             responses:
                 "200":
@@ -32849,7 +39139,7 @@ paths:
             x-speakeasy-group: SessionSettings
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.settings.v1.SessionSettingsService.Update method.
+            description: Update modifies the session security settings for the tenant, such as session length and IP allowlists.
             operationId: c1.api.settings.v1.SessionSettingsService.Update
             requestBody:
                 content:
@@ -32874,7 +39164,7 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/settings/session/test-source-ip:
         post:
-            description: Invokes the c1.api.settings.v1.SessionSettingsService.TestSourceIP method.
+            description: TestSourceIP checks whether a given IP address would be allowed by the specified CIDR allowlist rules.
             operationId: c1.api.settings.v1.SessionSettingsService.TestSourceIP
             requestBody:
                 content:
@@ -32893,9 +39183,229 @@ paths:
                 - Session Settings
             x-speakeasy-group: SessionSettings
             x-speakeasy-name-override: TestSourceIP
+    /api/v1/ssf-receiver-streams:
+        get:
+            description: List returns a paginated list of all SSF receiver streams configured for the tenant.
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverStreamService.List
+            parameters:
+                - in: query
+                  name: page_size
+                  schema:
+                    description: Maximum number of streams to return per page.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: Token from a previous ListResponse to fetch the next page of results.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceListResponse'
+                    description: SSFReceiverStreamServiceListResponse contains a page of SSF receiver streams.
+            summary: List
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverStream
+            x-speakeasy-name-override: List
+        post:
+            description: Create registers a new SSF receiver stream with the specified configuration and returns the created stream along with the push auth token (if push delivery).
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverStreamService.Create
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceCreateRequest'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceCreateResponse'
+                    description: SSFReceiverStreamServiceCreateResponse returns the created stream and the push auth token in plaintext.
+            summary: Create
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverStream
+            x-speakeasy-name-override: Create
+    /api/v1/ssf-receiver-streams/{id}:
+        delete:
+            description: Delete removes an SSF receiver stream and stops receiving events from the associated transmitter.
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverStreamService.Delete
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The ID of the SSF receiver stream to delete.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceDeleteRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceDeleteResponse'
+                    description: SSFReceiverStreamServiceDeleteResponse is empty on success.
+            summary: Delete
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverStream
+            x-speakeasy-name-override: Delete
+        get:
+            description: Get retrieves a single SSF receiver stream by its ID.
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverStreamService.Get
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The ID of the SSF receiver stream to retrieve.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceGetResponse'
+                    description: SSFReceiverStreamServiceGetResponse contains the requested SSF receiver stream.
+            summary: Get
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverStream
+            x-speakeasy-name-override: Get
+        post:
+            description: Update modifies an existing SSF receiver stream's configuration. Only fields specified in the update mask are changed.
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverStreamService.Update
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The unique identifier of this SSF receiver stream.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceUpdateRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceUpdateResponse'
+                    description: SSFReceiverStreamServiceUpdateResponse contains the updated SSF receiver stream.
+            summary: Update
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverStream
+            x-speakeasy-name-override: Update
+    /api/v1/ssf-receiver-streams/{id}/test:
+        post:
+            description: Test validates an SSF receiver stream's configuration by checking JWKS reachability, identity resolution, and action preview without processing real events.
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverStreamService.Test
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    description: The ID of the SSF receiver stream to test.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceTestRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceTestResponse'
+                    description: SSFReceiverStreamServiceTestResponse reports the results of the stream configuration test across JWKS, identity, and action readiness checks.
+            summary: Test
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverStream
+            x-speakeasy-name-override: Test
+    /api/v1/ssf-receiver-streams/{stream_id}/events:
+        get:
+            description: List returns a paginated list of events received on a specific SSF receiver stream, ordered by receipt time.
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverEventService.List
+            parameters:
+                - in: path
+                  name: stream_id
+                  required: true
+                  schema:
+                    description: The ID of the SSF receiver stream to list events for.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: page_size
+                  schema:
+                    description: Maximum number of events to return per page.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: Token from a previous ListResponse to fetch the next page of results.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverEventServiceListResponse'
+                    description: SSFReceiverEventServiceListResponse contains a page of received SSF events.
+            summary: List
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverEvent
+            x-speakeasy-name-override: List
+    /api/v1/ssf-receiver-streams/{stream_id}/stats:
+        get:
+            description: GetStats retrieves event processing statistics for a specific SSF receiver stream, including counts of received, acted-on, and failed events.
+            operationId: c1.api.ssf_receiver.v1.SSFReceiverStreamService.GetStats
+            parameters:
+                - in: path
+                  name: stream_id
+                  required: true
+                  schema:
+                    description: The ID of the SSF receiver stream to get stats for.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.ssf_receiver.v1.SSFReceiverStreamServiceGetStatsResponse'
+                    description: SSFReceiverStreamServiceGetStatsResponse contains the event processing statistics for the stream.
+            summary: Get Stats
+            tags:
+                - SSF Receiver
+            x-speakeasy-group: SSFReceiverStream
+            x-speakeasy-name-override: GetStats
     /api/v1/step-up/providers:
         get:
-            description: Invokes the c1.api.stepup.v1.StepUpProviderService.List method.
+            description: List returns all step-up authentication providers configured for the tenant.
             operationId: c1.api.stepup.v1.StepUpProviderService.List
             responses:
                 "200":
@@ -32910,7 +39420,7 @@ paths:
             x-speakeasy-group: StepUpProvider
             x-speakeasy-name-override: List
         post:
-            description: Invokes the c1.api.stepup.v1.StepUpProviderService.Create method.
+            description: Create registers a new step-up authentication provider for the tenant.
             operationId: c1.api.stepup.v1.StepUpProviderService.Create
             requestBody:
                 content:
@@ -32931,14 +39441,14 @@ paths:
             x-speakeasy-name-override: Create
     /api/v1/step-up/providers/{id}:
         delete:
-            description: Invokes the c1.api.stepup.v1.StepUpProviderService.Delete method.
+            description: Delete removes a step-up authentication provider from the tenant.
             operationId: c1.api.stepup.v1.StepUpProviderService.Delete
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the step-up provider to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -32959,14 +39469,14 @@ paths:
             x-speakeasy-group: StepUpProvider
             x-speakeasy-name-override: Delete
         get:
-            description: Invokes the c1.api.stepup.v1.StepUpProviderService.Get method.
+            description: Get retrieves a single step-up authentication provider by its ID.
             operationId: c1.api.stepup.v1.StepUpProviderService.Get
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the step-up provider to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -32982,14 +39492,14 @@ paths:
             x-speakeasy-group: StepUpProvider
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.stepup.v1.StepUpProviderService.Update method.
+            description: Update modifies an existing step-up authentication provider's configuration. Use the update mask to specify which fields to change.
             operationId: c1.api.stepup.v1.StepUpProviderService.Update
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the step-up provider.
                     readOnly: true
                     type: string
             requestBody:
@@ -33011,14 +39521,14 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/step-up/providers/{id}/secret:
         post:
-            description: Invokes the c1.api.stepup.v1.StepUpProviderService.UpdateSecret method.
+            description: UpdateSecret rotates the client secret for a step-up authentication provider without modifying other settings.
             operationId: c1.api.stepup.v1.StepUpProviderService.UpdateSecret
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the step-up provider whose secret is being rotated.
                     readOnly: false
                     type: string
             requestBody:
@@ -33040,14 +39550,14 @@ paths:
             x-speakeasy-name-override: UpdateSecret
     /api/v1/step-up/providers/{id}/test:
         post:
-            description: Invokes the c1.api.stepup.v1.StepUpProviderService.Test method.
+            description: Test initiates a test authentication flow against a step-up provider and returns a redirect URL for the caller to complete verification.
             operationId: c1.api.stepup.v1.StepUpProviderService.Test
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the step-up provider to test.
                     readOnly: false
                     type: string
             requestBody:
@@ -33168,7 +39678,7 @@ paths:
             x-speakeasy-name-override: Create
     /api/v1/systemlog/exports/{export_id}:
         delete:
-            description: Delete a policy by ID.
+            description: Delete a system log export by ID.
             operationId: c1.api.systemlog.v1.ExportService.Delete
             parameters:
                 - in: path
@@ -33219,7 +39729,7 @@ paths:
             x-speakeasy-group: Export
             x-speakeasy-name-override: Get
         post:
-            description: Update a system log export by providing a policy object and an update mask.
+            description: Update a system log export by providing an export object and an update mask.
             operationId: c1.api.systemlog.v1.ExportService.Update
             parameters:
                 - in: path
@@ -33248,14 +39758,14 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/systemlog/exports/{export_id}/events:
         post:
-            description: Invokes the c1.api.systemlog.v1.ExportService.ListEvents method.
+            description: List audit events belonging to a specific system log export.
             operationId: c1.api.systemlog.v1.ExportService.ListEvents
             parameters:
                 - in: path
                   name: export_id
                   required: true
                   schema:
-                    description: The exportId field.
+                    description: The ID of the system log export whose events are being listed.
                     readOnly: false
                     type: string
             requestBody:
@@ -33269,7 +39779,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.systemlog.v1.ExportServiceListEventsResponse'
-                    description: Successful response
+                    description: ExportServiceListEventsResponse is the response containing audit events for an export.
             summary: List Events
             tags:
                 - System Log Exporter
@@ -33277,7 +39787,7 @@ paths:
             x-speakeasy-name-override: ListEvents
     /api/v1/task/audits:
         post:
-            description: Invokes the c1.api.task.v1.TaskAudit.List method.
+            description: List audit trail events for a task.
             operationId: c1.api.task.v1.TaskAudit.List
             requestBody:
                 content:
@@ -33323,7 +39833,7 @@ paths:
             x-speakeasy-name-override: CreateGrantTask
     /api/v1/task/offboarding:
         post:
-            description: Invokes the c1.api.task.v1.TaskService.CreateOffboardingTask method.
+            description: Create an offboarding task to remove a user's access across applications.
             operationId: c1.api.task.v1.TaskService.CreateOffboardingTask
             requestBody:
                 content:
@@ -33336,7 +39846,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.task.v1.TaskServiceCreateOffboardingResponse'
-                    description: Successful response
+                    description: The TaskServiceCreateOffboardingResponse returns the created offboarding task with optional expanded related objects.
             summary: Create Offboarding Task
             tags:
                 - Task
@@ -33402,7 +39912,7 @@ paths:
             x-speakeasy-name-override: Get
     /api/v1/tasks/{task_id}/action/approve:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.Approve method.
+            description: Approve the specified policy step on a task.
             operationId: c1.api.task.v1.TaskActionsService.Approve
             parameters:
                 - in: path
@@ -33431,7 +39941,7 @@ paths:
             x-speakeasy-name-override: Approve
     /api/v1/tasks/{task_id}/action/approve-with-step-up:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.ApproveWithStepUp method.
+            description: Approve a task that requires step-up authentication. If a verified step-up transaction ID is provided, the approval is processed immediately. Otherwise, a redirect URL is returned for the caller to complete authentication first.
             operationId: c1.api.task.v1.TaskActionsService.ApproveWithStepUp
             parameters:
                 - in: path
@@ -33460,14 +39970,14 @@ paths:
             x-speakeasy-name-override: ApproveWithStepUp
     /api/v1/tasks/{task_id}/action/close:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.Close method.
+            description: Close a task, ending its workflow.
             operationId: c1.api.task.v1.TaskActionsService.Close
             parameters:
                 - in: path
                   name: task_id
                   required: true
                   schema:
-                    description: The taskId field.
+                    description: The ID of the task to close.
                     readOnly: false
                     type: string
             requestBody:
@@ -33489,7 +39999,7 @@ paths:
             x-speakeasy-name-override: Close
     /api/v1/tasks/{task_id}/action/comment:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.Comment method.
+            description: Post a comment on a task without changing its state.
             operationId: c1.api.task.v1.TaskActionsService.Comment
             parameters:
                 - in: path
@@ -33518,7 +40028,7 @@ paths:
             x-speakeasy-name-override: Comment
     /api/v1/tasks/{task_id}/action/deny:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.Deny method.
+            description: Deny the specified policy step on a task. In multi-step policies, this may route to fallback steps rather than finalizing the task outcome.
             operationId: c1.api.task.v1.TaskActionsService.Deny
             parameters:
                 - in: path
@@ -33547,14 +40057,14 @@ paths:
             x-speakeasy-name-override: Deny
     /api/v1/tasks/{task_id}/action/escalate:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.EscalateToEmergencyAccess method.
+            description: Escalate a grant task to use the emergency access policy, bypassing the normal approval flow. Only valid for grant tasks.
             operationId: c1.api.task.v1.TaskActionsService.EscalateToEmergencyAccess
             parameters:
                 - in: path
                   name: task_id
                   required: true
                   schema:
-                    description: The taskId field.
+                    description: The ID of the task to escalate.
                     readOnly: false
                     type: string
             requestBody:
@@ -33568,7 +40078,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.task.v1.TaskServiceActionResponse'
-                    description: Successful response
+                    description: A generic response for task action endpoints, containing the updated task and the ID of the action that was created.
             summary: Escalate To Emergency Access
             tags:
                 - Task
@@ -33576,7 +40086,7 @@ paths:
             x-speakeasy-name-override: EscalateToEmergencyAccess
     /api/v1/tasks/{task_id}/action/process:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.ProcessNow method.
+            description: Trigger immediate processing of a task, bypassing any scheduled wait. For tasks linked to an external system, this also attempts to sync the external state.
             operationId: c1.api.task.v1.TaskActionsService.ProcessNow
             parameters:
                 - in: path
@@ -33597,7 +40107,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.task.v1.TaskActionsServiceProcessNowResponse'
-                    description: Successful response
+                    description: The TaskActionsServiceProcessNowResponse returns the task view after triggering immediate processing.
             summary: Process Now
             tags:
                 - Task
@@ -33605,14 +40115,14 @@ paths:
             x-speakeasy-name-override: ProcessNow
     /api/v1/tasks/{task_id}/action/reassign:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.Reassign method.
+            description: Reassign a task's current policy step to a different set of users. The target step must be an approval, provision, or form step.
             operationId: c1.api.task.v1.TaskActionsService.Reassign
             parameters:
                 - in: path
                   name: task_id
                   required: true
                   schema:
-                    description: The taskId field.
+                    description: The ID of the task to reassign.
                     readOnly: false
                     type: string
             requestBody:
@@ -33634,7 +40144,7 @@ paths:
             x-speakeasy-name-override: Reassign
     /api/v1/tasks/{task_id}/action/reset:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.HardReset method.
+            description: Reset a task and recalculate its policy from scratch. Unlike Restart, this re-evaluates which policy applies to the task.
             operationId: c1.api.task.v1.TaskActionsService.HardReset
             parameters:
                 - in: path
@@ -33655,7 +40165,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.task.v1.TaskActionsServiceHardResetResponse'
-                    description: Successful response
+                    description: The TaskActionsServiceHardResetResponse returns the updated task after a hard reset.
             summary: Hard Reset
             tags:
                 - Task
@@ -33663,7 +40173,7 @@ paths:
             x-speakeasy-name-override: HardReset
     /api/v1/tasks/{task_id}/action/restart:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.Restart method.
+            description: Restart a task, returning it to the beginning of its current policy workflow.
             operationId: c1.api.task.v1.TaskActionsService.Restart
             parameters:
                 - in: path
@@ -33684,7 +40194,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.task.v1.TaskActionsServiceRestartResponse'
-                    description: Successful response
+                    description: The TaskActionsServiceRestartResponse returns the updated task after restarting.
             summary: Restart
             tags:
                 - Task
@@ -33692,7 +40202,7 @@ paths:
             x-speakeasy-name-override: Restart
     /api/v1/tasks/{task_id}/action/skip-step:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.SkipStep method.
+            description: Skip a specific policy step in a task, advancing the task to the next step in the workflow.
             operationId: c1.api.task.v1.TaskActionsService.SkipStep
             parameters:
                 - in: path
@@ -33713,7 +40223,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.task.v1.TaskServiceActionResponse'
-                    description: Successful response
+                    description: A generic response for task action endpoints, containing the updated task and the ID of the action that was created.
             summary: Skip Step
             tags:
                 - Task
@@ -33721,7 +40231,7 @@ paths:
             x-speakeasy-name-override: SkipStep
     /api/v1/tasks/{task_id}/action/update-grant-duration:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.UpdateGrantDuration method.
+            description: Update the grant duration for a task. Only applies to grant tasks with a single entitlement that are not in a provision step. The new duration must not exceed the entitlement's maximum allowed provision time.
             operationId: c1.api.task.v1.TaskActionsService.UpdateGrantDuration
             parameters:
                 - in: path
@@ -33742,7 +40252,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.task.v1.TaskServiceActionResponse'
-                    description: Successful response
+                    description: A generic response for task action endpoints, containing the updated task and the ID of the action that was created.
             summary: Update Grant Duration
             tags:
                 - Task
@@ -33750,7 +40260,7 @@ paths:
             x-speakeasy-name-override: UpdateGrantDuration
     /api/v1/tasks/{task_id}/action/update-request-data:
         post:
-            description: Invokes the c1.api.task.v1.TaskActionsService.UpdateRequestData method.
+            description: Update the request data on a task that is currently in a form step. The submitted data is validated against the form schema before being applied.
             operationId: c1.api.task.v1.TaskActionsService.UpdateRequestData
             parameters:
                 - in: path
@@ -33771,7 +40281,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.task.v1.TaskServiceActionResponse'
-                    description: Successful response
+                    description: A generic response for task action endpoints, containing the updated task and the ID of the action that was created.
             summary: Update Request Data
             tags:
                 - Task
@@ -33833,14 +40343,14 @@ paths:
             x-speakeasy-name-override: Get
     /api/v1/users/{user_id}/profile-types:
         get:
-            description: Invokes the c1.api.user.v1.UserService.GetUserProfileTypes method.
+            description: Retrieve the profile types associated with a user across their connected apps.
             operationId: c1.api.user.v1.UserService.GetUserProfileTypes
             parameters:
                 - in: path
                   name: user_id
                   required: true
                   schema:
-                    description: The userId field.
+                    description: The ID of the user whose profile types are being retrieved.
                     readOnly: false
                     type: string
             responses:
@@ -33849,7 +40359,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.user.v1.GetUserProfileTypesResponse'
-                    description: Successful response
+                    description: GetUserProfileTypesResponse is the response containing the profile types for a user.
             summary: Get User Profile Types
             tags:
                 - User
@@ -33857,14 +40367,14 @@ paths:
             x-speakeasy-name-override: GetUserProfileTypes
     /api/v1/users/{user_id}/set-delegation-by-admin:
         post:
-            description: Invokes the c1.api.user.v1.UserService.SetExpiringUserDelegationBindingByAdmin method.
+            description: Set or update an expiring delegation binding for a user, allowing an admin to designate a temporary delegate.
             operationId: c1.api.user.v1.UserService.SetExpiringUserDelegationBindingByAdmin
             parameters:
                 - in: path
                   name: user_id
                   required: true
                   schema:
-                    description: The userId field.
+                    description: The ID of the user whose tasks will be delegated.
                     readOnly: false
                     type: string
             requestBody:
@@ -33878,7 +40388,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.user.v1.SetExpiringUserDelegationBindingByAdminResponse'
-                    description: Successful response
+                    description: SetExpiringUserDelegationBindingByAdminResponse is the response containing the created or updated delegation binding.
             summary: Set Expiring User Delegation Binding By Admin
             tags:
                 - User
@@ -33886,7 +40396,7 @@ paths:
             x-speakeasy-name-override: SetExpiringUserDelegationBindingByAdmin
     /api/v1/vaults:
         post:
-            description: Invokes the c1.api.vault.v1.VaultService.Create method.
+            description: Create provisions a new external secret storage vault and returns it.
             operationId: c1.api.vault.v1.VaultService.Create
             requestBody:
                 content:
@@ -33899,7 +40409,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.vault.v1.VaultServiceCreateResponse'
-                    description: Successful response
+                    description: VaultServiceCreateResponse is the response message for creating a new vault.
             summary: Create
             tags:
                 - Vault
@@ -33912,14 +40422,14 @@ paths:
             x-stability-level: draft
     /api/v1/vaults/{id}:
         delete:
-            description: Invokes the c1.api.vault.v1.VaultService.Delete method.
+            description: Delete a vault by its ID. Active connectors using this vault will no longer be able to access their stored credentials.
             operationId: c1.api.vault.v1.VaultService.Delete
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the vault to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -33945,14 +40455,14 @@ paths:
             x-speakeasy-name-override: Delete
             x-stability-level: draft
         get:
-            description: Invokes the c1.api.vault.v1.VaultService.Get method.
+            description: Get returns a single vault by its ID.
             operationId: c1.api.vault.v1.VaultService.Get
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the vault to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -33961,7 +40471,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.vault.v1.VaultServiceGetResponse'
-                    description: Successful response
+                    description: VaultServiceGetResponse is the response message containing the requested vault.
             summary: Get
             tags:
                 - Vault
@@ -33974,14 +40484,14 @@ paths:
             x-speakeasy-name-override: Get
             x-stability-level: draft
         post:
-            description: Invokes the c1.api.vault.v1.VaultService.Update method.
+            description: Update modifies an existing vault's properties using a field mask.
             operationId: c1.api.vault.v1.VaultService.Update
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the vault.
                     readOnly: false
                     type: string
             requestBody:
@@ -33995,7 +40505,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/c1.api.vault.v1.VaultServiceUpdateResponse'
-                    description: Successful response
+                    description: VaultServiceUpdateResponse is the response message containing the updated vault.
             summary: Update
             tags:
                 - Vault
@@ -34008,20 +40518,20 @@ paths:
             x-stability-level: draft
     /api/v1/webhooks:
         get:
-            description: Invokes the c1.api.webhooks.v1.WebhooksService.List method.
+            description: List all webhook subscriptions in the tenant, with pagination.
             operationId: c1.api.webhooks.v1.WebhooksService.List
             parameters:
                 - in: query
                   name: page_size
                   schema:
-                    description: The pageSize field.
+                    description: The maximum number of webhooks to return per page.
                     format: int32
                     readOnly: false
                     type: integer
                 - in: query
                   name: page_token
                   schema:
-                    description: The pageToken field.
+                    description: The pagination token from a previous list response to fetch the next page.
                     readOnly: false
                     type: string
             responses:
@@ -34037,7 +40547,7 @@ paths:
             x-speakeasy-group: Webhooks
             x-speakeasy-name-override: List
         post:
-            description: Invokes the c1.api.webhooks.v1.WebhooksService.Create method.
+            description: Create a new webhook subscription to receive event notifications at the specified URL.
             operationId: c1.api.webhooks.v1.WebhooksService.Create
             requestBody:
                 content:
@@ -34062,14 +40572,14 @@ paths:
             x-speakeasy-name-override: Create
     /api/v1/webhooks/{id}:
         delete:
-            description: Invokes the c1.api.webhooks.v1.WebhooksService.Delete method.
+            description: Delete a webhook subscription, stopping all future event deliveries to its URL.
             operationId: c1.api.webhooks.v1.WebhooksService.Delete
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the webhook to delete.
                     readOnly: false
                     type: string
             requestBody:
@@ -34094,14 +40604,14 @@ paths:
             x-speakeasy-group: Webhooks
             x-speakeasy-name-override: Delete
         get:
-            description: Invokes the c1.api.webhooks.v1.WebhooksService.Get method.
+            description: Retrieve a single webhook by its ID.
             operationId: c1.api.webhooks.v1.WebhooksService.Get
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the webhook to retrieve.
                     readOnly: false
                     type: string
             responses:
@@ -34122,14 +40632,14 @@ paths:
             x-speakeasy-group: Webhooks
             x-speakeasy-name-override: Get
         post:
-            description: Invokes the c1.api.webhooks.v1.WebhooksService.Update method.
+            description: Update an existing webhook subscription's properties, such as its URL or display name.
             operationId: c1.api.webhooks.v1.WebhooksService.Update
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The unique identifier of the webhook.
                     readOnly: false
                     type: string
             requestBody:
@@ -34155,14 +40665,14 @@ paths:
             x-speakeasy-name-override: Update
     /api/v1/webhooks/{id}/test:
         post:
-            description: Invokes the c1.api.webhooks.v1.WebhooksService.Test method.
+            description: Send a sample event to the webhook URL to verify that the endpoint is reachable and responding correctly.
             operationId: c1.api.webhooks.v1.WebhooksService.Test
             parameters:
                 - in: path
                   name: id
                   required: true
                   schema:
-                    description: The id field.
+                    description: The ID of the webhook to send a test event to.
                     readOnly: false
                     type: string
             requestBody:
@@ -34325,11 +40835,268 @@ paths:
                 - Workload Federation
             x-speakeasy-group: WorkloadFederation
             x-speakeasy-name-override: TestCEL
+    /api/v2/apps/{app_id}/entitlements/{entitlement_id}/owners:
+        put:
+            description: Set replaces all owners for a given app entitlement and role.
+            operationId: c1.api.app.v2.AppEntitlementOwners.Set
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                - in: path
+                  name: entitlement_id
+                  required: true
+                  schema:
+                    description: The entitlementId field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.app.v2.SetAppEntitlementOwnersV2RequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.app.v2.SetAppEntitlementOwnersV2Response'
+                    description: SetAppEntitlementOwnersV2Response is the empty response for setting app entitlement owners.
+            summary: Set
+            tags:
+                - App Entitlement Owner V2
+            x-speakeasy-group: AppEntitlementOwnersV2
+            x-speakeasy-name-override: Set
+            x-stability-level: draft
+    /api/v2/apps/{app_id}/entitlements/{entitlement_id}/owners/entitlements:
+        get:
+            description: SearchEntitlementOwners searches for the entitlement ownership for an app entitlement.
+            operationId: c1.api.app.v2.AppEntitlementOwners.SearchEntitlementOwners
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                - in: path
+                  name: entitlement_id
+                  required: true
+                  schema:
+                    description: The entitlementId field.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: page_size
+                  schema:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: role_slug
+                  schema:
+                    description: Empty means "any role" (no filter).
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.app.v2.SearchAppEntitlementEntitlementOwnersResponse'
+                    description: SearchAppEntitlementEntitlementOwnersResponse is the response for searching entitlement ownership sources on an entitlement.
+            summary: Search Entitlement Owners
+            tags:
+                - App Entitlement Owner V2
+            x-speakeasy-group: AppEntitlementOwnersV2
+            x-speakeasy-name-override: SearchEntitlementOwners
+            x-stability-level: draft
+    /api/v2/apps/{app_id}/entitlements/{entitlement_id}/owners/users:
+        get:
+            description: SearchUserOwners searches for users who are owners of this app entitlement.
+            operationId: c1.api.app.v2.AppEntitlementOwners.SearchUserOwners
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                - in: path
+                  name: entitlement_id
+                  required: true
+                  schema:
+                    description: The entitlementId field.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: page_size
+                  schema:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: role_slug
+                  schema:
+                    description: Empty means "any role" (no filter).
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.app.v2.SearchAppEntitlementUserOwnersResponse'
+                    description: SearchAppEntitlementUserOwnersResponse is the response for searching user ownership sources on an entitlement.
+            summary: Search User Owners
+            tags:
+                - App Entitlement Owner V2
+            x-speakeasy-group: AppEntitlementOwnersV2
+            x-speakeasy-name-override: SearchUserOwners
+            x-stability-level: draft
+    /api/v2/apps/{app_id}/owners:
+        put:
+            description: Set replaces all user owners for a given app and role.
+            operationId: c1.api.app.v2.AppOwners.Set
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/c1.api.app.v2.SetAppOwnersRequestInput'
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.app.v2.SetAppOwnersResponse'
+                    description: SetAppOwnersResponse is the empty response for setting app owners.
+            summary: Set
+            tags:
+                - App Owner V2
+            x-speakeasy-group: AppOwnersV2
+            x-speakeasy-name-override: Set
+            x-stability-level: draft
+    /api/v2/apps/{app_id}/owners/entitlements:
+        get:
+            description: SearchEntitlementOwners searches for entitlement ownership sources for an app.
+            operationId: c1.api.app.v2.AppOwners.SearchEntitlementOwners
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: page_size
+                  schema:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: role_slug
+                  schema:
+                    description: The roleSlug field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.app.v2.SearchEntitlementOwnersResponse'
+                    description: SearchEntitlementOwnersResponse is the response for searching entitlement ownership sources.
+            summary: Search Entitlement Owners
+            tags:
+                - App Owner V2
+            x-speakeasy-group: AppOwnersV2
+            x-speakeasy-name-override: SearchEntitlementOwners
+            x-stability-level: draft
+    /api/v2/apps/{app_id}/owners/users:
+        get:
+            description: SearchUserOwners searches for user ownership sources for an app.
+            operationId: c1.api.app.v2.AppOwners.SearchUserOwners
+            parameters:
+                - in: path
+                  name: app_id
+                  required: true
+                  schema:
+                    description: The appId field.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: page_size
+                  schema:
+                    description: The pageSize field.
+                    format: int32
+                    readOnly: false
+                    type: integer
+                - in: query
+                  name: page_token
+                  schema:
+                    description: The pageToken field.
+                    readOnly: false
+                    type: string
+                - in: query
+                  name: role_slug
+                  schema:
+                    description: The roleSlug field.
+                    readOnly: false
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/c1.api.app.v2.SearchUserOwnersResponse'
+                    description: SearchUserOwnersResponse is the response for searching user ownership sources.
+            summary: Search User Owners
+            tags:
+                - App Owner V2
+            x-speakeasy-group: AppOwnersV2
+            x-speakeasy-name-override: SearchUserOwners
+            x-stability-level: draft
 security:
     - bearerAuth: []
       oauth: []
 servers:
-    - description: The ConductorOne API server for the current tenant.
+    - description: The C1 API server for the current tenant.
       url: https://{tenantDomain}.conductor.one
       variables:
         tenantDomain:


### PR DESCRIPTION
## Summary

Pulls c1 main's openapi.yaml at sha [\`2b228a7901\`](https://github.com/ductone/c1/commit/2b228a79013f28071fc012930181e6f9813c1b23) into this repo.

## Why

openapi.yaml on this repo's main has been frozen at PR #191's state since the last release ([v1.0.40](https://github.com/ConductorOne/terraform-provider-conductorone/releases/tag/v1.0.40), 2026-03-18). Six weeks of c1 spec drift have accumulated without flowing through to the SDK because the daily Speakeasy regen workflow has been silently broken — the plumbing fixes landed today (#198/#199/#200/#201) but the cron uses `./openapi.yaml` from this repo (per `.speakeasy/workflow.yaml: inputs: - location: ./openapi.yaml`), so the regen output is only as fresh as what's committed here.

The diff vs main spans:

- **IGA-1181 collision fix** ([c1#16848](https://github.com/ductone/c1/pull/16848)): V2 group overrides (AppOwnersV2 / AppEntitlementOwnersV2) and renamed schemas (AccessConflictNotificationConfig, AutomationsTaskAction, PolicyForm). HCL attribute renames will follow when the regen runs.
- **New API surfaces**: paper-secret, role-mining-management, principal/credentials, workload-federation, A2UI surfaces + feedback + actions, automations expansion, webhook callback_timeout.
- **Response shape changes**: TaskView, AccessReview/AccessReviewTemplate create/update/get/list, TaskAudit list. These already exist on c1 main; surfacing in the SDK is just catching up.

Stats: 34337 → 41041 lines (+6700), 1.56 MB → 1.90 MB.

## Test plan

After merge, the next [Speakeasy daily regen](https://github.com/ConductorOne/terraform-provider-conductorone/actions/workflows/speakeasy_sdk_generation.yml) (or manual \`workflow_dispatch\` with \`force: true\`) should regenerate against this spec and open a PR with the actual SDK changes — that PR is where the breaking-change discussion happens, and per [the v2.0.0-alpha plan](https://www.speakeasy.com/docs/sdks/manage/versioning) we'd cut as a major+prerelease release once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)