### PR TITLE
Align make generate output with Speakeasy regen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,5 +125,5 @@ install-hooks:
 	@echo "      Install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8"
 
 .PHONY: generate
-generate: fmt
-	cd tools && go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir .. --provider-name conductorone
+generate:
+	cd tools && go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir .. --provider-name conductorone --rendered-provider-name terraform-provider-conductorone


### PR DESCRIPTION
## Summary

Two-line Makefile change so `make generate` produces output identical to what the Speakeasy daily regen commits, eliminating spurious "Confirm no diff" failures on every regen PR (e.g., #205).

## Why

PR #205's Build job is failing with 197 diffs after `make generate`:

- **196 docs files**: `page_title` mismatch. Speakeasy invokes tfplugindocs with `--rendered-provider-name terraform-provider-conductorone` (CI's checkout dir name, not stripped); our Makefile passed only `--provider-name conductorone` and let rendered-provider-name default to the provider-name value.
- **1 Go file (`utils.go`)**: `gofmt -s` collapses Speakeasy's unsimplified `[]map[string]interface{}{map[string]interface{}{…}}` literal back to `{{…}}`. `make generate: fmt` was running `gofmt -s -w` first, undoing the regen output.

## Changes

- Add `--rendered-provider-name terraform-provider-conductorone` to the `tfplugindocs` invocation.
- Drop `fmt` as a prerequisite of `generate` — `make fmt` still works standalone for dev convenience.

## Test plan

- [x] Local `make generate` against post-#204 main: only docs that have `templates/` files re-render (20 of them), all with page_title `"X - terraform-provider-conductorone"` matching Speakeasy.
- [ ] After merge: rebase #205, re-run its Build job, "Confirm no diff" should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)