### PR TITLE
v1.2.1: IGA-1774: fix deleted_at on nested entity-root resource schemas

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,14 +5,14 @@ management:
   docVersion: 0.1.0-alpha
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
-  releaseVersion: 1.2.0
-  configChecksum: 4d18f3c35added024768fffe9b62fb87
+  releaseVersion: 1.2.1
+  configChecksum: 93364f15faf0b793036456db5e4212d9
   repoURL: https://github.com/ConductorOne/terraform-provider-conductorone.git
   installationURL: https://github.com/ConductorOne/terraform-provider-conductorone
 persistentEdits:
-  generation_id: d0b4e3c3-132b-4936-b46d-2eeec01d4276
-  pristine_commit_hash: 0c6084c54e44e6a533bf2d3399fda80232ba2379
-  pristine_tree_hash: 80bc1ce408694653f6c61f6041d1795b04b3d3c7
+  generation_id: 1be949da-bf26-4d0a-b653-434697d8e1fe
+  pristine_commit_hash: b555d7c161e9494400625c1db1538164b3914314
+  pristine_tree_hash: bc0614080478ea8023b9318edfd29285d1a5a5b4
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -238,8 +238,8 @@ trackedFiles:
     pristine_git_object: cbbe422a1a74c6c026e9648210d723901bd6aaf2
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:5b94bfa61fc3a1633d8a7b29166d2d8411bfb35f
-    pristine_git_object: 1754ba02322090fddf43cd2771a71d5a9046cc54
+    last_write_checksum: sha1:070849023bf737a3e3398e126afde47014cc9289
+    pristine_git_object: c8085a2f2e3daea4f90f5a174f8ae22b87fa54d6
   examples/resources/conductorone_access_conflict/import-by-string-id.tf:
     id: 75fb8f5a6d65
     last_write_checksum: sha1:82d79ecc5a7d6ab27f4f9f9234e220e0e9f65914
@@ -654,8 +654,8 @@ trackedFiles:
     pristine_git_object: 4d31c6d83c73018fc1b8ecb34d4555a8b3574e98
   go.mod:
     id: c47645c391ad
-    last_write_checksum: sha1:e7c52a0fffed6b109b273dbb7917c124e5cfef5c
-    pristine_git_object: ddb34e4718382b88b7d104c8e47a35160023fc39
+    last_write_checksum: sha1:e882464b1c9e8601f0b0f26f3f26aaa123d8dd21
+    pristine_git_object: bcd58b5c353b5fa4dfe183efa01c05184aa89941
   internal/planmodifiers/boolplanmodifier/suppress_diff.go:
     id: 3cf85b98963e
     last_write_checksum: sha1:dd46ab59ac03cebd72b7c570eca1c5ffa971caf4
@@ -3106,8 +3106,8 @@ trackedFiles:
     pristine_git_object: ccda06344d8f1db2a6155a8b5a2fda6be064d9bb
   internal/sdk/conductoroneapi.go:
     id: 84087b0a6f93
-    last_write_checksum: sha1:f23007e0bac37a90b6a7f69328d06a0a03a4ab6e
-    pristine_git_object: eb326cc0682ea714442581a7af827b0a6eca790b
+    last_write_checksum: sha1:3292a72c5a55df5007f2e564b42f053816dac657
+    pristine_git_object: f4a2b27da6cafc00efbdec7da1f7ecd600704544
   internal/sdk/connector.go:
     id: 41e2af88fe9e
     last_write_checksum: sha1:5dc15c34dc12560961cce647f66fe1b4e5a2b8fb

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.761.10
+speakeasyVersion: 1.762.0
 sources:
     my-source:
         sourceNamespace: my-source
-        sourceRevisionDigest: sha256:e6f340862ce9bc6e22453fac710704be6919edfe43d8c5a52a64e88a3fa05782
-        sourceBlobDigest: sha256:0e64bbe5cdfb46f610562c9fcd0663b670e37fe937706f03594f48b669e6bfe7
+        sourceRevisionDigest: sha256:8ab04438872bf95ab63981dd48b41465582c400c7ca2fbd7b852149c156a034a
+        sourceBlobDigest: sha256:b67bb00b272c192ca549b49dc608aa08f293866f9fb9d51f1873f19c1c73a67d
         tags:
             - latest
             - 0.1.0-alpha
@@ -11,11 +11,11 @@ targets:
     conductorone-terraform:
         source: my-source
         sourceNamespace: my-source
-        sourceRevisionDigest: sha256:e6f340862ce9bc6e22453fac710704be6919edfe43d8c5a52a64e88a3fa05782
-        sourceBlobDigest: sha256:0e64bbe5cdfb46f610562c9fcd0663b670e37fe937706f03594f48b669e6bfe7
+        sourceRevisionDigest: sha256:8ab04438872bf95ab63981dd48b41465582c400c7ca2fbd7b852149c156a034a
+        sourceBlobDigest: sha256:b67bb00b272c192ca549b49dc608aa08f293866f9fb9d51f1873f19c1c73a67d
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.761.10
+    speakeasyVersion: 1.762.0
     sources:
         my-source:
             inputs:

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.1.1"
+      version = "1.2.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.2.0"
+      version = "1.2.1"
     }
   }
 }

--- a/docs/resources/app_entitlement_owner_entitlement.md
+++ b/docs/resources/app_entitlement_owner_entitlement.md
@@ -72,6 +72,7 @@ Read-Only:
 - `compliance_framework_value_ids` (List of String) The IDs of different compliance frameworks associated with this app entitlement ex (SOX, HIPAA, PCI, etc.)
 - `created_at` (String)
 - `default_values_applied` (Boolean) Flag to indicate if app-level access request defaults have been applied to the entitlement
+- `deleted_at` (String)
 - `deprovisioner_policy` (Attributes) ProvisionPolicy is a oneOf that indicates how a provision step should be processed.
 
 This message contains a oneof named typ. Only a single field of the following list may be set at a time:

--- a/docs/resources/app_entitlement_owner_entitlement.md
+++ b/docs/resources/app_entitlement_owner_entitlement.md
@@ -72,7 +72,6 @@ Read-Only:
 - `compliance_framework_value_ids` (List of String) The IDs of different compliance frameworks associated with this app entitlement ex (SOX, HIPAA, PCI, etc.)
 - `created_at` (String)
 - `default_values_applied` (Boolean) Flag to indicate if app-level access request defaults have been applied to the entitlement
-- `deleted_at` (String)
 - `deprovisioner_policy` (Attributes) ProvisionPolicy is a oneOf that indicates how a provision step should be processed.
 
 This message contains a oneof named typ. Only a single field of the following list may be set at a time:

--- a/docs/resources/app_entitlement_owner_user.md
+++ b/docs/resources/app_entitlement_owner_user.md
@@ -58,6 +58,7 @@ Read-Only:
 
 - `created_at` (String)
 - `delegated_user_id` (String) The id of the user to whom tasks will be automatically reassigned to.
+- `deleted_at` (String)
 - `department` (String) The department which the user belongs to in the organization.
 - `department_sources` (Attributes List) A list of objects mapped based on department attribute mappings configured in the system. (see [below for nested schema](#nestedatt--user--department_sources))
 - `directory_ids` (List of String) A list of unique ids that represent different directories.

--- a/docs/resources/app_owner_entitlement.md
+++ b/docs/resources/app_owner_entitlement.md
@@ -70,7 +70,6 @@ Read-Only:
 - `compliance_framework_value_ids` (List of String) The IDs of different compliance frameworks associated with this app entitlement ex (SOX, HIPAA, PCI, etc.)
 - `created_at` (String)
 - `default_values_applied` (Boolean) Flag to indicate if app-level access request defaults have been applied to the entitlement
-- `deleted_at` (String)
 - `deprovisioner_policy` (Attributes) ProvisionPolicy is a oneOf that indicates how a provision step should be processed.
 
 This message contains a oneof named typ. Only a single field of the following list may be set at a time:

--- a/docs/resources/app_owner_entitlement.md
+++ b/docs/resources/app_owner_entitlement.md
@@ -70,6 +70,7 @@ Read-Only:
 - `compliance_framework_value_ids` (List of String) The IDs of different compliance frameworks associated with this app entitlement ex (SOX, HIPAA, PCI, etc.)
 - `created_at` (String)
 - `default_values_applied` (Boolean) Flag to indicate if app-level access request defaults have been applied to the entitlement
+- `deleted_at` (String)
 - `deprovisioner_policy` (Attributes) ProvisionPolicy is a oneOf that indicates how a provision step should be processed.
 
 This message contains a oneof named typ. Only a single field of the following list may be set at a time:

--- a/docs/resources/app_owner_user.md
+++ b/docs/resources/app_owner_user.md
@@ -56,6 +56,7 @@ Read-Only:
 
 - `created_at` (String)
 - `delegated_user_id` (String) The id of the user to whom tasks will be automatically reassigned to.
+- `deleted_at` (String)
 - `department` (String) The department which the user belongs to in the organization.
 - `department_sources` (Attributes List) A list of objects mapped based on department attribute mappings configured in the system. (see [below for nested schema](#nestedatt--user--department_sources))
 - `directory_ids` (List of String) A list of unique ids that represent different directories.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.2.0"
+      version = "1.2.1"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -35,7 +35,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.2.0
+  version: 1.2.1
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}

--- a/internal/provider/app_entitlement_owner_entitlement_resource.go
+++ b/internal/provider/app_entitlement_owner_entitlement_resource.go
@@ -96,6 +96,9 @@ func (r *AppEntitlementOwnerEntitlementResource) Schema(ctx context.Context, req
 						Computed:    true,
 						Description: `Flag to indicate if app-level access request defaults have been applied to the entitlement`,
 					},
+					"deleted_at": schema.StringAttribute{
+						Computed: true,
+					},
 					"deprovisioner_policy": schema.SingleNestedAttribute{
 						Computed: true,
 						Attributes: map[string]schema.Attribute{

--- a/internal/provider/app_entitlement_owner_user_resource.go
+++ b/internal/provider/app_entitlement_owner_user_resource.go
@@ -90,6 +90,9 @@ func (r *AppEntitlementOwnerUserResource) Schema(ctx context.Context, req resour
 						Computed:    true,
 						Description: `The id of the user to whom tasks will be automatically reassigned to.`,
 					},
+					"deleted_at": schema.StringAttribute{
+						Computed: true,
+					},
 					"department": schema.StringAttribute{
 						Computed:    true,
 						Description: `The department which the user belongs to in the organization.`,

--- a/internal/provider/app_owner_entitlement_resource.go
+++ b/internal/provider/app_owner_entitlement_resource.go
@@ -95,6 +95,9 @@ func (r *AppOwnerEntitlementResource) Schema(ctx context.Context, req resource.S
 						Computed:    true,
 						Description: `Flag to indicate if app-level access request defaults have been applied to the entitlement`,
 					},
+					"deleted_at": schema.StringAttribute{
+						Computed: true,
+					},
 					"deprovisioner_policy": schema.SingleNestedAttribute{
 						Computed: true,
 						Attributes: map[string]schema.Attribute{

--- a/internal/provider/app_owner_user_resource.go
+++ b/internal/provider/app_owner_user_resource.go
@@ -81,6 +81,9 @@ func (r *AppOwnerUserResource) Schema(ctx context.Context, req resource.SchemaRe
 						Computed:    true,
 						Description: `The id of the user to whom tasks will be automatically reassigned to.`,
 					},
+					"deleted_at": schema.StringAttribute{
+						Computed: true,
+					},
 					"department": schema.StringAttribute{
 						Computed:    true,
 						Description: `The department which the user belongs to in the organization.`,

--- a/internal/provider/directory_resource.go
+++ b/internal/provider/directory_resource.go
@@ -103,6 +103,9 @@ func (r *DirectoryResource) Schema(ctx context.Context, req resource.SchemaReque
 							"created_at": schema.StringAttribute{
 								Computed: true,
 							},
+							"deleted_at": schema.StringAttribute{
+								Computed: true,
+							},
 							"directory_account_filter_all": schema.SingleNestedAttribute{
 								Computed:    true,
 								Description: `The DirectoryAccountFilterAll message.`,

--- a/internal/provider/speakeasy_regen_test.go
+++ b/internal/provider/speakeasy_regen_test.go
@@ -112,3 +112,37 @@ func TestNullableNestedStructsHaveElseBranch(t *testing.T) {
 		}
 	}
 }
+
+// TestNestedDeletedAtSchemaAttribute verifies that resource schemas nesting
+// entity-root types (AppEntitlement, User, Directory) declare the deleted_at
+// attribute in their nested SingleNestedAttribute block.
+//
+// Regression: Speakeasy's x-speakeasy-soft-delete-property handling correctly
+// strips deleted_at from the resource schema when the field sits on the entity
+// root, but on nested uses of the same shared struct it leaves the field on
+// the Go struct while omitting the schema attribute. The resulting
+// struct/schema mismatch crashes terraform plan/apply with
+// "Mismatch between struct and object type: Struct defines fields not found
+// in object: deleted_at". Patched by patches/02-deleted-at-on-nested-resources.patch.
+func TestNestedDeletedAtSchemaAttribute(t *testing.T) {
+	// Resource files that nest a *tfTypes.{AppEntitlement,User,Directory}
+	// and therefore need deleted_at restored after every regen.
+	resourceFiles := []string{
+		"app_entitlement_owner_entitlement_resource.go",
+		"app_owner_entitlement_resource.go",
+		"app_entitlement_owner_user_resource.go",
+		"app_owner_user_resource.go",
+		"directory_resource.go",
+	}
+
+	for _, f := range resourceFiles {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Errorf("reading %s: %v", f, err)
+			continue
+		}
+		if !strings.Contains(string(data), `"deleted_at":`) {
+			t.Errorf("%s: nested schema missing \"deleted_at\" attribute (IGA-1774 regression); apply patches/02-deleted-at-on-nested-resources.patch", f)
+		}
+	}
+}

--- a/internal/sdk/conductoroneapi.go
+++ b/internal/sdk/conductoroneapi.go
@@ -231,9 +231,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *ConductoroneAPI {
 	sdk := &ConductoroneAPI{
-		SDKVersion: "1.2.0",
+		SDKVersion: "1.2.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.2.0 2.882.0 0.1.0-alpha github.com/conductorone/terraform-provider-conductorone/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.2.1 2.882.0 0.1.0-alpha github.com/conductorone/terraform-provider-conductorone/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: []map[string]string{
 				{

--- a/patches/02-deleted-at-on-nested-resources.patch
+++ b/patches/02-deleted-at-on-nested-resources.patch
@@ -1,0 +1,103 @@
+From: Brandon High <759848+highb@users.noreply.github.com>
+Date: Wed May 13 2026
+Subject: [PATCH] Re-add deleted_at to nested resource schemas (IGA-1774)
+
+Speakeasy's x-speakeasy-soft-delete-property handling has a known bug on
+nested uses of an entity-root struct: the field gets stripped from the
+resource schema but stays on the Go struct, triggering
+"Mismatch between struct and object type: Struct defines fields not
+found in object: deleted_at" at terraform plan/apply time.
+
+Tried fixing this in overlay.yaml with x-speakeasy-terraform-ignore (the
+pattern used for AccessReview at overlay.yaml:668-679), but that
+approach removes the field from BOTH the struct and the schema, which
+breaks the resource Read method's soft-delete handler (the generated
+`if !data.DeletedAt.IsNull() { resp.State.RemoveResource(ctx) }` block
+on top-level resources for these same entity-root types). AccessReview
+gets away with that overlay because it has no top-level resource;
+AppEntitlement, User, and Directory all do.
+
+Fix: re-add deleted_at to the five resource schema sites that nest
+these entity-root types. Files:
+  - app_entitlement_owner_entitlement_resource.go (IGA-1774 reported)
+  - app_owner_entitlement_resource.go             (IGA-1774 reported)
+  - app_entitlement_owner_user_resource.go        (latent same-class bug)
+  - app_owner_user_resource.go                    (latent same-class bug)
+  - directory_resource.go                         (latent same-class bug)
+
+The patch will go away when upstream Speakeasy fixes
+x-speakeasy-soft-delete-property propagation to nested struct uses;
+file the bug upstream so this can be tracked.
+
+Refs: IGA-1774
+---
+diff --git a/internal/provider/app_entitlement_owner_entitlement_resource.go b/internal/provider/app_entitlement_owner_entitlement_resource.go
+index 1c106439..07065c19 100644
+--- a/internal/provider/app_entitlement_owner_entitlement_resource.go
++++ b/internal/provider/app_entitlement_owner_entitlement_resource.go
+@@ -96,6 +96,9 @@ func (r *AppEntitlementOwnerEntitlementResource) Schema(ctx context.Context, req
+ 						Computed:    true,
+ 						Description: `Flag to indicate if app-level access request defaults have been applied to the entitlement`,
+ 					},
++					"deleted_at": schema.StringAttribute{
++						Computed: true,
++					},
+ 					"deprovisioner_policy": schema.SingleNestedAttribute{
+ 						Computed: true,
+ 						Attributes: map[string]schema.Attribute{
+diff --git a/internal/provider/app_entitlement_owner_user_resource.go b/internal/provider/app_entitlement_owner_user_resource.go
+index 939eedb2..2a1a7972 100644
+--- a/internal/provider/app_entitlement_owner_user_resource.go
++++ b/internal/provider/app_entitlement_owner_user_resource.go
+@@ -90,6 +90,9 @@ func (r *AppEntitlementOwnerUserResource) Schema(ctx context.Context, req resour
+ 						Computed:    true,
+ 						Description: `The id of the user to whom tasks will be automatically reassigned to.`,
+ 					},
++					"deleted_at": schema.StringAttribute{
++						Computed: true,
++					},
+ 					"department": schema.StringAttribute{
+ 						Computed:    true,
+ 						Description: `The department which the user belongs to in the organization.`,
+diff --git a/internal/provider/app_owner_entitlement_resource.go b/internal/provider/app_owner_entitlement_resource.go
+index 47452dcc..4832f505 100644
+--- a/internal/provider/app_owner_entitlement_resource.go
++++ b/internal/provider/app_owner_entitlement_resource.go
+@@ -95,6 +95,9 @@ func (r *AppOwnerEntitlementResource) Schema(ctx context.Context, req resource.S
+ 						Computed:    true,
+ 						Description: `Flag to indicate if app-level access request defaults have been applied to the entitlement`,
+ 					},
++					"deleted_at": schema.StringAttribute{
++						Computed: true,
++					},
+ 					"deprovisioner_policy": schema.SingleNestedAttribute{
+ 						Computed: true,
+ 						Attributes: map[string]schema.Attribute{
+diff --git a/internal/provider/app_owner_user_resource.go b/internal/provider/app_owner_user_resource.go
+index 1ba915ef..78cddb00 100644
+--- a/internal/provider/app_owner_user_resource.go
++++ b/internal/provider/app_owner_user_resource.go
+@@ -81,6 +81,9 @@ func (r *AppOwnerUserResource) Schema(ctx context.Context, req resource.SchemaRe
+ 						Computed:    true,
+ 						Description: `The id of the user to whom tasks will be automatically reassigned to.`,
+ 					},
++					"deleted_at": schema.StringAttribute{
++						Computed: true,
++					},
+ 					"department": schema.StringAttribute{
+ 						Computed:    true,
+ 						Description: `The department which the user belongs to in the organization.`,
+diff --git a/internal/provider/directory_resource.go b/internal/provider/directory_resource.go
+index da606749..5ba19b1f 100644
+--- a/internal/provider/directory_resource.go
++++ b/internal/provider/directory_resource.go
+@@ -103,6 +103,9 @@ func (r *DirectoryResource) Schema(ctx context.Context, req resource.SchemaReque
+ 							"created_at": schema.StringAttribute{
+ 								Computed: true,
+ 							},
++							"deleted_at": schema.StringAttribute{
++								Computed: true,
++							},
+ 							"directory_account_filter_all": schema.SingleNestedAttribute{
+ 								Computed:    true,
+ 								Description: `The DirectoryAccountFilterAll message.`,


### PR DESCRIPTION
## Summary

- Fixes the `Mismatch between struct and object type: Struct defines fields not found in object: deleted_at` runtime crash reported in IGA-1774 on `conductorone_app_entitlement_owner_entitlement` (and its 4 same-class siblings).
- Adds `patches/02-deleted-at-on-nested-resources.patch` so the fix survives every `make gen` until upstream Speakeasy fixes `x-speakeasy-soft-delete-property` propagation on nested struct uses.
- Supersedes #218 (which patched generated code directly and would have regressed on next regen).

## Background

`x-speakeasy-soft-delete-property: true` (applied via the blanket `$..deletedAt` rule at `overlay.yaml:36-38`) correctly strips `deleted_at` from the resource schema when the field sits on an entity-root struct, but on **nested** uses of the same shared struct it leaves the field on the Go struct while omitting the schema attribute — producing the IGA-1774 mismatch.

The repo's existing AccessReview workaround at `overlay.yaml:668-679` uses `x-speakeasy-terraform-ignore: true` to strip the field from both struct and schema. That works there because no top-level resource exists for those types. **It does not work for AppEntitlement / User / Directory**: those have top-level resources whose generated `Read` method emits the soft-delete handler `if !data.DeletedAt.IsNull() { resp.State.RemoveResource(ctx) }` (e.g. `custom_app_entitlement_resource.go:1108`), which fails to compile without the struct field. The patches/ mechanism leaves the struct untouched and only re-adds the missing schema attribute at nesting sites.

## Affected sites (5)

| Site | Reported / latent | Fix |
|---|---|---|
| `internal/provider/app_entitlement_owner_entitlement_resource.go:99` | IGA-1774 reported | `+ "deleted_at": schema.StringAttribute{Computed: true}` |
| `internal/provider/app_owner_entitlement_resource.go:98` | IGA-1774 reported | same |
| `internal/provider/app_entitlement_owner_user_resource.go:93` | latent (nested `*tfTypes.User`) | same |
| `internal/provider/app_owner_user_resource.go:84` | latent (nested `*tfTypes.User`) | same |
| `internal/provider/directory_resource.go:106` | latent (nested `*tfTypes.Directory` via `DirectoryView`) | same |

Note: `directory_resource.go` is not registered in `provider.go` today, so users can't hit the crash there yet; patched proactively for the day someone wires it up.

13 shared `tfTypes.*` structs carry `tfsdk:"deleted_at"` (app, app_entitlement, app_resource, app_resource_type, app_user, attribute_value, directory, org_domain, policy, request_catalog, role, user, webhook_endpoint) — each is a latent IGA-1774 the moment a new resource nests it. The new tripwire test covers the current set; any future nesting resource needs to be added to the list (or trigger schema-vs-struct introspection — see follow-up below).

## Regression coverage

`TestNestedDeletedAtSchemaAttribute` in `internal/provider/speakeasy_regen_test.go` matches the existing `TestNullableNestedStructsHaveElseBranch` pattern for `patches/01`: enumerates the 5 resource files and asserts each still contains `"deleted_at":` after regen. If a future Speakeasy version emits the surrounding schema differently and the patch context drifts, the test fails on every affected file with a message pointing back at the patch.

Verified: passes on patched HEAD, fails on all 5 sites when `git apply -R patches/02-*.patch` is run.

## Test plan

- [ ] `speakeasy run && make apply-patches && make build && make test` — all green (verified locally)
- [ ] `terraform apply` with the HCL from the Linear issue against a real tenant — confirms the runtime mismatch is gone
- [ ] `git apply -R patches/02-deleted-at-on-nested-resources.patch && go test ./internal/provider/... -run TestNestedDeletedAtSchemaAttribute` — fails on all 5 sites (proves the tripwire is load-bearing)
- [ ] File the upstream Speakeasy bug: soft-delete-on-nested-types regression. Once fixed, drop `patches/02-*.patch` and the tripwire.

## Follow-up (not in this PR)

The text-match tripwire catches missing patches on the 5 known sites but won't catch a 6th nesting site landing without coverage. The original PR #218 review draft proposes a reflection-based test that walks every resource's `Schema()` output and asserts the attribute set matches its backing struct's tfsdk tags — that would be the broader regression net. Worth a follow-up PR if soft-delete-on-nested keeps recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)