### PR TITLE
Build tfplugindocs binary, expose generate + validate-docs targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .speakeasy/temp/
 /*.md
 .claude
+/bin/

--- a/Makefile
+++ b/Makefile
@@ -135,9 +135,27 @@ install-hooks:
 	@echo "Note: golangci-lint v1.x (>= v1.63.0) is required for 'make lint' to work."
 	@echo "      Install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8"
 
+# tfplugindocs subcommands (generate / validate).
+#
 # --provider-name matches what Speakeasy's CI uses (filepath.Base of the
-# checkout dir = "terraform-provider-conductorone"), so make generate produces
-# the same page_title regardless of local worktree name.
+# checkout dir = "terraform-provider-conductorone"), so output is stable
+# regardless of local worktree name.
+#
+# We build the binary (pinned via tools/tools.go) and invoke it from the repo
+# root so its --provider-dir / --examples-dir / --templates-dir defaults
+# resolve to the repo's own directories. Running tfplugindocs as
+# `cd tools && go run ...` is functionally equivalent but obscures the default
+# resolution and rebuilds the binary on every invocation.
+bin/tfplugindocs:
+	go build -o $@ github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+
+# generate: regenerate docs/ from the live provider schema + templates/ + examples/.
 .PHONY: generate
-generate:
-	cd tools && go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir .. --provider-name terraform-provider-conductorone
+generate: bin/tfplugindocs
+	./bin/tfplugindocs generate --provider-name terraform-provider-conductorone
+
+# validate-docs: lint the generated docs structure (frontmatter, schema, links).
+# Read-only; safe to run in CI alongside generate.
+.PHONY: validate-docs
+validate-docs: bin/tfplugindocs
+	./bin/tfplugindocs validate --provider-name terraform-provider-conductorone


### PR DESCRIPTION
## Summary

- Replace `cd tools && go run github.com/.../tfplugindocs ... --provider-dir ..` with a `bin/tfplugindocs` build target invoked from the repo root.
- Add `validate-docs` target alongside the existing `generate`, exposing tfplugindocs's lint subcommand for CI use.
- Add `bin/` to `.gitignore`.

## Why

The `cd tools` trick was needed historically to keep tfplugindocs out of the provider's go.mod, but `tools/tools.go` already uses a `//go:build tools` tag so that's no longer necessary — `go build github.com/.../tfplugindocs` from anywhere in the module resolves through that pin. Building once into `bin/` and invoking from the repo root caches the binary and lets tfplugindocs's flag defaults (`--provider-dir`, `--examples-dir`, `--templates-dir`) resolve naturally without flag-threading.

## No docs delta

I confirmed the old target and the new target produce identical `docs/` output: `tfplugindocs validate --help` documents that `--examples-dir` and `--website-source-dir` defaults are *based on `--provider-dir`*, not CWD, so the original `--provider-dir ..` already pointed those at the repo's `examples/` and `templates/`. Running `make generate` after the cleanup produces a no-op diff against `origin/main`.

## Test plan

- [x] `make generate` produces a no-op `git diff` against `origin/main`
- [x] `make validate-docs` exits 0 against the current `docs/` tree
- [x] `bin/tfplugindocs` is gitignored
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)