### PR TITLE
Set gen.yaml terraform.version to 1.1.0 for next regen

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -35,7 +35,7 @@ generation:
   persistentEdits: {}
   versioningStrategy: automatic
 terraform:
-  version: 2.0.0-alpha.1
+  version: 1.1.0
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}


### PR DESCRIPTION
## Summary

Pre-stages a minor version bump in `gen.yaml` (`terraform.version: 2.0.0-alpha.1 → 1.1.0`) so the next Speakeasy regen produces v1.1.0.

## Why minor

The next regen ships substantial accumulated additive surface since v1.0.40 — new resources, new data sources, new attributes on existing resources, plus 4 new connector integrations (134 → 138 in `internal/provider/integrations.go`).

Also includes a small set of internal type-name consolidations from ongoing SDK development; those don't change customer-visible HCL because TF resource names and attribute keys come from `x-speakeasy-entity`, not `x-speakeasy-name-override`.

A minor bump matches the additive nature of the changes per standard semver.

## Mechanism

Speakeasy compares `gen.yaml`'s `<target>.version` against `.speakeasy/gen.lock`'s `releaseVersion`. When they mismatch, the next `speakeasy run` applies the gen.yaml value.

## Sequence

1. This PR merges first — pre-stages the version signal. No code regen yet.
2. Next regen (bot or manual `make gen` / `speakeasy run`) sees gen.yaml@1.1.0 vs gen.lock@1.7.16, applies the bump, regenerates, opens a PR.
3. Apply post-regen patches per the project's standard ritual (BoolNull else-branch hand-fix, pagination verification, doc updates).
4. Run acceptance tests + empirical `terraform plan` against a real tenant.
5. Merge regen PR + tag v1.1.0.

## Test plan

- [x] `gen.yaml` syntactically valid (single-character version edit)
- [ ] After merge: confirm next `speakeasy run` / bot regen tags v1.1.0
- [ ] After regen: post-regen patches applied, acceptance tests pass, `terraform plan` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
