### PR TITLE
fix(policy): stop approval bools drifting false→null (IGA-1899/IGA-1898)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -39,6 +39,22 @@ Pre-existing latent constructors that predate v1.0.40 are out of scope for any s
 
 For history: late 2025 versions silently dropped `Computed: true` on fields tagged `x-speakeasy-terraform-plan-only`, producing perpetual diffs on resources like `conductorone_custom_app_entitlement` (visible as `provision_policy`, `duration_grant`, `duration_unset` flapping on every refresh). Robert Chiniquy hit this in Dec 2025, defensively pinned 1.658.1, and the pin held until 1.761.10 in PR #199 (2026-04-30). The pin was applied 32 days before the upstream fix landed; nobody re-tested after the fix shipped, so the pin outlived the bug by ~5 months.
 
+## `conductorone_policy` approval bools drift `false → null` — FIXED (do not re-add object-level plan-only)
+
+### Status
+
+**Fixed** in this repo via `overlay.yaml` (IGA-1898 / IGA-1899). Do not mark the `c1.api.policy.v1.Approval` schema `x-speakeasy-terraform-plan-only: true`.
+
+### Background
+
+An approval step that leaves its optional scalar bools unset (`allow_delegation`, `allow_reassignment`, `assigned`, `escalation_enabled`, `require_approval_reason`, `require_denial_reason`, `require_reassignment_reason`, and the per-approver `allow_self_approval` / `require_distinct_approvers` / `is_group_fallback_enabled` / `fallback`, plus the optional list fields) showed a perpetual `false → null` diff on every `terraform plan`.
+
+Root cause is **plan-side, not read-side**. The C1 API marshals proto3 with `EmitUnpopulated=true`, so these scalars always come back as literal `false` — refresh writes `false` into state correctly. The drift came from object-level plan-only (`UseConfigValue`) on the parent `Approval` object: it stamped the *config* object onto the plan, and config-unset leaves are `null`, so the plan wanted `null` while state held `false`. A read-path coalesce (`BoolPointerOrFalse`) is a no-op for this because the API never omits the field.
+
+### Fix
+
+Do **not** put `x-speakeasy-terraform-plan-only` on `Approval`. Instead follow the same treatment already used for the `ProvisionPolicy` union: leave the parent object alone and set `x-speakeasy-param-computed: false` on each approver oneof member schema (`AgentApproval`, `ManagerApproval`, `AppGroupApproval`, `AppOwnerApproval`, `EntitlementOwnerApproval`, `ResourceOwnerApproval`, `SelfApproval`, `UserApproval`, `ExpressionApproval`, `WebhookApproval`). Unselected members then plan as `null` (config-driven), while a selected member's Computed scalar leaves retain the server's value — no cascade re-nulling them. `TestAccPolicyResource` (re-enabled) locks the apply→plan=no-diff invariant, including approver oneof switching.
+
 ## Speakeasy nullable-nested-struct flatten regression — STILL PRESENT
 
 ### Summary

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -5,7 +5,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	speakeasy_objectplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/objectplanmodifier"
 	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
 	speakeasy_objectvalidators "github.com/conductorone/terraform-provider-conductorone/internal/validators/objectvalidators"
@@ -15,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -169,12 +167,8 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 									},
 									"approval": schema.SingleNestedAttribute{
 										Optional: true,
-										PlanModifiers: []planmodifier.Object{
-											speakeasy_objectplanmodifier.UseConfigValue(),
-										},
 										Attributes: map[string]schema.Attribute{
 											"agent_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"agent_failure_action": schema.StringAttribute{
@@ -229,7 +223,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												Description: `List of users for whom this step can be reassigned.`,
 											},
 											"app_group_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -306,7 +299,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"app_owner_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -339,7 +331,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												Description: `A field indicating whether this step is assigned.`,
 											},
 											"entitlement_owner_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -469,7 +460,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												Description: `Whether escalation is enabled for this step.`,
 											},
 											"expression_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -547,7 +537,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"manager_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -640,7 +629,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 													` If set, approvers must complete the step-up authentication flow before they can approve.`,
 											},
 											"resource_owner_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -707,7 +695,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"self_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"assigned_user_ids": schema.ListAttribute{
@@ -769,7 +756,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"user_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -804,7 +790,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"webhook_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"webhook_id": schema.StringAttribute{

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -6,16 +6,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// TestAccPolicyResource locks the IGA-1898/1899 invariant: an approval step
+// whose optional scalar bools are left unset must not perpetually diff
+// false → null. The two steps also exercise approver oneof switching
+// (app_owner_approval → manager_approval). terraform-plugin-testing runs an
+// implicit plan after each apply and fails the step on a non-empty plan, so a
+// re-introduction of the drift fails here. Was skipped while the parent
+// c1.api.policy.v1.Approval schema carried object-level plan-only
+// (UseConfigValue), which stamped config-null leaves back into the plan; the
+// fix drops that cascade and disables computed on the approver oneof members
+// (overlay.yaml), mirroring the existing ProvisionPolicy union treatment.
 func TestAccPolicyResource(t *testing.T) {
-	// Skipped pending upstream Speakeasy fix. Approval-block fields
-	// (allow_delegation, assigned, escalation_enabled, etc.) drift
-	// false → null on refresh because x-speakeasy-terraform-plan-only on
-	// the parent c1.api.policy.v1.Approval schema does not propagate the
-	// UseConfigValue plan modifier into nested leaf fields. Same root
-	// cause family as speakeasy-api/speakeasy#2031 (nullable nested
-	// flatten); separate upstream issue covering nested plan-only
-	// propagation pending.
-	t.Skip("upstream: plan-only annotation does not propagate to nested fields in Speakeasy 1.761.10")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -74,9 +74,14 @@ actions:
   - target: $["components"]["schemas"]["c1.api.app.v1.AppEntitlementAutomationRuleNone"]
     update:
       x-speakeasy-terraform-plan-only: true
-  - target: $["components"]["schemas"]["c1.api.policy.v1.Approval"]
-    update:
-      x-speakeasy-terraform-plan-only: true
+  # Approval: do NOT mark the whole object plan-only. Object-level plan-only
+  # (UseConfigValue) stamps the config object onto the plan, re-nulling the
+  # Computed+Optional scalar leaves (allowDelegation, escalationEnabled, …)
+  # that the API always returns as literal `false` — a perpetual `false -> null`
+  # diff (IGA-1898 / IGA-1899). Mirror the ProvisionPolicy union treatment
+  # below instead: leave the parent alone and disable computed on each approver
+  # oneof member so unselected members go null while a selected member's scalar
+  # leaves keep their server value.
   # ProvisionPolicy: keep Computed: true on the parent union so API-returned
   # defaults (unconfigured_provision) don't cause perpetual diffs. Instead,
   # disable computed on each individual union member below.
@@ -100,6 +105,41 @@ actions:
     update:
       x-speakeasy-param-computed: false
   - target: $["components"]["schemas"]["c1.api.policy.v1.WebhookProvision"]
+    update:
+      x-speakeasy-param-computed: false
+  # Approval typ-oneof members: disable computed on each so unselected members
+  # plan as null (config-driven) instead of retaining stale/computed state, and
+  # so the parent Approval object no longer needs object-level plan-only. A
+  # selected member's own scalar leaves stay Computed and keep their server
+  # value, eliminating the IGA-1898/1899 `false -> null` drift.
+  - target: $["components"]["schemas"]["c1.api.policy.v1.AgentApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.AppGroupApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.AppOwnerApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.EntitlementOwnerApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.ExpressionApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.ManagerApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.ResourceOwnerApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.SelfApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.UserApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.WebhookApproval"]
     update:
       x-speakeasy-param-computed: false
   - target: $["components"]["schemas"]["c1.api.app.v1.App"]["properties"]["appOwners"]


### PR DESCRIPTION
## What

Fix the perpetual `false → null` drift on `conductorone_policy` approval steps (**IGA-1899**, **IGA-1898** is a dup), and re-enable the acceptance test that locks the invariant.

An approval step that leaves its optional scalar bools unset diffed forever on every `terraform plan`:

```
~ approval = {
    - allow_delegation             = false -> null
    - allow_reassignment           = false -> null
    - allowed_reassignees          = []    -> null
    - assigned                     = false -> null
    - escalation_enabled           = false -> null
    ~ manager_approval             = {
        - allow_self_approval        = false -> null
        - assigned_user_ids          = []    -> null
        - fallback                   = false -> null
        - fallback_group_ids         = []    -> null
        - fallback_user_ids          = []    -> null
        - is_group_fallback_enabled  = false -> null
        - require_distinct_approvers = false -> null
      }
    - require_approval_reason      = false -> null
    - require_denial_reason        = false -> null
    - require_reassignment_reason  = false -> null
  }
```

## Root cause (plan-side, not read-side)

The C1 API marshals proto3 with `EmitUnpopulated=true`, so these scalars always come back as literal `false` — state refresh writes `false` correctly. The drift is created on the **plan** side: object-level plan-only (`UseConfigValue`) on the parent `c1.api.policy.v1.Approval` schema stamps the *config* object onto the plan. Config-unset leaves are `null`, so the plan wants `null` while state holds `false` → perpetual `false → null`.

Verified on a live local C1 stack (tenant `c1dev`): a raw API GET returns `"escalationEnabled": false`, `"allowSelfApproval": false`, … (literal `false`), with only genuine sub-objects (`"escalation": null`) coming back null.

## Fix

Mirror the treatment this repo already uses for the `ProvisionPolicy` union (see the `x-speakeasy-param-computed: false` block in `overlay.yaml`): **do not** mark the parent `Approval` object plan-only; instead set `x-speakeasy-param-computed: false` on each approver oneof member schema (`AgentApproval`, `ManagerApproval`, `AppGroupApproval`, `AppOwnerApproval`, `EntitlementOwnerApproval`, `ResourceOwnerApproval`, `SelfApproval`, `UserApproval`, `ExpressionApproval`, `WebhookApproval`).

Result: unselected approver members plan as `null` (config-driven), and a selected member's Computed scalar leaves retain the server's value — nothing re-nulls them, so the leaves no longer drift. `escalation` / `provision_policy` keep their genuinely-nullable semantics.

### Where the fix lives — regen-safe

- **`overlay.yaml`** — the Speakeasy overlay (listed in `.genignore`, so it survives `make gen`). This is the durable source of the change.
- **`internal/provider/policy_resource.go`** — the regenerated output (drops the `UseConfigValue` object plan modifier + now-unused imports, and `Computed: true` on the ten approver member objects). A `make gen` reproduces this from the overlay; committed as a separate commit per repo convention.

> ⚠️ I could not run a full `make gen` in this environment (the pinned `speakeasy` CLI and the `insulator.conductor.one` OpenAPI fetch aren't available here). The overlay change is deterministic and structurally identical to the in-repo `ProvisionPolicy` precedent that `make gen` already produces, and the generated `policy_resource.go` was hand-edited to match that output. **Please run `make gen` once on merge to confirm zero diff.**

## Proof

Against a live local C1 stack (`make repro CONFIG=policy_approval`, the `ductone/squire-terraform` harness):

| | 2nd `terraform plan` |
|---|---|
| `main` (before) | `Plan: 0 to add, 1 to change` — `false → null` drift (exit 2) |
| this branch | **No changes** (exit 0) |

- Clean cycle (destroy → fresh apply → plan → plan): **No changes**, idempotent.
- Variant (explicit `true` values + a different oneof member `self_approval`): **No changes** — explicit values round-trip, oneof selection is safe.
- **`TestAccPolicyResource`** (re-enabled, was `t.Skip`'d) passes live (2.79s). Its two steps switch `app_owner_approval → manager_approval`; the testing framework's implicit post-apply plan asserts no non-empty plan, locking apply→plan=no-diff including oneof switching.
- `go vet` + provider unit tests (regen tripwires, registration) green.

## Supersedes #226

This **supersedes PR #226** (`fix/iga-1899-policy-bool-drift`, the `BoolPointerOrFalse` read-path coalesce). #226 is a **no-op for this drift**: the API never omits these bools (it returns literal `false`), so `BoolPointerOrFalse(&false) == false` — `main` and #226 drift byte-for-byte identically. The lever is the plan modifier, not the read path. **Recommend closing #226** in favor of this PR. (I have not modified or closed #226.)

## Note on commit signing

The commits on this branch are **unsigned** — this build environment has no SSH signing key or signing config (no `commit.gpgsign`, no `user.signingkey`, no `~/.ssh` pubkey), so a Verified commit was not achievable here. No signing was disabled (`-c commit.gpgsign=false` was never passed). **Please re-commit/amend with a signing key for a Verified status before merge** if the repo requires it.

Refs: IGA-1899, IGA-1898.
