### PR TITLE
fix(request_schema): resolve Value Conversion Error + plan convergence (IGA-743)

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -9,8 +9,6 @@ overlay.yaml
 /internal/sdk/extra_sdk_options.go
 /internal/provider/app_entitlement_resource.go
 /internal/provider/app_entitlement_resource_sdk.go
-/internal/provider/request_schema_resource.go
-/internal/provider/request_schema_resource_sdk.go
 /internal/provider/*_test.go
 /internal/provider/integration_*
 /internal/provider/integrations.go

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,18 +1,18 @@
 lockVersion: 2.0.0
 id: d7d79ae7-a058-4cb5-862e-7ffd3269d83b
 management:
-  docChecksum: 56d3a007abd7bc174d7c097f747410ba
+  docChecksum: 9a5d49250707e75667b1251f89f24803
   docVersion: 0.1.0-alpha
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
-  releaseVersion: 1.4.0
-  configChecksum: b909b6d01b5a6fbd8e99e412bc87d42b
+  releaseVersion: 1.4.1
+  configChecksum: 2fe0f327a5ce956390a3aa5f032c29f3
   repoURL: https://github.com/ConductorOne/terraform-provider-conductorone.git
   installationURL: https://github.com/ConductorOne/terraform-provider-conductorone
 persistentEdits:
-  generation_id: eca05039-e4e1-473e-8d0f-d490ea502c07
-  pristine_commit_hash: 2f3c039b3fdb8f4ef7e8f495b3013285efa5fca3
-  pristine_tree_hash: dac726c4f87a5060c9108cda04f7ce80da6d976b
+  generation_id: f4bf5dde-df99-45c4-b872-d220f6e92441
+  pristine_commit_hash: 9e4fb56c509bc97f52b074abc2ec710fc2ea16f2
+  pristine_tree_hash: e395434caad52b4a3a002f19322ac64c836c41e5
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -247,7 +247,7 @@ trackedFiles:
   examples/provider/provider.tf:
     id: 954e955c0240
     last_write_checksum: sha1:0352db5ced6953661f41527325bd247d0a836b90
-    pristine_git_object: 1dce016e5ee2a8ae3a5e4fba462b0f111906ad43
+    pristine_git_object: f087acb8b99ffbe976bd9ded8ee4413855a344d1
   examples/resources/conductorone_access_conflict/import-by-string-id.tf:
     id: 75fb8f5a6d65
     last_write_checksum: sha1:82d79ecc5a7d6ab27f4f9f9234e220e0e9f65914
@@ -686,8 +686,8 @@ trackedFiles:
     pristine_git_object: 4d31c6d83c73018fc1b8ecb34d4555a8b3574e98
   go.mod:
     id: c47645c391ad
-    last_write_checksum: sha1:e7c52a0fffed6b109b273dbb7917c124e5cfef5c
-    pristine_git_object: ddb34e4718382b88b7d104c8e47a35160023fc39
+    last_write_checksum: sha1:e882464b1c9e8601f0b0f26f3f26aaa123d8dd21
+    pristine_git_object: bcd58b5c353b5fa4dfe183efa01c05184aa89941
   internal/planmodifiers/boolplanmodifier/suppress_diff.go:
     id: 3cf85b98963e
     last_write_checksum: sha1:dd46ab59ac03cebd72b7c570eca1c5ffa971caf4
@@ -1501,9 +1501,13 @@ trackedFiles:
     last_write_checksum: sha1:24f07c46fdddc1fc5519451e9e521debfa351d0e
     pristine_git_object: 59a89d4a489181ecf9e1d2590182f6e2041cd442
   internal/provider/request_schema_resource.go:
-    last_write_checksum: sha1:4cad97aeda637d58824dc61de6e74cb3bc703a5d
+    id: fd88c9af1dbb
+    last_write_checksum: sha1:6afe5f0b815eabc3bf57d0953aba9ad9224294cc
+    pristine_git_object: bede670ed10fd8239d66ddb96b247b79004175e9
   internal/provider/request_schema_resource_sdk.go:
+    id: 4fe798e15fdf
     last_write_checksum: sha1:367c00e6654d31715a085af024dcd96088747f03
+    pristine_git_object: 365ee4b2435deecc92d7894ee462b9154e7684e6
   internal/provider/risk_level_data_source.go:
     id: 8fa89eec3bfc
     last_write_checksum: sha1:e88f9632b0955a555b0530ce2e293be4efaffe27
@@ -1546,24 +1550,24 @@ trackedFiles:
     pristine_git_object: 369a8bac18320c7907d64aad798245e2363e5b4b
   internal/provider/taskgrant_resource.go:
     id: 59e6f82d8bc0
-    last_write_checksum: sha1:0708f740161084dc4dec8dd7b1241a32a636cb73
-    pristine_git_object: d22c6e5ad5557a5d826404b96f9cd52457859523
+    last_write_checksum: sha1:a3185bf99e2d1716f462690cd576eed6d9297925
+    pristine_git_object: 331c06e23c61f8ff556f39ab6592812accab578e
   internal/provider/taskgrant_resource_sdk.go:
     id: 0cd8d812d545
     last_write_checksum: sha1:dd17df11836d98b8929c9620174d1b779e468cc5
     pristine_git_object: 1dbbc83fe5df7df8c99ea674165cb08022926b5f
   internal/provider/taskoffboarding_resource.go:
     id: 56cc5025534a
-    last_write_checksum: sha1:5a3079de8f133cdd58418e109fb38590c2dd71d3
-    pristine_git_object: 6701d59fc7f07f58a8a8053205b96d51d0e234be
+    last_write_checksum: sha1:295d4a991dbd744feb27133348d2931cd829da9e
+    pristine_git_object: aa86295f260ac99d5bb48261673be2c3138470db
   internal/provider/taskoffboarding_resource_sdk.go:
     id: 2f47e6d64f6c
     last_write_checksum: sha1:e155a3badccf3fbc1913c00b84fd317b075cb976
     pristine_git_object: b3d08e900f96ea52006b1afcd664882d362e20c2
   internal/provider/taskrevoke_resource.go:
     id: 1929ad211c2a
-    last_write_checksum: sha1:8812bf539ea8661ede759ce984597b16e0cc83c4
-    pristine_git_object: b3ba6c87df820ea72f11ed3b5a89041e870bdda2
+    last_write_checksum: sha1:02536f9914b0679b0a10a7f77b0b1df7ef7757c5
+    pristine_git_object: 91c4b8aea5c822b2fbc237fe403120c3c3cfa4a3
   internal/provider/taskrevoke_resource_sdk.go:
     id: 3b7f1b0d05b1
     last_write_checksum: sha1:bc109e27398116d703ba31630464e6357f7c05a8
@@ -3179,7 +3183,7 @@ trackedFiles:
   internal/sdk/conductoroneapi.go:
     id: 84087b0a6f93
     last_write_checksum: sha1:64a5920af2c0db18d6929bd66e0a8d8d516b72e6
-    pristine_git_object: 1631c5f8d0fd33c7dba06c1f3075a153291f108b
+    pristine_git_object: 8dd0acfbd59bf8c0e2f3d5f85c02050eb27ae85a
   internal/sdk/connector.go:
     id: 41e2af88fe9e
     last_write_checksum: sha1:5dc15c34dc12560961cce647f66fe1b4e5a2b8fb

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -246,7 +246,7 @@ trackedFiles:
     pristine_git_object: cbbe422a1a74c6c026e9648210d723901bd6aaf2
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:6d2f3b657ad83e5fde4f377c1cac59ed241ee3d0
+    last_write_checksum: sha1:0352db5ced6953661f41527325bd247d0a836b90
     pristine_git_object: 1dce016e5ee2a8ae3a5e4fba462b0f111906ad43
   examples/resources/conductorone_access_conflict/import-by-string-id.tf:
     id: 75fb8f5a6d65
@@ -1500,6 +1500,10 @@ trackedFiles:
     id: 733ed6f8a30a
     last_write_checksum: sha1:24f07c46fdddc1fc5519451e9e521debfa351d0e
     pristine_git_object: 59a89d4a489181ecf9e1d2590182f6e2041cd442
+  internal/provider/request_schema_resource.go:
+    last_write_checksum: sha1:4cad97aeda637d58824dc61de6e74cb3bc703a5d
+  internal/provider/request_schema_resource_sdk.go:
+    last_write_checksum: sha1:367c00e6654d31715a085af024dcd96088747f03
   internal/provider/risk_level_data_source.go:
     id: 8fa89eec3bfc
     last_write_checksum: sha1:e88f9632b0955a555b0530ce2e293be4efaffe27
@@ -3174,7 +3178,7 @@ trackedFiles:
     pristine_git_object: ccda06344d8f1db2a6155a8b5a2fda6be064d9bb
   internal/sdk/conductoroneapi.go:
     id: 84087b0a6f93
-    last_write_checksum: sha1:fa378467b996c1b2c7bea058736be8f11efdfa48
+    last_write_checksum: sha1:64a5920af2c0db18d6929bd66e0a8d8d516b72e6
     pristine_git_object: 1631c5f8d0fd33c7dba06c1f3075a153291f108b
   internal/sdk/connector.go:
     id: 41e2af88fe9e

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     my-source:
         sourceNamespace: my-source
-        sourceRevisionDigest: sha256:8ab04438872bf95ab63981dd48b41465582c400c7ca2fbd7b852149c156a034a
-        sourceBlobDigest: sha256:b67bb00b272c192ca549b49dc608aa08f293866f9fb9d51f1873f19c1c73a67d
+        sourceRevisionDigest: sha256:b0255d2cc6090e64b7fe0b5f102fe0db57576eb6e561992cd71a2a1707869648
+        sourceBlobDigest: sha256:a95645fee423ac09eac021ace453241dd5821646552454eff0c2bab72d0b4312
         tags:
             - latest
             - 0.1.0-alpha
@@ -11,8 +11,8 @@ targets:
     conductorone-terraform:
         source: my-source
         sourceNamespace: my-source
-        sourceRevisionDigest: sha256:8ab04438872bf95ab63981dd48b41465582c400c7ca2fbd7b852149c156a034a
-        sourceBlobDigest: sha256:b67bb00b272c192ca549b49dc608aa08f293866f9fb9d51f1873f19c1c73a67d
+        sourceRevisionDigest: sha256:b0255d2cc6090e64b7fe0b5f102fe0db57576eb6e561992cd71a2a1707869648
+        sourceBlobDigest: sha256:a95645fee423ac09eac021ace453241dd5821646552454eff0c2bab72d0b4312
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.762.0

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.4.0"
+      version = "1.4.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.4.0"
+      version = "1.4.1"
     }
   }
 }

--- a/docs/resources/request_schema.md
+++ b/docs/resources/request_schema.md
@@ -218,47 +218,48 @@ resource "conductorone_request_schema" "my_request_schema" {
 
 Optional:
 
+- `admin_provider_config` (Attributes) The AdminProviderConfig message. (see [below for nested schema](#nestedatt--fields--admin_provider_config))
 - `bool_field` (Attributes) The BoolField message.
 
 This message contains a oneof named view. Only a single field of the following list may be set at a time:
   - checkboxField
-
-
-This message contains a oneof named _rules. Only a single field of the following list may be set at a time:
-  - rules (see [below for nested schema](#nestedatt--fields--bool_field))
+  - toggleField (see [below for nested schema](#nestedatt--fields--bool_field))
 - `description` (String) The description field.
 - `display_name` (String) The displayName field.
 - `file_field` (Attributes) The FileField message.
 
 This message contains a oneof named view. Only a single field of the following list may be set at a time:
-  - fileInputField
-
-
-This message contains a oneof named _max_file_size. Only a single field of the following list may be set at a time:
-  - maxFileSize (see [below for nested schema](#nestedatt--fields--file_field))
-- `int64_field` (Attributes) The Int64Field message.
-
-This message contains a oneof named view. Only a single field of the following list may be set at a time:
-  - numberField
-
-
-This message contains a oneof named _default_value. Only a single field of the following list may be set at a time:
-  - defaultValue
-
-
-This message contains a oneof named _rules. Only a single field of the following list may be set at a time:
-  - rules (see [below for nested schema](#nestedatt--fields--int64_field))
-- `name` (String) The name field.
-- `string_field` (Attributes) The StringField message.
+  - fileInputField (see [below for nested schema](#nestedatt--fields--file_field))
+- `form_string_field` (Attributes) The StringField message.
 
 This message contains a oneof named view. Only a single field of the following list may be set at a time:
   - textField
   - passwordField
   - selectField
+  - pickerField (see [below for nested schema](#nestedatt--fields--form_string_field))
+- `form_string_map_field` (Attributes) The StringMapField message. (see [below for nested schema](#nestedatt--fields--form_string_map_field))
+- `int64_field` (Attributes) The Int64Field message.
 
+This message contains a oneof named view. Only a single field of the following list may be set at a time:
+  - numberField (see [below for nested schema](#nestedatt--fields--int64_field))
+- `name` (String) The name field.
+- `oauth2_field` (Attributes) The Oauth2Field message.
 
-This message contains a oneof named _rules. Only a single field of the following list may be set at a time:
-  - rules (see [below for nested schema](#nestedatt--fields--string_field))
+This message contains a oneof named view. Only a single field of the following list may be set at a time:
+  - oauth2FieldView (see [below for nested schema](#nestedatt--fields--oauth2_field))
+- `read_only` (Boolean) When true, this field is displayed to the user but cannot be edited.
+- `required` (Boolean) The required field.
+- `shared_provider_config` (Attributes) The SharedProviderConfig message. (see [below for nested schema](#nestedatt--fields--shared_provider_config))
+- `user_provider_config` (Attributes) The UserProviderConfig message. (see [below for nested schema](#nestedatt--fields--user_provider_config))
+
+<a id="nestedatt--fields--admin_provider_config"></a>
+### Nested Schema for `fields.admin_provider_config`
+
+Optional:
+
+- `default_value_cel` (String) The defaultValueCel field.
+- `show_to_user` (Boolean) The showToUser field.
+
 
 <a id="nestedatt--fields--bool_field"></a>
 ### Nested Schema for `fields.bool_field`
@@ -268,6 +269,7 @@ Optional:
 - `bool_rules` (Attributes) BoolRules describes the constraints applied to `bool` values (see [below for nested schema](#nestedatt--fields--bool_field--bool_rules))
 - `checkbox_field` (Attributes) The CheckboxField message. (see [below for nested schema](#nestedatt--fields--bool_field--checkbox_field))
 - `default_value` (Boolean) The defaultValue field.
+- `toggle_field` (Attributes) The ToggleField message. (see [below for nested schema](#nestedatt--fields--bool_field--toggle_field))
 
 <a id="nestedatt--fields--bool_field--bool_rules"></a>
 ### Nested Schema for `fields.bool_field.bool_rules`
@@ -281,6 +283,10 @@ Optional:
 ### Nested Schema for `fields.bool_field.checkbox_field`
 
 
+<a id="nestedatt--fields--bool_field--toggle_field"></a>
+### Nested Schema for `fields.bool_field.toggle_field`
+
+
 
 <a id="nestedatt--fields--file_field"></a>
 ### Nested Schema for `fields.file_field`
@@ -290,70 +296,27 @@ Optional:
 - `accepted_file_types` (List of String) The acceptedFileTypes field.
 - `file_input_field` (Attributes) The FileInputField message. (see [below for nested schema](#nestedatt--fields--file_field--file_input_field))
 - `max_file_size` (String) The maxFileSize field.
-This field is part of the `_max_file_size` oneof.
-See the documentation for `c1.api.form.v1.FileField` for more details.
 
 <a id="nestedatt--fields--file_field--file_input_field"></a>
 ### Nested Schema for `fields.file_field.file_input_field`
 
 
 
-<a id="nestedatt--fields--int64_field"></a>
-### Nested Schema for `fields.int64_field`
+<a id="nestedatt--fields--form_string_field"></a>
+### Nested Schema for `fields.form_string_field`
 
 Optional:
 
 - `default_value` (String) The defaultValue field.
-This field is part of the `_default_value` oneof.
-See the documentation for `c1.api.form.v1.Int64Field` for more details.
-- `int64_rules` (Attributes) Int64Rules describes the constraints applied to `int64` values (see [below for nested schema](#nestedatt--fields--int64_field--int64_rules))
-- `number_field` (Attributes) The NumberField message. (see [below for nested schema](#nestedatt--fields--int64_field--number_field))
+- `password_field` (Attributes) The PasswordField message. (see [below for nested schema](#nestedatt--fields--form_string_field--password_field))
+- `picker_field` (Attributes) The PickerField message.
+
+This message contains a oneof named type. Only a single field of the following list may be set at a time:
+  - appUserPicker
+  - resourcePicker
+  - c1UserPicker (see [below for nested schema](#nestedatt--fields--form_string_field--picker_field))
 - `placeholder` (String) The placeholder field.
-
-<a id="nestedatt--fields--int64_field--int64_rules"></a>
-### Nested Schema for `fields.int64_field.int64_rules`
-
-Optional:
-
-- `const` (String) Const specifies that this field must be exactly the specified value
-- `gt` (String) Gt specifies that this field must be greater than the specified value,
- exclusive. If the value of Gt is larger than a specified Lt or Lte, the
- range is reversed.
-- `gte` (String) Gte specifies that this field must be greater than or equal to the
- specified value, inclusive. If the value of Gte is larger than a
- specified Lt or Lte, the range is reversed.
-- `ignore_empty` (Boolean) IgnoreEmpty specifies that the validation rules of this field should be
- evaluated only if the field is not empty
-- `in` (List of String) In specifies that this field must be equal to one of the specified
- values
-- `lt` (String) Lt specifies that this field must be less than the specified value,
- exclusive
-- `lte` (String) Lte specifies that this field must be less than or equal to the
- specified value, inclusive
-- `not_in` (List of String) NotIn specifies that this field cannot be equal to one of the specified
- values
-
-
-<a id="nestedatt--fields--int64_field--number_field"></a>
-### Nested Schema for `fields.int64_field.number_field`
-
-Optional:
-
-- `max_value` (String) The maxValue field.
-- `min_value` (String) The minValue field.
-- `step` (String) The step field.
-
-
-
-<a id="nestedatt--fields--string_field"></a>
-### Nested Schema for `fields.string_field`
-
-Optional:
-
-- `default_value` (String) The defaultValue field.
-- `password_field` (Attributes) The PasswordField message. (see [below for nested schema](#nestedatt--fields--string_field--password_field))
-- `placeholder` (String) The placeholder field.
-- `select_field` (Attributes) The SelectField message. (see [below for nested schema](#nestedatt--fields--string_field--select_field))
+- `select_field` (Attributes) The SelectField message. (see [below for nested schema](#nestedatt--fields--form_string_field--select_field))
 - `string_rules` (Attributes) StringRules describe the constraints applied to `string` values
 
 This message contains a oneof named well_known. Only a single field of the following list may be set at a time:
@@ -366,32 +329,66 @@ This message contains a oneof named well_known. Only a single field of the follo
   - uriRef
   - address
   - uuid
-  - wellKnownRegex (see [below for nested schema](#nestedatt--fields--string_field--string_rules))
-- `text_field` (Attributes) The TextField message. (see [below for nested schema](#nestedatt--fields--string_field--text_field))
+  - wellKnownRegex (see [below for nested schema](#nestedatt--fields--form_string_field--string_rules))
+- `text_field` (Attributes) The TextField message. (see [below for nested schema](#nestedatt--fields--form_string_field--text_field))
 
-<a id="nestedatt--fields--string_field--password_field"></a>
-### Nested Schema for `fields.string_field.password_field`
+<a id="nestedatt--fields--form_string_field--password_field"></a>
+### Nested Schema for `fields.form_string_field.password_field`
 
 
-<a id="nestedatt--fields--string_field--select_field"></a>
-### Nested Schema for `fields.string_field.select_field`
-
-Optional:
-
-- `options` (Attributes List) The options field. (see [below for nested schema](#nestedatt--fields--string_field--select_field--options))
-
-<a id="nestedatt--fields--string_field--select_field--options"></a>
-### Nested Schema for `fields.string_field.select_field.options`
+<a id="nestedatt--fields--form_string_field--picker_field"></a>
+### Nested Schema for `fields.form_string_field.picker_field`
 
 Optional:
 
+- `app_resource_filter` (Attributes) The AppResourceFilter message. (see [below for nested schema](#nestedatt--fields--form_string_field--picker_field--app_resource_filter))
+- `app_user_filter` (Attributes) The AppUserFilter message. (see [below for nested schema](#nestedatt--fields--form_string_field--picker_field--app_user_filter))
+- `c1_user_filter` (Attributes) C1UserFilter is used to configure a picker for selecting ConductorOne users.
+ This is distinct from AppUserFilter which selects accounts within a connected app. (see [below for nested schema](#nestedatt--fields--form_string_field--picker_field--c1_user_filter))
+
+<a id="nestedatt--fields--form_string_field--picker_field--app_resource_filter"></a>
+### Nested Schema for `fields.form_string_field.picker_field.app_resource_filter`
+
+Optional:
+
+- `app_id` (String) The appId field.
+- `resource_type_id` (String) The resourceTypeId field.
+
+
+<a id="nestedatt--fields--form_string_field--picker_field--app_user_filter"></a>
+### Nested Schema for `fields.form_string_field.picker_field.app_user_filter`
+
+Optional:
+
+- `app_id` (String) The appId field.
+
+
+<a id="nestedatt--fields--form_string_field--picker_field--c1_user_filter"></a>
+### Nested Schema for `fields.form_string_field.picker_field.c1_user_filter`
+
+
+
+<a id="nestedatt--fields--form_string_field--select_field"></a>
+### Nested Schema for `fields.form_string_field.select_field`
+
+Optional:
+
+- `options` (Attributes List) The options field. (see [below for nested schema](#nestedatt--fields--form_string_field--select_field--options))
+- `type` (String) The type field.
+
+<a id="nestedatt--fields--form_string_field--select_field--options"></a>
+### Nested Schema for `fields.form_string_field.select_field.options`
+
+Optional:
+
+- `description` (String) Used for type BUTTONS
 - `display_name` (String) The displayName field.
 - `value` (String) The value field.
 
 
 
-<a id="nestedatt--fields--string_field--string_rules"></a>
-### Nested Schema for `fields.string_field.string_rules`
+<a id="nestedatt--fields--form_string_field--string_rules"></a>
+### Nested Schema for `fields.form_string_field.string_rules`
 
 Optional:
 
@@ -476,13 +473,107 @@ See the documentation for `validate.StringRules` for more details.
 must be one of ["UNKNOWN", "HTTP_HEADER_NAME", "HTTP_HEADER_VALUE"]
 
 
-<a id="nestedatt--fields--string_field--text_field"></a>
-### Nested Schema for `fields.string_field.text_field`
+<a id="nestedatt--fields--form_string_field--text_field"></a>
+### Nested Schema for `fields.form_string_field.text_field`
 
 Optional:
 
 - `multiline` (Boolean) The multiline field.
+- `suffix` (String) Static text displayed as an end adornment (e.g. ".example.com" for domain fields).
 
+
+
+<a id="nestedatt--fields--form_string_map_field"></a>
+### Nested Schema for `fields.form_string_map_field`
+
+Optional:
+
+- `default_value` (Map of String) The defaultValue field.
+- `string_map_rules` (Attributes) The StringMapRules message. (see [below for nested schema](#nestedatt--fields--form_string_map_field--string_map_rules))
+
+<a id="nestedatt--fields--form_string_map_field--string_map_rules"></a>
+### Nested Schema for `fields.form_string_map_field.string_map_rules`
+
+Optional:
+
+- `is_required` (Boolean) The isRequired field.
+- `validate_empty` (Boolean) The validateEmpty field.
+
+
+
+<a id="nestedatt--fields--int64_field"></a>
+### Nested Schema for `fields.int64_field`
+
+Optional:
+
+- `default_value` (String) The defaultValue field.
+- `int64_rules` (Attributes) Int64Rules describes the constraints applied to `int64` values (see [below for nested schema](#nestedatt--fields--int64_field--int64_rules))
+- `number_field` (Attributes) The NumberField message. (see [below for nested schema](#nestedatt--fields--int64_field--number_field))
+- `placeholder` (String) The placeholder field.
+
+<a id="nestedatt--fields--int64_field--int64_rules"></a>
+### Nested Schema for `fields.int64_field.int64_rules`
+
+Optional:
+
+- `const` (String) Const specifies that this field must be exactly the specified value
+- `gt` (String) Gt specifies that this field must be greater than the specified value,
+ exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+ range is reversed.
+- `gte` (String) Gte specifies that this field must be greater than or equal to the
+ specified value, inclusive. If the value of Gte is larger than a
+ specified Lt or Lte, the range is reversed.
+- `ignore_empty` (Boolean) IgnoreEmpty specifies that the validation rules of this field should be
+ evaluated only if the field is not empty
+- `in` (List of String) In specifies that this field must be equal to one of the specified
+ values
+- `lt` (String) Lt specifies that this field must be less than the specified value,
+ exclusive
+- `lte` (String) Lte specifies that this field must be less than or equal to the
+ specified value, inclusive
+- `not_in` (List of String) NotIn specifies that this field cannot be equal to one of the specified
+ values
+
+
+<a id="nestedatt--fields--int64_field--number_field"></a>
+### Nested Schema for `fields.int64_field.number_field`
+
+Optional:
+
+- `max_value` (String) The maxValue field.
+- `min_value` (String) The minValue field.
+- `step` (String) The step field.
+
+
+
+<a id="nestedatt--fields--oauth2_field"></a>
+### Nested Schema for `fields.oauth2_field`
+
+Optional:
+
+- `oauth2_field_view` (Attributes) The Oauth2FieldView message. (see [below for nested schema](#nestedatt--fields--oauth2_field--oauth2_field_view))
+
+<a id="nestedatt--fields--oauth2_field--oauth2_field_view"></a>
+### Nested Schema for `fields.oauth2_field.oauth2_field_view`
+
+
+
+<a id="nestedatt--fields--shared_provider_config"></a>
+### Nested Schema for `fields.shared_provider_config`
+
+Optional:
+
+- `default_value_cel` (String) The defaultValueCel field.
+- `input_transformation_cel` (String) The inputTransformationCel field.
+- `lock_default_values` (Boolean) The lockDefaultValues field.
+
+
+<a id="nestedatt--fields--user_provider_config"></a>
+### Nested Schema for `fields.user_provider_config`
+
+Optional:
+
+- `input_transformation_cel` (String) The inputTransformationCel field.
 
 
 

--- a/docs/resources/request_schema.md
+++ b/docs/resources/request_schema.md
@@ -203,15 +203,62 @@ resource "conductorone_request_schema" "my_request_schema" {
 
 ### Optional
 
-- `description` (String) The description field.
-- `fields` (Attributes List) The fields field. (see [below for nested schema](#nestedatt--fields))
-- `name` (String) The name field.
+- `description` (String) An optional description of the request schema's purpose.
+- `field_groups` (Attributes List) Logical groupings of fields for display purposes. (see [below for nested schema](#nestedatt--field_groups))
+- `field_relationships` (Attributes List) Dependencies between fields that control conditional visibility or validation. (see [below for nested schema](#nestedatt--field_relationships))
+- `fields` (Attributes List) The form fields that users must fill out when requesting access. (see [below for nested schema](#nestedatt--fields))
+- `justification_visibility` (String) Controls whether the justification field is shown or hidden on the request form. possible known values include one of ["JUSTIFICATION_VISIBILITY_UNSPECIFIED", "JUSTIFICATION_VISIBILITY_SHOW", "JUSTIFICATION_VISIBILITY_HIDE"]
+- `name` (String) The human-readable name for the request schema.
 
 ### Read-Only
 
 - `created_at` (String)
-- `field_relationships` (Attributes List) The fieldRelationships field. (see [below for nested schema](#nestedatt--field_relationships))
-- `id` (String) The id field.
+- `id` (String) The unique identifier of this request schema.
+
+<a id="nestedatt--field_groups"></a>
+### Nested Schema for `field_groups`
+
+Optional:
+
+- `default` (Boolean) The default field.
+- `display_name` (String) The displayName field.
+- `fields` (List of String) The fields field.
+- `help_text` (String) The helpText field.
+- `name` (String) The name field.
+
+
+<a id="nestedatt--field_relationships"></a>
+### Nested Schema for `field_relationships`
+
+Optional:
+
+- `at_least_one` (Attributes) The AtLeastOne message. (see [below for nested schema](#nestedatt--field_relationships--at_least_one))
+- `dependent_on` (Attributes) DependentOn means the fields in field_names are only valid if all fields
+ in dependency_field_names are also present (see [below for nested schema](#nestedatt--field_relationships--dependent_on))
+- `field_names` (List of String) The names of the fields that share this relationship
+- `mutually_exclusive` (Attributes) The MutuallyExclusive message. (see [below for nested schema](#nestedatt--field_relationships--mutually_exclusive))
+- `required_together` (Attributes) The RequiredTogether message. (see [below for nested schema](#nestedatt--field_relationships--required_together))
+
+<a id="nestedatt--field_relationships--at_least_one"></a>
+### Nested Schema for `field_relationships.at_least_one`
+
+
+<a id="nestedatt--field_relationships--dependent_on"></a>
+### Nested Schema for `field_relationships.dependent_on`
+
+Optional:
+
+- `dependency_field_names` (List of String) The fields that must be present for the primary field_names to be valid
+
+
+<a id="nestedatt--field_relationships--mutually_exclusive"></a>
+### Nested Schema for `field_relationships.mutually_exclusive`
+
+
+<a id="nestedatt--field_relationships--required_together"></a>
+### Nested Schema for `field_relationships.required_together`
+
+
 
 <a id="nestedatt--fields"></a>
 ### Nested Schema for `fields`
@@ -374,7 +421,7 @@ Optional:
 Optional:
 
 - `options` (Attributes List) The options field. (see [below for nested schema](#nestedatt--fields--form_string_field--select_field--options))
-- `type` (String) The type field.
+- `type` (String) The type field. possible known values include one of ["SELECT_TYPE_UNSPECIFIED", "SELECT_TYPE_DROPDOWN", "SELECT_TYPE_RADIO", "SELECT_TYPE_BUTTONS"]
 
 <a id="nestedatt--fields--form_string_field--select_field--options"></a>
 ### Nested Schema for `fields.form_string_field.select_field.options`
@@ -470,7 +517,7 @@ See the documentation for `validate.StringRules` for more details.
 - `well_known_regex` (String) WellKnownRegex specifies a common well known pattern defined as a regex.
 This field is part of the `well_known` oneof.
 See the documentation for `validate.StringRules` for more details.
-must be one of ["UNKNOWN", "HTTP_HEADER_NAME", "HTTP_HEADER_VALUE"]
+possible known values include one of ["UNKNOWN", "HTTP_HEADER_NAME", "HTTP_HEADER_VALUE"]
 
 
 <a id="nestedatt--fields--form_string_field--text_field"></a>
@@ -574,26 +621,3 @@ Optional:
 Optional:
 
 - `input_transformation_cel` (String) The inputTransformationCel field.
-
-
-
-<a id="nestedatt--field_relationships"></a>
-### Nested Schema for `field_relationships`
-
-Read-Only:
-
-- `at_least_one` (Attributes) The AtLeastOne message. (see [below for nested schema](#nestedatt--field_relationships--at_least_one))
-- `field_names` (List of String) The names of the fields that share this relationship
-- `mutually_exclusive` (Attributes) The MutuallyExclusive message. (see [below for nested schema](#nestedatt--field_relationships--mutually_exclusive))
-- `required_together` (Attributes) The RequiredTogether message. (see [below for nested schema](#nestedatt--field_relationships--required_together))
-
-<a id="nestedatt--field_relationships--at_least_one"></a>
-### Nested Schema for `field_relationships.at_least_one`
-
-
-<a id="nestedatt--field_relationships--mutually_exclusive"></a>
-### Nested Schema for `field_relationships.mutually_exclusive`
-
-
-<a id="nestedatt--field_relationships--required_together"></a>
-### Nested Schema for `field_relationships.required_together`

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.4.0"
+      version = "1.4.1"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -35,7 +35,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.4.0
+  version: 1.4.1
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}

--- a/internal/provider/request_schema_convergence_test.go
+++ b/internal/provider/request_schema_convergence_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// suppressDescFragment is the human-readable description emitted by the in-repo
+// SuppressDiff plan modifiers (internal/planmodifiers/*/suppress_diff.go):
+//
+//	"Once set, the value of this attribute in state will not change."
+//
+// We match on a stable fragment so the assertion survives minor wording changes.
+const suppressDescFragment = "will not change"
+
+// TestRequestSchemaComputedAttrsArePlanStable is the IGA-743 *convergence*
+// tripwire (distinct from the crash tripwires in
+// request_schema_schema_symmetry_test.go / request_schema_roundtrip_test.go).
+//
+// The crash fix on PR #232 stopped the "Value Conversion Error", but a
+// conductorone_request_schema with a bool_field still did NOT reach an empty
+// plan: several server-derived computed attributes re-planned as
+// "(known after apply)" on every plan after the first apply, so a config that
+// already matched the read-back never converged.
+//
+// The fix marks each drifting attribute plan-stable via
+// x-speakeasy-param-suppress-computed-diff in overlay.yaml — exactly the
+// treatment already applied to RequestSchema.id. Speakeasy regenerates that
+// into a SuppressDiff(ExplicitSuppress) plan modifier, which propagates the
+// prior state value into the plan when the planned value is unknown (the
+// framework's UseStateForUnknown behavior) and is a no-op when the user
+// explicitly sets the attribute.
+//
+// This test FAILS on the broken HEAD (these attributes carry no plan modifier)
+// and PASSES once the overlay change is regenerated.
+func TestRequestSchemaComputedAttrsArePlanStable(t *testing.T) {
+	ctx := context.Background()
+	resp := &resource.SchemaResponse{}
+	NewRequestSchemaResource().Schema(ctx, resource.SchemaRequest{}, resp)
+	attrs := resp.Schema.Attributes
+
+	// Top-level server-derived computed attributes.
+	assertStringAttrStable(t, attrs, "created_at")
+	assertStringAttrStable(t, attrs, "justification_visibility")
+	assertListAttrStable(t, attrs, "field_groups")
+	assertListAttrStable(t, attrs, "field_relationships")
+
+	// fields[].name — the server derives an internal field name, so the nested
+	// "name" attribute churns unless it is plan-stable.
+	fields, ok := attrs["fields"].(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf(`"fields" is %T, want schema.ListNestedAttribute`, attrs["fields"])
+	}
+	nameAttr, ok := fields.NestedObject.Attributes["name"]
+	if !ok {
+		t.Fatal(`"fields" nested object has no "name" attribute`)
+	}
+	strName, ok := nameAttr.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf(`fields[].name is %T, want schema.StringAttribute`, nameAttr)
+	}
+	assertStringModifiersStable(t, "fields[].name", strName.PlanModifiers)
+}
+
+func assertStringAttrStable(t *testing.T, attrs map[string]schema.Attribute, name string) {
+	t.Helper()
+	a, ok := attrs[name].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("%q is %T, want schema.StringAttribute", name, attrs[name])
+	}
+	assertStringModifiersStable(t, name, a.PlanModifiers)
+}
+
+func assertStringModifiersStable(t *testing.T, name string, pms []planmodifier.String) {
+	t.Helper()
+	for _, pm := range pms {
+		if strings.Contains(pm.Description(context.Background()), suppressDescFragment) {
+			return
+		}
+	}
+	t.Errorf("attribute %q has no state-stability plan modifier (got %d); it re-plans as "+
+		"(known after apply) — IGA-743 convergence regression", name, len(pms))
+}
+
+func assertListAttrStable(t *testing.T, attrs map[string]schema.Attribute, name string) {
+	t.Helper()
+	a, ok := attrs[name].(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("%q is %T, want schema.ListNestedAttribute", name, attrs[name])
+	}
+	for _, pm := range a.PlanModifiers {
+		if strings.Contains(pm.Description(context.Background()), suppressDescFragment) {
+			return
+		}
+	}
+	t.Errorf("attribute %q has no state-stability plan modifier (got %d); it re-plans as "+
+		"(known after apply) — IGA-743 convergence regression", name, len(a.PlanModifiers))
+}

--- a/internal/provider/request_schema_resource.go
+++ b/internal/provider/request_schema_resource.go
@@ -5,13 +5,10 @@ package provider
 import (
 	"context"
 	"fmt"
-
 	speakeasy_stringplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
-	"github.com/conductorone/terraform-provider-conductorone/internal/validators"
 	speakeasy_objectvalidators "github.com/conductorone/terraform-provider-conductorone/internal/validators/objectvalidators"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -37,13 +34,15 @@ type RequestSchemaResource struct {
 
 // RequestSchemaResourceModel describes the resource data model.
 type RequestSchemaResourceModel struct {
-	CreatedAt          types.String                `tfsdk:"created_at"`
-	DeletedAt          types.String                `tfsdk:"-"`
-	Description        types.String                `tfsdk:"description"`
-	FieldRelationships []tfTypes.FieldRelationship `tfsdk:"field_relationships"`
-	Fields             []tfTypes.FormField         `tfsdk:"fields"`
-	ID                 types.String                `tfsdk:"id"`
-	Name               types.String                `tfsdk:"name"`
+	CreatedAt               types.String                `tfsdk:"created_at"`
+	DeletedAt               types.String                `tfsdk:"-"`
+	Description             types.String                `tfsdk:"description"`
+	FieldGroups             []tfTypes.FormFieldGroup    `tfsdk:"field_groups"`
+	FieldRelationships      []tfTypes.FieldRelationship `tfsdk:"field_relationships"`
+	Fields                  []tfTypes.FormField         `tfsdk:"fields"`
+	ID                      types.String                `tfsdk:"id"`
+	JustificationVisibility types.String                `tfsdk:"justification_visibility"`
+	Name                    types.String                `tfsdk:"name"`
 }
 
 func (r *RequestSchemaResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -56,39 +55,96 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 		Attributes: map[string]schema.Attribute{
 			"created_at": schema.StringAttribute{
 				Computed: true,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
-				Description: `The description field.`,
+				Description: `An optional description of the request schema's purpose.`,
+			},
+			"field_groups": schema.ListNestedAttribute{
+				Computed: true,
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Validators: []validator.Object{
+						speakeasy_objectvalidators.NotNull(),
+					},
+					Attributes: map[string]schema.Attribute{
+						"default": schema.BoolAttribute{
+							Computed:    true,
+							Optional:    true,
+							Description: `The default field.`,
+						},
+						"display_name": schema.StringAttribute{
+							Computed:    true,
+							Optional:    true,
+							Description: `The displayName field.`,
+						},
+						"fields": schema.ListAttribute{
+							Computed:    true,
+							Optional:    true,
+							ElementType: types.StringType,
+							Description: `The fields field.`,
+						},
+						"help_text": schema.StringAttribute{
+							Computed:    true,
+							Optional:    true,
+							Description: `The helpText field.`,
+						},
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Optional:    true,
+							Description: `The name field.`,
+						},
+					},
+				},
+				Description: `Logical groupings of fields for display purposes.`,
 			},
 			"field_relationships": schema.ListNestedAttribute{
 				Computed: true,
+				Optional: true,
 				NestedObject: schema.NestedAttributeObject{
+					Validators: []validator.Object{
+						speakeasy_objectvalidators.NotNull(),
+					},
 					Attributes: map[string]schema.Attribute{
 						"at_least_one": schema.SingleNestedAttribute{
 							Computed:    true,
+							Optional:    true,
 							Description: `The AtLeastOne message.`,
+						},
+						"dependent_on": schema.SingleNestedAttribute{
+							Computed: true,
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"dependency_field_names": schema.ListAttribute{
+									Computed:    true,
+									Optional:    true,
+									ElementType: types.StringType,
+									Description: `The fields that must be present for the primary field_names to be valid`,
+								},
+							},
+							MarkdownDescription: `DependentOn means the fields in field_names are only valid if all fields` + "\n" +
+								` in dependency_field_names are also present`,
 						},
 						"field_names": schema.ListAttribute{
 							Computed:    true,
+							Optional:    true,
 							ElementType: types.StringType,
 							Description: `The names of the fields that share this relationship`,
 						},
 						"mutually_exclusive": schema.SingleNestedAttribute{
 							Computed:    true,
+							Optional:    true,
 							Description: `The MutuallyExclusive message.`,
 						},
 						"required_together": schema.SingleNestedAttribute{
 							Computed:    true,
+							Optional:    true,
 							Description: `The RequiredTogether message.`,
 						},
 					},
 				},
-				Description: `The fieldRelationships field.`,
+				Description: `Dependencies between fields that control conditional visibility or validation.`,
 			},
 			"fields": schema.ListNestedAttribute{
 				Computed: true,
@@ -263,6 +319,9 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 											Computed: true,
 											Optional: true,
 											NestedObject: schema.NestedAttributeObject{
+												Validators: []validator.Object{
+													speakeasy_objectvalidators.NotNull(),
+												},
 												Attributes: map[string]schema.Attribute{
 													"description": schema.StringAttribute{
 														Computed:    true,
@@ -286,7 +345,7 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 										"type": schema.StringAttribute{
 											Computed:    true,
 											Optional:    true,
-											Description: `The type field.`,
+											Description: `The type field. possible known values include one of ["SELECT_TYPE_UNSPECIFIED", "SELECT_TYPE_DROPDOWN", "SELECT_TYPE_RADIO", "SELECT_TYPE_BUTTONS"]`,
 										},
 									},
 									Description: `The SelectField message.`,
@@ -478,14 +537,7 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 											MarkdownDescription: `WellKnownRegex specifies a common well known pattern defined as a regex.` + "\n" +
 												`This field is part of the ` + "`" + `well_known` + "`" + ` oneof.` + "\n" +
 												`See the documentation for ` + "`" + `validate.StringRules` + "`" + ` for more details.` + "\n" +
-												`must be one of ["UNKNOWN", "HTTP_HEADER_NAME", "HTTP_HEADER_VALUE"]`,
-											Validators: []validator.String{
-												stringvalidator.OneOf(
-													"UNKNOWN",
-													"HTTP_HEADER_NAME",
-													"HTTP_HEADER_VALUE",
-												),
-											},
+												`possible known values include one of ["UNKNOWN", "HTTP_HEADER_NAME", "HTTP_HEADER_VALUE"]`,
 										},
 									},
 									MarkdownDescription: `StringRules describe the constraints applied to ` + "`" + `string` + "`" + ` values` + "\n" +
@@ -724,19 +776,24 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 						},
 					},
 				},
-				Description: `The fields field.`,
+				Description: `The form fields that users must fill out when requesting access.`,
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
-				Description: `The id field.`,
+				Description: `The unique identifier of this request schema.`,
+			},
+			"justification_visibility": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: `Controls whether the justification field is shown or hidden on the request form. possible known values include one of ["JUSTIFICATION_VISIBILITY_UNSPECIFIED", "JUSTIFICATION_VISIBILITY_SHOW", "JUSTIFICATION_VISIBILITY_HIDE"]`,
 			},
 			"name": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
-				Description: `The name field.`,
+				Description: `The human-readable name for the request schema.`,
 			},
 		},
 	}
@@ -802,16 +859,11 @@ func (r *RequestSchemaResource) Create(ctx context.Context, req resource.CreateR
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}
-	if !(res.RequestSchemaServiceCreateResponse != nil && res.RequestSchemaServiceCreateResponse.RequestSchema != nil && res.RequestSchemaServiceCreateResponse.RequestSchema.RequestSchemaForm != nil) {
+	if !(res.RequestSchemaServiceCreateResponse != nil) {
 		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
 		return
 	}
-
-	// ManualChange. We store the requestSchema into the terraform state.
-	// Once speakeasy team fixes it, we can remove it.
-	resp.Diagnostics.Append(data.RefreshFromSharedRequestSchema(ctx, res.RequestSchemaServiceCreateResponse.RequestSchema)...)
-
-	resp.Diagnostics.Append(data.RefreshFromSharedForm(ctx, res.RequestSchemaServiceCreateResponse.RequestSchema.RequestSchemaForm)...)
+	resp.Diagnostics.Append(data.RefreshFromSharedRequestSchemaServiceCreateResponse(ctx, res.RequestSchemaServiceCreateResponse)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -871,16 +923,11 @@ func (r *RequestSchemaResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}
-	if !(res.RequestSchemaServiceGetResponse != nil && res.RequestSchemaServiceGetResponse.RequestSchema != nil && res.RequestSchemaServiceGetResponse.RequestSchema.RequestSchemaForm != nil) {
+	if !(res.RequestSchemaServiceGetResponse != nil) {
 		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
 		return
 	}
-
-	// ManualChange. We store the requestSchema into the terraform state.
-	// Once speakeasy team fixes it, we can remove it.
-	resp.Diagnostics.Append(data.RefreshFromSharedRequestSchema(ctx, res.RequestSchemaServiceGetResponse.RequestSchema)...)
-
-	resp.Diagnostics.Append(data.RefreshFromSharedForm(ctx, res.RequestSchemaServiceGetResponse.RequestSchema.RequestSchemaForm)...)
+	resp.Diagnostics.Append(data.RefreshFromSharedRequestSchemaServiceGetResponse(ctx, res.RequestSchemaServiceGetResponse)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -931,56 +978,11 @@ func (r *RequestSchemaResource) Update(ctx context.Context, req resource.UpdateR
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}
-	if !(res.RequestSchemaServiceUpdateResponse != nil && res.RequestSchemaServiceUpdateResponse.RequestSchema != nil && res.RequestSchemaServiceUpdateResponse.RequestSchema.RequestSchemaForm != nil) {
+	if !(res.RequestSchemaServiceUpdateResponse != nil) {
 		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
 		return
 	}
-	// ManualChange. We store the requestSchema into the terraform state.
-	// Once speakeasy team fixes it, we can remove it.
-	resp.Diagnostics.Append(data.RefreshFromSharedRequestSchema(ctx, res.RequestSchemaServiceUpdateResponse.RequestSchema)...)
-
-	resp.Diagnostics.Append(data.RefreshFromSharedForm(ctx, res.RequestSchemaServiceUpdateResponse.RequestSchema.RequestSchemaForm)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsC1APIRequestSchemaV1RequestSchemaServiceGetRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.RequestSchema.Get(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.RequestSchemaServiceGetResponse != nil && res1.RequestSchemaServiceGetResponse.RequestSchema != nil && res1.RequestSchemaServiceGetResponse.RequestSchema.RequestSchemaForm != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	// ManualChange. We store the requestSchema into the terraform state.
-	// Once speakeasy team fixes it, we can remove it.
-	resp.Diagnostics.Append(data.RefreshFromSharedRequestSchema(ctx, res1.RequestSchemaServiceGetResponse.RequestSchema)...)
-
-	resp.Diagnostics.Append(data.RefreshFromSharedForm(ctx, res1.RequestSchemaServiceGetResponse.RequestSchema.RequestSchemaForm)...)
+	resp.Diagnostics.Append(data.RefreshFromSharedRequestSchemaServiceUpdateResponse(ctx, res.RequestSchemaServiceUpdateResponse)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -1032,7 +1034,10 @@ func (r *RequestSchemaResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/request_schema_resource.go
+++ b/internal/provider/request_schema_resource.go
@@ -5,6 +5,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	speakeasy_boolplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/boolplanmodifier"
+	speakeasy_listplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/listplanmodifier"
+	speakeasy_objectplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
@@ -55,6 +58,9 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 		Attributes: map[string]schema.Attribute{
 			"created_at": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+				},
 			},
 			"description": schema.StringAttribute{
 				Computed:    true,
@@ -64,35 +70,56 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 			"field_groups": schema.ListNestedAttribute{
 				Computed: true,
 				Optional: true,
+				PlanModifiers: []planmodifier.List{
+					speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Validators: []validator.Object{
 						speakeasy_objectvalidators.NotNull(),
 					},
+					PlanModifiers: []planmodifier.Object{
+						speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+					},
 					Attributes: map[string]schema.Attribute{
 						"default": schema.BoolAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.Bool{
+								speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+							},
 							Description: `The default field.`,
 						},
 						"display_name": schema.StringAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+							},
 							Description: `The displayName field.`,
 						},
 						"fields": schema.ListAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.List{
+								speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+							},
 							ElementType: types.StringType,
 							Description: `The fields field.`,
 						},
 						"help_text": schema.StringAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+							},
 							Description: `The helpText field.`,
 						},
 						"name": schema.StringAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+							},
 							Description: `The name field.`,
 						},
 					},
@@ -102,23 +129,38 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 			"field_relationships": schema.ListNestedAttribute{
 				Computed: true,
 				Optional: true,
+				PlanModifiers: []planmodifier.List{
+					speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Validators: []validator.Object{
 						speakeasy_objectvalidators.NotNull(),
 					},
+					PlanModifiers: []planmodifier.Object{
+						speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+					},
 					Attributes: map[string]schema.Attribute{
 						"at_least_one": schema.SingleNestedAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.Object{
+								speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+							},
 							Description: `The AtLeastOne message.`,
 						},
 						"dependent_on": schema.SingleNestedAttribute{
 							Computed: true,
 							Optional: true,
+							PlanModifiers: []planmodifier.Object{
+								speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+							},
 							Attributes: map[string]schema.Attribute{
 								"dependency_field_names": schema.ListAttribute{
-									Computed:    true,
-									Optional:    true,
+									Computed: true,
+									Optional: true,
+									PlanModifiers: []planmodifier.List{
+										speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+									},
 									ElementType: types.StringType,
 									Description: `The fields that must be present for the primary field_names to be valid`,
 								},
@@ -127,19 +169,28 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 								` in dependency_field_names are also present`,
 						},
 						"field_names": schema.ListAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.List{
+								speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+							},
 							ElementType: types.StringType,
 							Description: `The names of the fields that share this relationship`,
 						},
 						"mutually_exclusive": schema.SingleNestedAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.Object{
+								speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+							},
 							Description: `The MutuallyExclusive message.`,
 						},
 						"required_together": schema.SingleNestedAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.Object{
+								speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+							},
 							Description: `The RequiredTogether message.`,
 						},
 					},
@@ -711,8 +762,11 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 								`  - numberField`,
 						},
 						"name": schema.StringAttribute{
-							Computed:    true,
-							Optional:    true,
+							Computed: true,
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+							},
 							Description: `The name field.`,
 						},
 						"oauth2_field": schema.SingleNestedAttribute{
@@ -786,8 +840,11 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 				Description: `The unique identifier of this request schema.`,
 			},
 			"justification_visibility": schema.StringAttribute{
-				Computed:    true,
-				Optional:    true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+				},
 				Description: `Controls whether the justification field is shown or hidden on the request form. possible known values include one of ["JUSTIFICATION_VISIBILITY_UNSPECIFIED", "JUSTIFICATION_VISIBILITY_SHOW", "JUSTIFICATION_VISIBILITY_HIDE"]`,
 			},
 			"name": schema.StringAttribute{

--- a/internal/provider/request_schema_resource.go
+++ b/internal/provider/request_schema_resource.go
@@ -41,7 +41,7 @@ type RequestSchemaResourceModel struct {
 	DeletedAt          types.String                `tfsdk:"-"`
 	Description        types.String                `tfsdk:"description"`
 	FieldRelationships []tfTypes.FieldRelationship `tfsdk:"field_relationships"`
-	Fields             []tfTypes.FormField             `tfsdk:"fields"`
+	Fields             []tfTypes.FormField         `tfsdk:"fields"`
 	ID                 types.String                `tfsdk:"id"`
 	Name               types.String                `tfsdk:"name"`
 }
@@ -98,6 +98,23 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 						speakeasy_objectvalidators.NotNull(),
 					},
 					Attributes: map[string]schema.Attribute{
+						"admin_provider_config": schema.SingleNestedAttribute{
+							Computed: true,
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"default_value_cel": schema.StringAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The defaultValueCel field.`,
+								},
+								"show_to_user": schema.BoolAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The showToUser field.`,
+								},
+							},
+							Description: `The AdminProviderConfig message.`,
+						},
 						"bool_field": schema.SingleNestedAttribute{
 							Computed: true,
 							Optional: true,
@@ -124,15 +141,17 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 									Optional:    true,
 									Description: `The defaultValue field.`,
 								},
+								"toggle_field": schema.SingleNestedAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The ToggleField message.`,
+								},
 							},
 							MarkdownDescription: `The BoolField message.` + "\n" +
 								`` + "\n" +
 								`This message contains a oneof named view. Only a single field of the following list may be set at a time:` + "\n" +
 								`  - checkboxField` + "\n" +
-								`` + "\n" +
-								`` + "\n" +
-								`This message contains a oneof named _rules. Only a single field of the following list may be set at a time:` + "\n" +
-								`  - rules`,
+								`  - toggleField`,
 						},
 						"description": schema.StringAttribute{
 							Computed:    true,
@@ -160,138 +179,17 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 									Description: `The FileInputField message.`,
 								},
 								"max_file_size": schema.StringAttribute{
-									Computed: true,
-									Optional: true,
-									MarkdownDescription: `The maxFileSize field.` + "\n" +
-										`This field is part of the ` + "`" + `_max_file_size` + "`" + ` oneof.` + "\n" +
-										`See the documentation for ` + "`" + `c1.api.form.v1.FileField` + "`" + ` for more details.`,
+									Computed:    true,
+									Optional:    true,
+									Description: `The maxFileSize field.`,
 								},
 							},
 							MarkdownDescription: `The FileField message.` + "\n" +
 								`` + "\n" +
 								`This message contains a oneof named view. Only a single field of the following list may be set at a time:` + "\n" +
-								`  - fileInputField` + "\n" +
-								`` + "\n" +
-								`` + "\n" +
-								`This message contains a oneof named _max_file_size. Only a single field of the following list may be set at a time:` + "\n" +
-								`  - maxFileSize`,
+								`  - fileInputField`,
 						},
-						"int64_field": schema.SingleNestedAttribute{
-							Computed: true,
-							Optional: true,
-							Attributes: map[string]schema.Attribute{
-								"default_value": schema.StringAttribute{
-									Computed: true,
-									Optional: true,
-									MarkdownDescription: `The defaultValue field.` + "\n" +
-										`This field is part of the ` + "`" + `_default_value` + "`" + ` oneof.` + "\n" +
-										`See the documentation for ` + "`" + `c1.api.form.v1.Int64Field` + "`" + ` for more details.`,
-								},
-								"int64_rules": schema.SingleNestedAttribute{
-									Computed: true,
-									Optional: true,
-									Attributes: map[string]schema.Attribute{
-										"const": schema.StringAttribute{
-											Computed:    true,
-											Optional:    true,
-											Description: `Const specifies that this field must be exactly the specified value`,
-										},
-										"gt": schema.StringAttribute{
-											Computed: true,
-											Optional: true,
-											MarkdownDescription: `Gt specifies that this field must be greater than the specified value,` + "\n" +
-												` exclusive. If the value of Gt is larger than a specified Lt or Lte, the` + "\n" +
-												` range is reversed.`,
-										},
-										"gte": schema.StringAttribute{
-											Computed: true,
-											Optional: true,
-											MarkdownDescription: `Gte specifies that this field must be greater than or equal to the` + "\n" +
-												` specified value, inclusive. If the value of Gte is larger than a` + "\n" +
-												` specified Lt or Lte, the range is reversed.`,
-										},
-										"ignore_empty": schema.BoolAttribute{
-											Computed: true,
-											Optional: true,
-											MarkdownDescription: `IgnoreEmpty specifies that the validation rules of this field should be` + "\n" +
-												` evaluated only if the field is not empty`,
-										},
-										"in": schema.ListAttribute{
-											Computed:    true,
-											Optional:    true,
-											ElementType: types.StringType,
-											MarkdownDescription: `In specifies that this field must be equal to one of the specified` + "\n" +
-												` values`,
-										},
-										"lt": schema.StringAttribute{
-											Computed: true,
-											Optional: true,
-											MarkdownDescription: `Lt specifies that this field must be less than the specified value,` + "\n" +
-												` exclusive`,
-										},
-										"lte": schema.StringAttribute{
-											Computed: true,
-											Optional: true,
-											MarkdownDescription: `Lte specifies that this field must be less than or equal to the` + "\n" +
-												` specified value, inclusive`,
-										},
-										"not_in": schema.ListAttribute{
-											Computed:    true,
-											Optional:    true,
-											ElementType: types.StringType,
-											MarkdownDescription: `NotIn specifies that this field cannot be equal to one of the specified` + "\n" +
-												` values`,
-										},
-									},
-									Description: `Int64Rules describes the constraints applied to ` + "`" + `int64` + "`" + ` values`,
-								},
-								"number_field": schema.SingleNestedAttribute{
-									Computed: true,
-									Optional: true,
-									Attributes: map[string]schema.Attribute{
-										"max_value": schema.StringAttribute{
-											Computed:    true,
-											Optional:    true,
-											Description: `The maxValue field.`,
-										},
-										"min_value": schema.StringAttribute{
-											Computed:    true,
-											Optional:    true,
-											Description: `The minValue field.`,
-										},
-										"step": schema.StringAttribute{
-											Computed:    true,
-											Optional:    true,
-											Description: `The step field.`,
-										},
-									},
-									Description: `The NumberField message.`,
-								},
-								"placeholder": schema.StringAttribute{
-									Computed:    true,
-									Optional:    true,
-									Description: `The placeholder field.`,
-								},
-							},
-							MarkdownDescription: `The Int64Field message.` + "\n" +
-								`` + "\n" +
-								`This message contains a oneof named view. Only a single field of the following list may be set at a time:` + "\n" +
-								`  - numberField` + "\n" +
-								`` + "\n" +
-								`` + "\n" +
-								`This message contains a oneof named _default_value. Only a single field of the following list may be set at a time:` + "\n" +
-								`  - defaultValue` + "\n" +
-								`` + "\n" +
-								`` + "\n" +
-								`This message contains a oneof named _rules. Only a single field of the following list may be set at a time:` + "\n" +
-								`  - rules`,
-						},
-						"name": schema.StringAttribute{
-							Computed:    true,
-							Optional:    true,
-							Description: `The name field.`,
-						},
-						"string_field": schema.SingleNestedAttribute{
+						"form_string_field": schema.SingleNestedAttribute{
 							Computed: true,
 							Optional: true,
 							Attributes: map[string]schema.Attribute{
@@ -304,6 +202,53 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 									Computed:    true,
 									Optional:    true,
 									Description: `The PasswordField message.`,
+								},
+								"picker_field": schema.SingleNestedAttribute{
+									Computed: true,
+									Optional: true,
+									Attributes: map[string]schema.Attribute{
+										"app_resource_filter": schema.SingleNestedAttribute{
+											Computed: true,
+											Optional: true,
+											Attributes: map[string]schema.Attribute{
+												"app_id": schema.StringAttribute{
+													Computed:    true,
+													Optional:    true,
+													Description: `The appId field.`,
+												},
+												"resource_type_id": schema.StringAttribute{
+													Computed:    true,
+													Optional:    true,
+													Description: `The resourceTypeId field.`,
+												},
+											},
+											Description: `The AppResourceFilter message.`,
+										},
+										"app_user_filter": schema.SingleNestedAttribute{
+											Computed: true,
+											Optional: true,
+											Attributes: map[string]schema.Attribute{
+												"app_id": schema.StringAttribute{
+													Computed:    true,
+													Optional:    true,
+													Description: `The appId field.`,
+												},
+											},
+											Description: `The AppUserFilter message.`,
+										},
+										"c1_user_filter": schema.SingleNestedAttribute{
+											Computed: true,
+											Optional: true,
+											MarkdownDescription: `C1UserFilter is used to configure a picker for selecting ConductorOne users.` + "\n" +
+												` This is distinct from AppUserFilter which selects accounts within a connected app.`,
+										},
+									},
+									MarkdownDescription: `The PickerField message.` + "\n" +
+										`` + "\n" +
+										`This message contains a oneof named type. Only a single field of the following list may be set at a time:` + "\n" +
+										`  - appUserPicker` + "\n" +
+										`  - resourcePicker` + "\n" +
+										`  - c1UserPicker`,
 								},
 								"placeholder": schema.StringAttribute{
 									Computed:    true,
@@ -318,10 +263,12 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 											Computed: true,
 											Optional: true,
 											NestedObject: schema.NestedAttributeObject{
-												Validators: []validator.Object{
-													speakeasy_objectvalidators.NotNull(),
-												},
 												Attributes: map[string]schema.Attribute{
+													"description": schema.StringAttribute{
+														Computed:    true,
+														Optional:    true,
+														Description: `Used for type BUTTONS`,
+													},
 													"display_name": schema.StringAttribute{
 														Computed:    true,
 														Optional:    true,
@@ -335,6 +282,11 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 												},
 											},
 											Description: `The options field.`,
+										},
+										"type": schema.StringAttribute{
+											Computed:    true,
+											Optional:    true,
+											Description: `The type field.`,
 										},
 									},
 									Description: `The SelectField message.`,
@@ -559,6 +511,11 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 											Optional:    true,
 											Description: `The multiline field.`,
 										},
+										"suffix": schema.StringAttribute{
+											Computed:    true,
+											Optional:    true,
+											Description: `Static text displayed as an end adornment (e.g. ".example.com" for domain fields).`,
+										},
 									},
 									Description: `The TextField message.`,
 								},
@@ -569,10 +526,201 @@ func (r *RequestSchemaResource) Schema(ctx context.Context, req resource.SchemaR
 								`  - textField` + "\n" +
 								`  - passwordField` + "\n" +
 								`  - selectField` + "\n" +
+								`  - pickerField`,
+						},
+						"form_string_map_field": schema.SingleNestedAttribute{
+							Computed: true,
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"default_value": schema.MapAttribute{
+									Computed:    true,
+									Optional:    true,
+									ElementType: types.StringType,
+									Description: `The defaultValue field.`,
+								},
+								"string_map_rules": schema.SingleNestedAttribute{
+									Computed: true,
+									Optional: true,
+									Attributes: map[string]schema.Attribute{
+										"is_required": schema.BoolAttribute{
+											Computed:    true,
+											Optional:    true,
+											Description: `The isRequired field.`,
+										},
+										"validate_empty": schema.BoolAttribute{
+											Computed:    true,
+											Optional:    true,
+											Description: `The validateEmpty field.`,
+										},
+									},
+									Description: `The StringMapRules message.`,
+								},
+							},
+							Description: `The StringMapField message.`,
+						},
+						"int64_field": schema.SingleNestedAttribute{
+							Computed: true,
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"default_value": schema.StringAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The defaultValue field.`,
+								},
+								"int64_rules": schema.SingleNestedAttribute{
+									Computed: true,
+									Optional: true,
+									Attributes: map[string]schema.Attribute{
+										"const": schema.StringAttribute{
+											Computed:    true,
+											Optional:    true,
+											Description: `Const specifies that this field must be exactly the specified value`,
+										},
+										"gt": schema.StringAttribute{
+											Computed: true,
+											Optional: true,
+											MarkdownDescription: `Gt specifies that this field must be greater than the specified value,` + "\n" +
+												` exclusive. If the value of Gt is larger than a specified Lt or Lte, the` + "\n" +
+												` range is reversed.`,
+										},
+										"gte": schema.StringAttribute{
+											Computed: true,
+											Optional: true,
+											MarkdownDescription: `Gte specifies that this field must be greater than or equal to the` + "\n" +
+												` specified value, inclusive. If the value of Gte is larger than a` + "\n" +
+												` specified Lt or Lte, the range is reversed.`,
+										},
+										"ignore_empty": schema.BoolAttribute{
+											Computed: true,
+											Optional: true,
+											MarkdownDescription: `IgnoreEmpty specifies that the validation rules of this field should be` + "\n" +
+												` evaluated only if the field is not empty`,
+										},
+										"in": schema.ListAttribute{
+											Computed:    true,
+											Optional:    true,
+											ElementType: types.StringType,
+											MarkdownDescription: `In specifies that this field must be equal to one of the specified` + "\n" +
+												` values`,
+										},
+										"lt": schema.StringAttribute{
+											Computed: true,
+											Optional: true,
+											MarkdownDescription: `Lt specifies that this field must be less than the specified value,` + "\n" +
+												` exclusive`,
+										},
+										"lte": schema.StringAttribute{
+											Computed: true,
+											Optional: true,
+											MarkdownDescription: `Lte specifies that this field must be less than or equal to the` + "\n" +
+												` specified value, inclusive`,
+										},
+										"not_in": schema.ListAttribute{
+											Computed:    true,
+											Optional:    true,
+											ElementType: types.StringType,
+											MarkdownDescription: `NotIn specifies that this field cannot be equal to one of the specified` + "\n" +
+												` values`,
+										},
+									},
+									Description: `Int64Rules describes the constraints applied to ` + "`" + `int64` + "`" + ` values`,
+								},
+								"number_field": schema.SingleNestedAttribute{
+									Computed: true,
+									Optional: true,
+									Attributes: map[string]schema.Attribute{
+										"max_value": schema.StringAttribute{
+											Computed:    true,
+											Optional:    true,
+											Description: `The maxValue field.`,
+										},
+										"min_value": schema.StringAttribute{
+											Computed:    true,
+											Optional:    true,
+											Description: `The minValue field.`,
+										},
+										"step": schema.StringAttribute{
+											Computed:    true,
+											Optional:    true,
+											Description: `The step field.`,
+										},
+									},
+									Description: `The NumberField message.`,
+								},
+								"placeholder": schema.StringAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The placeholder field.`,
+								},
+							},
+							MarkdownDescription: `The Int64Field message.` + "\n" +
 								`` + "\n" +
+								`This message contains a oneof named view. Only a single field of the following list may be set at a time:` + "\n" +
+								`  - numberField`,
+						},
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Optional:    true,
+							Description: `The name field.`,
+						},
+						"oauth2_field": schema.SingleNestedAttribute{
+							Computed: true,
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"oauth2_field_view": schema.SingleNestedAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The Oauth2FieldView message.`,
+								},
+							},
+							MarkdownDescription: `The Oauth2Field message.` + "\n" +
 								`` + "\n" +
-								`This message contains a oneof named _rules. Only a single field of the following list may be set at a time:` + "\n" +
-								`  - rules`,
+								`This message contains a oneof named view. Only a single field of the following list may be set at a time:` + "\n" +
+								`  - oauth2FieldView`,
+						},
+						"read_only": schema.BoolAttribute{
+							Computed:    true,
+							Optional:    true,
+							Description: `When true, this field is displayed to the user but cannot be edited.`,
+						},
+						"required": schema.BoolAttribute{
+							Computed:    true,
+							Optional:    true,
+							Description: `The required field.`,
+						},
+						"shared_provider_config": schema.SingleNestedAttribute{
+							Computed: true,
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"default_value_cel": schema.StringAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The defaultValueCel field.`,
+								},
+								"input_transformation_cel": schema.StringAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The inputTransformationCel field.`,
+								},
+								"lock_default_values": schema.BoolAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The lockDefaultValues field.`,
+								},
+							},
+							Description: `The SharedProviderConfig message.`,
+						},
+						"user_provider_config": schema.SingleNestedAttribute{
+							Computed: true,
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"input_transformation_cel": schema.StringAttribute{
+									Computed:    true,
+									Optional:    true,
+									Description: `The inputTransformationCel field.`,
+								},
+							},
+							Description: `The UserProviderConfig message.`,
 						},
 					},
 				},

--- a/internal/provider/request_schema_resource_sdk.go
+++ b/internal/provider/request_schema_resource_sdk.go
@@ -64,6 +64,13 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 			for _, fieldsItem := range resp.Fields {
 				var fields tfTypes.FormField
 
+				if fieldsItem.AdminProviderConfig == nil {
+					fields.AdminProviderConfig = nil
+				} else {
+					fields.AdminProviderConfig = &tfTypes.AdminProviderConfig{}
+					fields.AdminProviderConfig.DefaultValueCel = types.StringPointerValue(fieldsItem.AdminProviderConfig.DefaultValueCel)
+					fields.AdminProviderConfig.ShowToUser = types.BoolPointerValue(fieldsItem.AdminProviderConfig.ShowToUser)
+				}
 				if fieldsItem.BoolField == nil {
 					fields.BoolField = nil
 				} else {
@@ -80,6 +87,11 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 						fields.BoolField.CheckboxField = &tfTypes.CheckboxField{}
 					}
 					fields.BoolField.DefaultValue = types.BoolPointerValue(fieldsItem.BoolField.DefaultValue)
+					if fieldsItem.BoolField.ToggleField == nil {
+						fields.BoolField.ToggleField = nil
+					} else {
+						fields.BoolField.ToggleField = &tfTypes.ToggleField{}
+					}
 				}
 				fields.Description = types.StringPointerValue(fieldsItem.Description)
 				fields.DisplayName = types.StringPointerValue(fieldsItem.DisplayName)
@@ -92,6 +104,8 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 						for _, v := range fieldsItem.FileField.AcceptedFileTypes {
 							fields.FileField.AcceptedFileTypes = append(fields.FileField.AcceptedFileTypes, types.StringValue(v))
 						}
+					} else {
+						fields.FileField.AcceptedFileTypes = nil
 					}
 					if fieldsItem.FileField.FileInputField == nil {
 						fields.FileField.FileInputField = nil
@@ -100,45 +114,6 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 					}
 					fields.FileField.MaxFileSize = types.StringPointerValue(fieldsItem.FileField.MaxFileSize)
 				}
-				if fieldsItem.Int64Field == nil {
-					fields.Int64Field = nil
-				} else {
-					fields.Int64Field = &tfTypes.Int64Field{}
-					fields.Int64Field.DefaultValue = types.StringPointerValue(fieldsItem.Int64Field.DefaultValue)
-					if fieldsItem.Int64Field.Int64Rules == nil {
-						fields.Int64Field.Int64Rules = nil
-					} else {
-						fields.Int64Field.Int64Rules = &tfTypes.Int64Rules{}
-						fields.Int64Field.Int64Rules.Const = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Const)
-						fields.Int64Field.Int64Rules.Gt = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Gt)
-						fields.Int64Field.Int64Rules.Gte = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Gte)
-						fields.Int64Field.Int64Rules.IgnoreEmpty = types.BoolPointerValue(fieldsItem.Int64Field.Int64Rules.IgnoreEmpty)
-						if fieldsItem.Int64Field.Int64Rules.In != nil {
-							fields.Int64Field.Int64Rules.In = make([]types.String, 0, len(fieldsItem.Int64Field.Int64Rules.In))
-							for _, v := range fieldsItem.Int64Field.Int64Rules.In {
-								fields.Int64Field.Int64Rules.In = append(fields.Int64Field.Int64Rules.In, types.StringValue(v))
-							}
-						}
-						fields.Int64Field.Int64Rules.Lt = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Lt)
-						fields.Int64Field.Int64Rules.Lte = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Lte)
-						if fieldsItem.Int64Field.Int64Rules.NotIn != nil {
-							fields.Int64Field.Int64Rules.NotIn = make([]types.String, 0, len(fieldsItem.Int64Field.Int64Rules.NotIn))
-							for _, v := range fieldsItem.Int64Field.Int64Rules.NotIn {
-								fields.Int64Field.Int64Rules.NotIn = append(fields.Int64Field.Int64Rules.NotIn, types.StringValue(v))
-							}
-						}
-					}
-					if fieldsItem.Int64Field.NumberField == nil {
-						fields.Int64Field.NumberField = nil
-					} else {
-						fields.Int64Field.NumberField = &tfTypes.NumberField{}
-						fields.Int64Field.NumberField.MaxValue = types.StringPointerValue(fieldsItem.Int64Field.NumberField.MaxValue)
-						fields.Int64Field.NumberField.MinValue = types.StringPointerValue(fieldsItem.Int64Field.NumberField.MinValue)
-						fields.Int64Field.NumberField.Step = types.StringPointerValue(fieldsItem.Int64Field.NumberField.Step)
-					}
-					fields.Int64Field.Placeholder = types.StringPointerValue(fieldsItem.Int64Field.Placeholder)
-				}
-				fields.Name = types.StringPointerValue(fieldsItem.Name)
 				if fieldsItem.FormStringField == nil {
 					fields.FormStringField = nil
 				} else {
@@ -148,6 +123,29 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 						fields.FormStringField.PasswordField = nil
 					} else {
 						fields.FormStringField.PasswordField = &tfTypes.PasswordField{}
+					}
+					if fieldsItem.FormStringField.PickerField == nil {
+						fields.FormStringField.PickerField = nil
+					} else {
+						fields.FormStringField.PickerField = &tfTypes.PickerField{}
+						if fieldsItem.FormStringField.PickerField.AppResourceFilter == nil {
+							fields.FormStringField.PickerField.AppResourceFilter = nil
+						} else {
+							fields.FormStringField.PickerField.AppResourceFilter = &tfTypes.AppResourceFilter{}
+							fields.FormStringField.PickerField.AppResourceFilter.AppID = types.StringPointerValue(fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID)
+							fields.FormStringField.PickerField.AppResourceFilter.ResourceTypeID = types.StringPointerValue(fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID)
+						}
+						if fieldsItem.FormStringField.PickerField.AppUserFilter == nil {
+							fields.FormStringField.PickerField.AppUserFilter = nil
+						} else {
+							fields.FormStringField.PickerField.AppUserFilter = &tfTypes.AppUserFilter{}
+							fields.FormStringField.PickerField.AppUserFilter.AppID = types.StringPointerValue(fieldsItem.FormStringField.PickerField.AppUserFilter.AppID)
+						}
+						if fieldsItem.FormStringField.PickerField.C1UserFilter == nil {
+							fields.FormStringField.PickerField.C1UserFilter = nil
+						} else {
+							fields.FormStringField.PickerField.C1UserFilter = &tfTypes.C1UserFilter{}
+						}
 					}
 					fields.FormStringField.Placeholder = types.StringPointerValue(fieldsItem.FormStringField.Placeholder)
 					if fieldsItem.FormStringField.SelectField == nil {
@@ -160,11 +158,19 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 							for _, optionsVarItem := range fieldsItem.FormStringField.SelectField.Options {
 								var optionsVar tfTypes.SelectOption
 
+								optionsVar.Description = types.StringPointerValue(optionsVarItem.Description)
 								optionsVar.DisplayName = types.StringPointerValue(optionsVarItem.DisplayName)
 								optionsVar.Value = types.StringPointerValue(optionsVarItem.Value)
 
 								fields.FormStringField.SelectField.Options = append(fields.FormStringField.SelectField.Options, optionsVar)
 							}
+						} else {
+							fields.FormStringField.SelectField.Options = nil
+						}
+						if fieldsItem.FormStringField.SelectField.Type != nil {
+							fields.FormStringField.SelectField.Type = types.StringValue(string(*fieldsItem.FormStringField.SelectField.Type))
+						} else {
+							fields.FormStringField.SelectField.Type = types.StringNull()
 						}
 					}
 					if fieldsItem.FormStringField.StringRules == nil {
@@ -182,6 +188,8 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 							for _, v := range fieldsItem.FormStringField.StringRules.In {
 								fields.FormStringField.StringRules.In = append(fields.FormStringField.StringRules.In, types.StringValue(v))
 							}
+						} else {
+							fields.FormStringField.StringRules.In = nil
 						}
 						fields.FormStringField.StringRules.IP = types.BoolPointerValue(fieldsItem.FormStringField.StringRules.IP)
 						fields.FormStringField.StringRules.Ipv4 = types.BoolPointerValue(fieldsItem.FormStringField.StringRules.Ipv4)
@@ -198,6 +206,8 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 							for _, v := range fieldsItem.FormStringField.StringRules.NotIn {
 								fields.FormStringField.StringRules.NotIn = append(fields.FormStringField.StringRules.NotIn, types.StringValue(v))
 							}
+						} else {
+							fields.FormStringField.StringRules.NotIn = nil
 						}
 						fields.FormStringField.StringRules.Pattern = types.StringPointerValue(fieldsItem.FormStringField.StringRules.Pattern)
 						fields.FormStringField.StringRules.Prefix = types.StringPointerValue(fieldsItem.FormStringField.StringRules.Prefix)
@@ -217,7 +227,95 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 					} else {
 						fields.FormStringField.TextField = &tfTypes.TextField{}
 						fields.FormStringField.TextField.Multiline = types.BoolPointerValue(fieldsItem.FormStringField.TextField.Multiline)
+						fields.FormStringField.TextField.Suffix = types.StringPointerValue(fieldsItem.FormStringField.TextField.Suffix)
 					}
+				}
+				if fieldsItem.FormStringMapField == nil {
+					fields.FormStringMapField = nil
+				} else {
+					fields.FormStringMapField = &tfTypes.FormStringMapField{}
+					if len(fieldsItem.FormStringMapField.DefaultValue) > 0 {
+						fields.FormStringMapField.DefaultValue = make(map[string]types.String, len(fieldsItem.FormStringMapField.DefaultValue))
+						for key, value := range fieldsItem.FormStringMapField.DefaultValue {
+							fields.FormStringMapField.DefaultValue[key] = types.StringValue(value)
+						}
+					}
+					if fieldsItem.FormStringMapField.StringMapRules == nil {
+						fields.FormStringMapField.StringMapRules = nil
+					} else {
+						fields.FormStringMapField.StringMapRules = &tfTypes.StringMapRules{}
+						fields.FormStringMapField.StringMapRules.IsRequired = types.BoolPointerValue(fieldsItem.FormStringMapField.StringMapRules.IsRequired)
+						fields.FormStringMapField.StringMapRules.ValidateEmpty = types.BoolPointerValue(fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty)
+					}
+				}
+				if fieldsItem.Int64Field == nil {
+					fields.Int64Field = nil
+				} else {
+					fields.Int64Field = &tfTypes.Int64Field{}
+					fields.Int64Field.DefaultValue = types.StringPointerValue(fieldsItem.Int64Field.DefaultValue)
+					if fieldsItem.Int64Field.Int64Rules == nil {
+						fields.Int64Field.Int64Rules = nil
+					} else {
+						fields.Int64Field.Int64Rules = &tfTypes.Int64Rules{}
+						fields.Int64Field.Int64Rules.Const = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Const)
+						fields.Int64Field.Int64Rules.Gt = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Gt)
+						fields.Int64Field.Int64Rules.Gte = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Gte)
+						fields.Int64Field.Int64Rules.IgnoreEmpty = types.BoolPointerValue(fieldsItem.Int64Field.Int64Rules.IgnoreEmpty)
+						if fieldsItem.Int64Field.Int64Rules.In != nil {
+							fields.Int64Field.Int64Rules.In = make([]types.String, 0, len(fieldsItem.Int64Field.Int64Rules.In))
+							for _, v := range fieldsItem.Int64Field.Int64Rules.In {
+								fields.Int64Field.Int64Rules.In = append(fields.Int64Field.Int64Rules.In, types.StringValue(v))
+							}
+						} else {
+							fields.Int64Field.Int64Rules.In = nil
+						}
+						fields.Int64Field.Int64Rules.Lt = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Lt)
+						fields.Int64Field.Int64Rules.Lte = types.StringPointerValue(fieldsItem.Int64Field.Int64Rules.Lte)
+						if fieldsItem.Int64Field.Int64Rules.NotIn != nil {
+							fields.Int64Field.Int64Rules.NotIn = make([]types.String, 0, len(fieldsItem.Int64Field.Int64Rules.NotIn))
+							for _, v := range fieldsItem.Int64Field.Int64Rules.NotIn {
+								fields.Int64Field.Int64Rules.NotIn = append(fields.Int64Field.Int64Rules.NotIn, types.StringValue(v))
+							}
+						} else {
+							fields.Int64Field.Int64Rules.NotIn = nil
+						}
+					}
+					if fieldsItem.Int64Field.NumberField == nil {
+						fields.Int64Field.NumberField = nil
+					} else {
+						fields.Int64Field.NumberField = &tfTypes.NumberField{}
+						fields.Int64Field.NumberField.MaxValue = types.StringPointerValue(fieldsItem.Int64Field.NumberField.MaxValue)
+						fields.Int64Field.NumberField.MinValue = types.StringPointerValue(fieldsItem.Int64Field.NumberField.MinValue)
+						fields.Int64Field.NumberField.Step = types.StringPointerValue(fieldsItem.Int64Field.NumberField.Step)
+					}
+					fields.Int64Field.Placeholder = types.StringPointerValue(fieldsItem.Int64Field.Placeholder)
+				}
+				fields.Name = types.StringPointerValue(fieldsItem.Name)
+				if fieldsItem.Oauth2Field == nil {
+					fields.Oauth2Field = nil
+				} else {
+					fields.Oauth2Field = &tfTypes.Oauth2Field{}
+					if fieldsItem.Oauth2Field.Oauth2FieldView == nil {
+						fields.Oauth2Field.Oauth2FieldView = nil
+					} else {
+						fields.Oauth2Field.Oauth2FieldView = &tfTypes.Oauth2FieldView{}
+					}
+				}
+				fields.ReadOnly = types.BoolPointerValue(fieldsItem.ReadOnly)
+				fields.Required = types.BoolPointerValue(fieldsItem.Required)
+				if fieldsItem.SharedProviderConfig == nil {
+					fields.SharedProviderConfig = nil
+				} else {
+					fields.SharedProviderConfig = &tfTypes.SharedProviderConfig{}
+					fields.SharedProviderConfig.DefaultValueCel = types.StringPointerValue(fieldsItem.SharedProviderConfig.DefaultValueCel)
+					fields.SharedProviderConfig.InputTransformationCel = types.StringPointerValue(fieldsItem.SharedProviderConfig.InputTransformationCel)
+					fields.SharedProviderConfig.LockDefaultValues = types.BoolPointerValue(fieldsItem.SharedProviderConfig.LockDefaultValues)
+				}
+				if fieldsItem.UserProviderConfig == nil {
+					fields.UserProviderConfig = nil
+				} else {
+					fields.UserProviderConfig = &tfTypes.UserProviderConfig{}
+					fields.UserProviderConfig.InputTransformationCel = types.StringPointerValue(fieldsItem.UserProviderConfig.InputTransformationCel)
 				}
 
 				r.Fields = append(r.Fields, fields)
@@ -756,6 +854,49 @@ func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.
 						Multiline: multiline,
 					}
 				}
+				var pickerField *shared.PickerField
+				if fieldsItem.FormStringField.PickerField != nil {
+					var appResourceFilter *shared.AppResourceFilter
+					if fieldsItem.FormStringField.PickerField.AppResourceFilter != nil {
+						appResourceFilterAppID := new(string)
+						if !fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.IsNull() {
+							*appResourceFilterAppID = fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.ValueString()
+						} else {
+							appResourceFilterAppID = nil
+						}
+						appResourceFilterResourceTypeID := new(string)
+						if !fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsNull() {
+							*appResourceFilterResourceTypeID = fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.ValueString()
+						} else {
+							appResourceFilterResourceTypeID = nil
+						}
+						appResourceFilter = &shared.AppResourceFilter{
+							AppID:          appResourceFilterAppID,
+							ResourceTypeID: appResourceFilterResourceTypeID,
+						}
+					}
+					var appUserFilter *shared.AppUserFilter
+					if fieldsItem.FormStringField.PickerField.AppUserFilter != nil {
+						appUserFilterAppID := new(string)
+						if !fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.IsNull() {
+							*appUserFilterAppID = fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.ValueString()
+						} else {
+							appUserFilterAppID = nil
+						}
+						appUserFilter = &shared.AppUserFilter{
+							AppID: appUserFilterAppID,
+						}
+					}
+					var c1UserFilter *shared.C1UserFilter
+					if fieldsItem.FormStringField.PickerField.C1UserFilter != nil {
+						c1UserFilter = &shared.C1UserFilter{}
+					}
+					pickerField = &shared.PickerField{
+						AppUserFilter:     appUserFilter,
+						C1UserFilter:      c1UserFilter,
+						AppResourceFilter: appResourceFilter,
+					}
+				}
 				stringField = &shared.FormStringField{
 					DefaultValue:  defaultValue2,
 					PasswordField: passwordField,
@@ -763,16 +904,136 @@ func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.
 					StringRules:   stringRules,
 					SelectField:   selectField,
 					TextField:     textField,
+					PickerField:   pickerField,
 				}
 			}
+			var adminProviderConfig *shared.AdminProviderConfig
+			if fieldsItem.AdminProviderConfig != nil {
+				adminDefaultValueCel := new(string)
+				if !fieldsItem.AdminProviderConfig.DefaultValueCel.IsUnknown() && !fieldsItem.AdminProviderConfig.DefaultValueCel.IsNull() {
+					*adminDefaultValueCel = fieldsItem.AdminProviderConfig.DefaultValueCel.ValueString()
+				} else {
+					adminDefaultValueCel = nil
+				}
+				adminShowToUser := new(bool)
+				if !fieldsItem.AdminProviderConfig.ShowToUser.IsUnknown() && !fieldsItem.AdminProviderConfig.ShowToUser.IsNull() {
+					*adminShowToUser = fieldsItem.AdminProviderConfig.ShowToUser.ValueBool()
+				} else {
+					adminShowToUser = nil
+				}
+				adminProviderConfig = &shared.AdminProviderConfig{
+					DefaultValueCel: adminDefaultValueCel,
+					ShowToUser:      adminShowToUser,
+				}
+			}
+			var sharedProviderConfig *shared.SharedProviderConfig
+			if fieldsItem.SharedProviderConfig != nil {
+				sharedDefaultValueCel := new(string)
+				if !fieldsItem.SharedProviderConfig.DefaultValueCel.IsUnknown() && !fieldsItem.SharedProviderConfig.DefaultValueCel.IsNull() {
+					*sharedDefaultValueCel = fieldsItem.SharedProviderConfig.DefaultValueCel.ValueString()
+				} else {
+					sharedDefaultValueCel = nil
+				}
+				sharedInputTransformationCel := new(string)
+				if !fieldsItem.SharedProviderConfig.InputTransformationCel.IsUnknown() && !fieldsItem.SharedProviderConfig.InputTransformationCel.IsNull() {
+					*sharedInputTransformationCel = fieldsItem.SharedProviderConfig.InputTransformationCel.ValueString()
+				} else {
+					sharedInputTransformationCel = nil
+				}
+				sharedLockDefaultValues := new(bool)
+				if !fieldsItem.SharedProviderConfig.LockDefaultValues.IsUnknown() && !fieldsItem.SharedProviderConfig.LockDefaultValues.IsNull() {
+					*sharedLockDefaultValues = fieldsItem.SharedProviderConfig.LockDefaultValues.ValueBool()
+				} else {
+					sharedLockDefaultValues = nil
+				}
+				sharedProviderConfig = &shared.SharedProviderConfig{
+					DefaultValueCel:        sharedDefaultValueCel,
+					InputTransformationCel: sharedInputTransformationCel,
+					LockDefaultValues:      sharedLockDefaultValues,
+				}
+			}
+			var userProviderConfig *shared.UserProviderConfig
+			if fieldsItem.UserProviderConfig != nil {
+				userInputTransformationCel := new(string)
+				if !fieldsItem.UserProviderConfig.InputTransformationCel.IsUnknown() && !fieldsItem.UserProviderConfig.InputTransformationCel.IsNull() {
+					*userInputTransformationCel = fieldsItem.UserProviderConfig.InputTransformationCel.ValueString()
+				} else {
+					userInputTransformationCel = nil
+				}
+				userProviderConfig = &shared.UserProviderConfig{
+					InputTransformationCel: userInputTransformationCel,
+				}
+			}
+			var oauth2Field *shared.Oauth2Field
+			if fieldsItem.Oauth2Field != nil {
+				var oauth2FieldView *shared.Oauth2FieldView
+				if fieldsItem.Oauth2Field.Oauth2FieldView != nil {
+					oauth2FieldView = &shared.Oauth2FieldView{}
+				}
+				oauth2Field = &shared.Oauth2Field{
+					Oauth2FieldView: oauth2FieldView,
+				}
+			}
+			var formStringMapField *shared.FormStringMapField
+			if fieldsItem.FormStringMapField != nil {
+				var stringMapDefaultValue map[string]string
+				if fieldsItem.FormStringMapField.DefaultValue != nil {
+					stringMapDefaultValue = make(map[string]string, len(fieldsItem.FormStringMapField.DefaultValue))
+					for stringMapKey, stringMapVal := range fieldsItem.FormStringMapField.DefaultValue {
+						stringMapDefaultValue[stringMapKey] = stringMapVal.ValueString()
+					}
+				}
+				var stringMapRules *shared.StringMapRules
+				if fieldsItem.FormStringMapField.StringMapRules != nil {
+					stringMapIsRequired := new(bool)
+					if !fieldsItem.FormStringMapField.StringMapRules.IsRequired.IsUnknown() && !fieldsItem.FormStringMapField.StringMapRules.IsRequired.IsNull() {
+						*stringMapIsRequired = fieldsItem.FormStringMapField.StringMapRules.IsRequired.ValueBool()
+					} else {
+						stringMapIsRequired = nil
+					}
+					stringMapValidateEmpty := new(bool)
+					if !fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.IsUnknown() && !fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.IsNull() {
+						*stringMapValidateEmpty = fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.ValueBool()
+					} else {
+						stringMapValidateEmpty = nil
+					}
+					stringMapRules = &shared.StringMapRules{
+						IsRequired:    stringMapIsRequired,
+						ValidateEmpty: stringMapValidateEmpty,
+					}
+				}
+				formStringMapField = &shared.FormStringMapField{
+					DefaultValue:   stringMapDefaultValue,
+					StringMapRules: stringMapRules,
+				}
+			}
+			readOnly := new(bool)
+			if !fieldsItem.ReadOnly.IsUnknown() && !fieldsItem.ReadOnly.IsNull() {
+				*readOnly = fieldsItem.ReadOnly.ValueBool()
+			} else {
+				readOnly = nil
+			}
+			required := new(bool)
+			if !fieldsItem.Required.IsUnknown() && !fieldsItem.Required.IsNull() {
+				*required = fieldsItem.Required.ValueBool()
+			} else {
+				required = nil
+			}
 			fields = append(fields, shared.FormField{
-				BoolField:   boolField,
-				Description: description1,
-				DisplayName: displayName,
-				FileField:   fileField,
-				Int64Field:  int64Field,
-				Name:        name1,
-				FormStringField: stringField,
+				AdminProviderConfig:  adminProviderConfig,
+				Oauth2Field:          oauth2Field,
+				ReadOnly:             readOnly,
+				Required:             required,
+				SharedProviderConfig: sharedProviderConfig,
+				FormStringMapField:   formStringMapField,
+				UserProviderConfig:   userProviderConfig,
+				BoolField:            boolField,
+				Description:          description1,
+				DisplayName:          displayName,
+				FileField:            fileField,
+				Int64Field:           int64Field,
+				Name:                 name1,
+				FormStringField:      stringField,
 			})
 		}
 	}
@@ -815,10 +1076,10 @@ func (r *RequestSchemaResourceModel) ToSharedRequestSchema(ctx context.Context) 
 		id = nil
 	}
 	out := shared.RequestSchema{
-		CreatedAt: createdAt,
-		DeletedAt: deletedAt,
+		CreatedAt:         createdAt,
+		DeletedAt:         deletedAt,
 		RequestSchemaForm: form,
-		ID:        id,
+		ID:                id,
 	}
 
 	return &out, diags
@@ -1267,6 +1528,49 @@ func (r *RequestSchemaResourceModel) ToSharedRequestSchemaServiceCreateRequest(c
 						Multiline: multiline,
 					}
 				}
+				var pickerField *shared.PickerField
+				if fieldsItem.FormStringField.PickerField != nil {
+					var appResourceFilter *shared.AppResourceFilter
+					if fieldsItem.FormStringField.PickerField.AppResourceFilter != nil {
+						appResourceFilterAppID := new(string)
+						if !fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.IsNull() {
+							*appResourceFilterAppID = fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.ValueString()
+						} else {
+							appResourceFilterAppID = nil
+						}
+						appResourceFilterResourceTypeID := new(string)
+						if !fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsNull() {
+							*appResourceFilterResourceTypeID = fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.ValueString()
+						} else {
+							appResourceFilterResourceTypeID = nil
+						}
+						appResourceFilter = &shared.AppResourceFilter{
+							AppID:          appResourceFilterAppID,
+							ResourceTypeID: appResourceFilterResourceTypeID,
+						}
+					}
+					var appUserFilter *shared.AppUserFilter
+					if fieldsItem.FormStringField.PickerField.AppUserFilter != nil {
+						appUserFilterAppID := new(string)
+						if !fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.IsNull() {
+							*appUserFilterAppID = fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.ValueString()
+						} else {
+							appUserFilterAppID = nil
+						}
+						appUserFilter = &shared.AppUserFilter{
+							AppID: appUserFilterAppID,
+						}
+					}
+					var c1UserFilter *shared.C1UserFilter
+					if fieldsItem.FormStringField.PickerField.C1UserFilter != nil {
+						c1UserFilter = &shared.C1UserFilter{}
+					}
+					pickerField = &shared.PickerField{
+						AppUserFilter:     appUserFilter,
+						C1UserFilter:      c1UserFilter,
+						AppResourceFilter: appResourceFilter,
+					}
+				}
 				stringField = &shared.FormStringField{
 					DefaultValue:  defaultValue2,
 					PasswordField: passwordField,
@@ -1274,16 +1578,136 @@ func (r *RequestSchemaResourceModel) ToSharedRequestSchemaServiceCreateRequest(c
 					StringRules:   stringRules,
 					SelectField:   selectField,
 					TextField:     textField,
+					PickerField:   pickerField,
 				}
 			}
+			var adminProviderConfig *shared.AdminProviderConfig
+			if fieldsItem.AdminProviderConfig != nil {
+				adminDefaultValueCel := new(string)
+				if !fieldsItem.AdminProviderConfig.DefaultValueCel.IsUnknown() && !fieldsItem.AdminProviderConfig.DefaultValueCel.IsNull() {
+					*adminDefaultValueCel = fieldsItem.AdminProviderConfig.DefaultValueCel.ValueString()
+				} else {
+					adminDefaultValueCel = nil
+				}
+				adminShowToUser := new(bool)
+				if !fieldsItem.AdminProviderConfig.ShowToUser.IsUnknown() && !fieldsItem.AdminProviderConfig.ShowToUser.IsNull() {
+					*adminShowToUser = fieldsItem.AdminProviderConfig.ShowToUser.ValueBool()
+				} else {
+					adminShowToUser = nil
+				}
+				adminProviderConfig = &shared.AdminProviderConfig{
+					DefaultValueCel: adminDefaultValueCel,
+					ShowToUser:      adminShowToUser,
+				}
+			}
+			var sharedProviderConfig *shared.SharedProviderConfig
+			if fieldsItem.SharedProviderConfig != nil {
+				sharedDefaultValueCel := new(string)
+				if !fieldsItem.SharedProviderConfig.DefaultValueCel.IsUnknown() && !fieldsItem.SharedProviderConfig.DefaultValueCel.IsNull() {
+					*sharedDefaultValueCel = fieldsItem.SharedProviderConfig.DefaultValueCel.ValueString()
+				} else {
+					sharedDefaultValueCel = nil
+				}
+				sharedInputTransformationCel := new(string)
+				if !fieldsItem.SharedProviderConfig.InputTransformationCel.IsUnknown() && !fieldsItem.SharedProviderConfig.InputTransformationCel.IsNull() {
+					*sharedInputTransformationCel = fieldsItem.SharedProviderConfig.InputTransformationCel.ValueString()
+				} else {
+					sharedInputTransformationCel = nil
+				}
+				sharedLockDefaultValues := new(bool)
+				if !fieldsItem.SharedProviderConfig.LockDefaultValues.IsUnknown() && !fieldsItem.SharedProviderConfig.LockDefaultValues.IsNull() {
+					*sharedLockDefaultValues = fieldsItem.SharedProviderConfig.LockDefaultValues.ValueBool()
+				} else {
+					sharedLockDefaultValues = nil
+				}
+				sharedProviderConfig = &shared.SharedProviderConfig{
+					DefaultValueCel:        sharedDefaultValueCel,
+					InputTransformationCel: sharedInputTransformationCel,
+					LockDefaultValues:      sharedLockDefaultValues,
+				}
+			}
+			var userProviderConfig *shared.UserProviderConfig
+			if fieldsItem.UserProviderConfig != nil {
+				userInputTransformationCel := new(string)
+				if !fieldsItem.UserProviderConfig.InputTransformationCel.IsUnknown() && !fieldsItem.UserProviderConfig.InputTransformationCel.IsNull() {
+					*userInputTransformationCel = fieldsItem.UserProviderConfig.InputTransformationCel.ValueString()
+				} else {
+					userInputTransformationCel = nil
+				}
+				userProviderConfig = &shared.UserProviderConfig{
+					InputTransformationCel: userInputTransformationCel,
+				}
+			}
+			var oauth2Field *shared.Oauth2Field
+			if fieldsItem.Oauth2Field != nil {
+				var oauth2FieldView *shared.Oauth2FieldView
+				if fieldsItem.Oauth2Field.Oauth2FieldView != nil {
+					oauth2FieldView = &shared.Oauth2FieldView{}
+				}
+				oauth2Field = &shared.Oauth2Field{
+					Oauth2FieldView: oauth2FieldView,
+				}
+			}
+			var formStringMapField *shared.FormStringMapField
+			if fieldsItem.FormStringMapField != nil {
+				var stringMapDefaultValue map[string]string
+				if fieldsItem.FormStringMapField.DefaultValue != nil {
+					stringMapDefaultValue = make(map[string]string, len(fieldsItem.FormStringMapField.DefaultValue))
+					for stringMapKey, stringMapVal := range fieldsItem.FormStringMapField.DefaultValue {
+						stringMapDefaultValue[stringMapKey] = stringMapVal.ValueString()
+					}
+				}
+				var stringMapRules *shared.StringMapRules
+				if fieldsItem.FormStringMapField.StringMapRules != nil {
+					stringMapIsRequired := new(bool)
+					if !fieldsItem.FormStringMapField.StringMapRules.IsRequired.IsUnknown() && !fieldsItem.FormStringMapField.StringMapRules.IsRequired.IsNull() {
+						*stringMapIsRequired = fieldsItem.FormStringMapField.StringMapRules.IsRequired.ValueBool()
+					} else {
+						stringMapIsRequired = nil
+					}
+					stringMapValidateEmpty := new(bool)
+					if !fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.IsUnknown() && !fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.IsNull() {
+						*stringMapValidateEmpty = fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.ValueBool()
+					} else {
+						stringMapValidateEmpty = nil
+					}
+					stringMapRules = &shared.StringMapRules{
+						IsRequired:    stringMapIsRequired,
+						ValidateEmpty: stringMapValidateEmpty,
+					}
+				}
+				formStringMapField = &shared.FormStringMapField{
+					DefaultValue:   stringMapDefaultValue,
+					StringMapRules: stringMapRules,
+				}
+			}
+			readOnly := new(bool)
+			if !fieldsItem.ReadOnly.IsUnknown() && !fieldsItem.ReadOnly.IsNull() {
+				*readOnly = fieldsItem.ReadOnly.ValueBool()
+			} else {
+				readOnly = nil
+			}
+			required := new(bool)
+			if !fieldsItem.Required.IsUnknown() && !fieldsItem.Required.IsNull() {
+				*required = fieldsItem.Required.ValueBool()
+			} else {
+				required = nil
+			}
 			fields = append(fields, shared.FormField{
-				BoolField:   boolField,
-				Description: description1,
-				DisplayName: displayName,
-				FileField:   fileField,
-				Int64Field:  int64Field,
-				Name:        name,
-				FormStringField: stringField,
+				AdminProviderConfig:  adminProviderConfig,
+				Oauth2Field:          oauth2Field,
+				ReadOnly:             readOnly,
+				Required:             required,
+				SharedProviderConfig: sharedProviderConfig,
+				FormStringMapField:   formStringMapField,
+				UserProviderConfig:   userProviderConfig,
+				BoolField:            boolField,
+				Description:          description1,
+				DisplayName:          displayName,
+				FileField:            fileField,
+				Int64Field:           int64Field,
+				Name:                 name,
+				FormStringField:      stringField,
 			})
 		}
 	}

--- a/internal/provider/request_schema_resource_sdk.go
+++ b/internal/provider/request_schema_resource_sdk.go
@@ -4,29 +4,67 @@ package provider
 
 import (
 	"context"
-	"time"
-
 	"github.com/conductorone/terraform-provider-conductorone/internal/provider/typeconvert"
 	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/operations"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"time"
 )
 
 func (r *RequestSchemaResourceModel) RefreshFromSharedRequestSchema(ctx context.Context, resp *shared.RequestSchema) diag.Diagnostics {
 	var diags diag.Diagnostics
-	r.CreatedAt = types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.CreatedAt))
-	r.DeletedAt = types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.DeletedAt))
-	r.ID = types.StringPointerValue(resp.ID)
+
+	if resp != nil {
+		r.CreatedAt = types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.CreatedAt))
+		r.DeletedAt = types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.DeletedAt))
+		r.ID = types.StringPointerValue(resp.ID)
+		if resp.JustificationVisibility != nil {
+			r.JustificationVisibility = types.StringValue(string(*resp.JustificationVisibility))
+		} else {
+			r.JustificationVisibility = types.StringNull()
+		}
+		diags.Append(r.RefreshFromSharedRequestSchemaForm(ctx, resp.RequestSchemaForm)...)
+
+		if diags.HasError() {
+			return diags
+		}
+
+	}
+
 	return diags
 }
 
-func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, resp *shared.RequestSchemaForm) diag.Diagnostics {
+func (r *RequestSchemaResourceModel) RefreshFromSharedRequestSchemaForm(ctx context.Context, resp *shared.RequestSchemaForm) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if resp != nil {
 		r.Description = types.StringPointerValue(resp.Description)
+		if resp.FieldGroups != nil {
+			r.FieldGroups = []tfTypes.FormFieldGroup{}
+
+			for _, fieldGroupsItem := range resp.FieldGroups {
+				var fieldGroups tfTypes.FormFieldGroup
+
+				fieldGroups.Default = types.BoolPointerValue(fieldGroupsItem.Default)
+				fieldGroups.DisplayName = types.StringPointerValue(fieldGroupsItem.DisplayName)
+				if fieldGroupsItem.Fields != nil {
+					fieldGroups.Fields = make([]types.String, 0, len(fieldGroupsItem.Fields))
+					for _, v := range fieldGroupsItem.Fields {
+						fieldGroups.Fields = append(fieldGroups.Fields, types.StringValue(v))
+					}
+				} else {
+					fieldGroups.Fields = nil
+				}
+				fieldGroups.HelpText = types.StringPointerValue(fieldGroupsItem.HelpText)
+				fieldGroups.Name = types.StringPointerValue(fieldGroupsItem.Name)
+
+				r.FieldGroups = append(r.FieldGroups, fieldGroups)
+			}
+		} else {
+			r.FieldGroups = nil
+		}
 		if resp.FieldRelationships != nil {
 			r.FieldRelationships = []tfTypes.FieldRelationship{}
 
@@ -38,11 +76,26 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 				} else {
 					fieldRelationships.AtLeastOne = &tfTypes.AtLeastOne{}
 				}
+				if fieldRelationshipsItem.DependentOn == nil {
+					fieldRelationships.DependentOn = nil
+				} else {
+					fieldRelationships.DependentOn = &tfTypes.DependentOn{}
+					if fieldRelationshipsItem.DependentOn.DependencyFieldNames != nil {
+						fieldRelationships.DependentOn.DependencyFieldNames = make([]types.String, 0, len(fieldRelationshipsItem.DependentOn.DependencyFieldNames))
+						for _, v := range fieldRelationshipsItem.DependentOn.DependencyFieldNames {
+							fieldRelationships.DependentOn.DependencyFieldNames = append(fieldRelationships.DependentOn.DependencyFieldNames, types.StringValue(v))
+						}
+					} else {
+						fieldRelationships.DependentOn.DependencyFieldNames = nil
+					}
+				}
 				if fieldRelationshipsItem.FieldNames != nil {
 					fieldRelationships.FieldNames = make([]types.String, 0, len(fieldRelationshipsItem.FieldNames))
 					for _, v := range fieldRelationshipsItem.FieldNames {
 						fieldRelationships.FieldNames = append(fieldRelationships.FieldNames, types.StringValue(v))
 					}
+				} else {
+					fieldRelationships.FieldNames = nil
 				}
 				if fieldRelationshipsItem.MutuallyExclusive == nil {
 					fieldRelationships.MutuallyExclusive = nil
@@ -57,6 +110,8 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 
 				r.FieldRelationships = append(r.FieldRelationships, fieldRelationships)
 			}
+		} else {
+			r.FieldRelationships = nil
 		}
 		if resp.Fields != nil {
 			r.Fields = []tfTypes.FormField{}
@@ -320,8 +375,55 @@ func (r *RequestSchemaResourceModel) RefreshFromSharedForm(ctx context.Context, 
 
 				r.Fields = append(r.Fields, fields)
 			}
+		} else {
+			r.Fields = nil
 		}
 		r.Name = types.StringPointerValue(resp.Name)
+	}
+
+	return diags
+}
+
+func (r *RequestSchemaResourceModel) RefreshFromSharedRequestSchemaServiceCreateResponse(ctx context.Context, resp *shared.RequestSchemaServiceCreateResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if resp != nil {
+		diags.Append(r.RefreshFromSharedRequestSchema(ctx, resp.RequestSchema)...)
+
+		if diags.HasError() {
+			return diags
+		}
+
+	}
+
+	return diags
+}
+
+func (r *RequestSchemaResourceModel) RefreshFromSharedRequestSchemaServiceGetResponse(ctx context.Context, resp *shared.RequestSchemaServiceGetResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if resp != nil {
+		diags.Append(r.RefreshFromSharedRequestSchema(ctx, resp.RequestSchema)...)
+
+		if diags.HasError() {
+			return diags
+		}
+
+	}
+
+	return diags
+}
+
+func (r *RequestSchemaResourceModel) RefreshFromSharedRequestSchemaServiceUpdateResponse(ctx context.Context, resp *shared.RequestSchemaServiceUpdateResponse) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if resp != nil {
+		diags.Append(r.RefreshFromSharedRequestSchema(ctx, resp.RequestSchema)...)
+
+		if diags.HasError() {
+			return diags
+		}
+
 	}
 
 	return diags
@@ -374,7 +476,52 @@ func (r *RequestSchemaResourceModel) ToOperationsC1APIRequestSchemaV1RequestSche
 	return &out, diags
 }
 
-func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.RequestSchemaForm, diag.Diagnostics) {
+func (r *RequestSchemaResourceModel) ToSharedRequestSchema(ctx context.Context) (*shared.RequestSchema, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	createdAt := new(time.Time)
+	if !r.CreatedAt.IsUnknown() && !r.CreatedAt.IsNull() {
+		*createdAt, _ = time.Parse(time.RFC3339Nano, r.CreatedAt.ValueString())
+	} else {
+		createdAt = nil
+	}
+	deletedAt := new(time.Time)
+	if !r.DeletedAt.IsUnknown() && !r.DeletedAt.IsNull() {
+		*deletedAt, _ = time.Parse(time.RFC3339Nano, r.DeletedAt.ValueString())
+	} else {
+		deletedAt = nil
+	}
+	requestSchemaForm, requestSchemaFormDiags := r.ToSharedRequestSchemaForm(ctx)
+	diags.Append(requestSchemaFormDiags...)
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	id := new(string)
+	if !r.ID.IsUnknown() && !r.ID.IsNull() {
+		*id = r.ID.ValueString()
+	} else {
+		id = nil
+	}
+	justificationVisibility := new(shared.RequestSchemaJustificationVisibility)
+	if !r.JustificationVisibility.IsUnknown() && !r.JustificationVisibility.IsNull() {
+		*justificationVisibility = shared.RequestSchemaJustificationVisibility(r.JustificationVisibility.ValueString())
+	} else {
+		justificationVisibility = nil
+	}
+	out := shared.RequestSchema{
+		CreatedAt:               createdAt,
+		DeletedAt:               deletedAt,
+		RequestSchemaForm:       requestSchemaForm,
+		ID:                      id,
+		JustificationVisibility: justificationVisibility,
+	}
+
+	return &out, diags
+}
+
+func (r *RequestSchemaResourceModel) ToSharedRequestSchemaForm(ctx context.Context) (*shared.RequestSchemaForm, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	description := new(string)
@@ -389,58 +536,135 @@ func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.
 	} else {
 		name = nil
 	}
+	var fieldGroups []shared.FormFieldGroup
+	if r.FieldGroups != nil {
+		fieldGroups = make([]shared.FormFieldGroup, 0, len(r.FieldGroups))
+		for fieldGroupsIndex := range r.FieldGroups {
+			defaultVar := new(bool)
+			if !r.FieldGroups[fieldGroupsIndex].Default.IsUnknown() && !r.FieldGroups[fieldGroupsIndex].Default.IsNull() {
+				*defaultVar = r.FieldGroups[fieldGroupsIndex].Default.ValueBool()
+			} else {
+				defaultVar = nil
+			}
+			displayName := new(string)
+			if !r.FieldGroups[fieldGroupsIndex].DisplayName.IsUnknown() && !r.FieldGroups[fieldGroupsIndex].DisplayName.IsNull() {
+				*displayName = r.FieldGroups[fieldGroupsIndex].DisplayName.ValueString()
+			} else {
+				displayName = nil
+			}
+			var fields []string
+			if r.FieldGroups[fieldGroupsIndex].Fields != nil {
+				fields = make([]string, 0, len(r.FieldGroups[fieldGroupsIndex].Fields))
+				for fieldsIndex := range r.FieldGroups[fieldGroupsIndex].Fields {
+					fields = append(fields, r.FieldGroups[fieldGroupsIndex].Fields[fieldsIndex].ValueString())
+				}
+			}
+			helpText := new(string)
+			if !r.FieldGroups[fieldGroupsIndex].HelpText.IsUnknown() && !r.FieldGroups[fieldGroupsIndex].HelpText.IsNull() {
+				*helpText = r.FieldGroups[fieldGroupsIndex].HelpText.ValueString()
+			} else {
+				helpText = nil
+			}
+			name1 := new(string)
+			if !r.FieldGroups[fieldGroupsIndex].Name.IsUnknown() && !r.FieldGroups[fieldGroupsIndex].Name.IsNull() {
+				*name1 = r.FieldGroups[fieldGroupsIndex].Name.ValueString()
+			} else {
+				name1 = nil
+			}
+			fieldGroups = append(fieldGroups, shared.FormFieldGroup{
+				Default:     defaultVar,
+				DisplayName: displayName,
+				Fields:      fields,
+				HelpText:    helpText,
+				Name:        name1,
+			})
+		}
+	}
 	var fieldRelationships []shared.FieldRelationship
 	if r.FieldRelationships != nil {
 		fieldRelationships = make([]shared.FieldRelationship, 0, len(r.FieldRelationships))
-		for _, fieldRelationshipsItem := range r.FieldRelationships {
+		for fieldRelationshipsIndex := range r.FieldRelationships {
 			var atLeastOne *shared.AtLeastOne
-			if fieldRelationshipsItem.AtLeastOne != nil {
+			if r.FieldRelationships[fieldRelationshipsIndex].AtLeastOne != nil {
 				atLeastOne = &shared.AtLeastOne{}
 			}
+			var dependentOn *shared.DependentOn
+			if r.FieldRelationships[fieldRelationshipsIndex].DependentOn != nil {
+				var dependencyFieldNames []string
+				if r.FieldRelationships[fieldRelationshipsIndex].DependentOn.DependencyFieldNames != nil {
+					dependencyFieldNames = make([]string, 0, len(r.FieldRelationships[fieldRelationshipsIndex].DependentOn.DependencyFieldNames))
+					for dependencyFieldNamesIndex := range r.FieldRelationships[fieldRelationshipsIndex].DependentOn.DependencyFieldNames {
+						dependencyFieldNames = append(dependencyFieldNames, r.FieldRelationships[fieldRelationshipsIndex].DependentOn.DependencyFieldNames[dependencyFieldNamesIndex].ValueString())
+					}
+				}
+				dependentOn = &shared.DependentOn{
+					DependencyFieldNames: dependencyFieldNames,
+				}
+			}
 			var fieldNames []string
-			if fieldRelationshipsItem.FieldNames != nil {
-				fieldNames = make([]string, 0, len(fieldRelationshipsItem.FieldNames))
-				for _, fieldNamesItem := range fieldRelationshipsItem.FieldNames {
-					fieldNames = append(fieldNames, fieldNamesItem.ValueString())
+			if r.FieldRelationships[fieldRelationshipsIndex].FieldNames != nil {
+				fieldNames = make([]string, 0, len(r.FieldRelationships[fieldRelationshipsIndex].FieldNames))
+				for fieldNamesIndex := range r.FieldRelationships[fieldRelationshipsIndex].FieldNames {
+					fieldNames = append(fieldNames, r.FieldRelationships[fieldRelationshipsIndex].FieldNames[fieldNamesIndex].ValueString())
 				}
 			}
 			var mutuallyExclusive *shared.MutuallyExclusive
-			if fieldRelationshipsItem.MutuallyExclusive != nil {
+			if r.FieldRelationships[fieldRelationshipsIndex].MutuallyExclusive != nil {
 				mutuallyExclusive = &shared.MutuallyExclusive{}
 			}
 			var requiredTogether *shared.RequiredTogether
-			if fieldRelationshipsItem.RequiredTogether != nil {
+			if r.FieldRelationships[fieldRelationshipsIndex].RequiredTogether != nil {
 				requiredTogether = &shared.RequiredTogether{}
 			}
 			fieldRelationships = append(fieldRelationships, shared.FieldRelationship{
 				AtLeastOne:        atLeastOne,
+				DependentOn:       dependentOn,
 				FieldNames:        fieldNames,
 				MutuallyExclusive: mutuallyExclusive,
 				RequiredTogether:  requiredTogether,
 			})
 		}
 	}
-	var fields []shared.FormField
+	var fields1 []shared.FormField
 	if r.Fields != nil {
-		fields = make([]shared.FormField, 0, len(r.Fields))
-		for _, fieldsItem := range r.Fields {
+		fields1 = make([]shared.FormField, 0, len(r.Fields))
+		for fieldsIndex1 := range r.Fields {
+			var adminProviderConfig *shared.AdminProviderConfig
+			if r.Fields[fieldsIndex1].AdminProviderConfig != nil {
+				defaultValueCel := new(string)
+				if !r.Fields[fieldsIndex1].AdminProviderConfig.DefaultValueCel.IsUnknown() && !r.Fields[fieldsIndex1].AdminProviderConfig.DefaultValueCel.IsNull() {
+					*defaultValueCel = r.Fields[fieldsIndex1].AdminProviderConfig.DefaultValueCel.ValueString()
+				} else {
+					defaultValueCel = nil
+				}
+				showToUser := new(bool)
+				if !r.Fields[fieldsIndex1].AdminProviderConfig.ShowToUser.IsUnknown() && !r.Fields[fieldsIndex1].AdminProviderConfig.ShowToUser.IsNull() {
+					*showToUser = r.Fields[fieldsIndex1].AdminProviderConfig.ShowToUser.ValueBool()
+				} else {
+					showToUser = nil
+				}
+				adminProviderConfig = &shared.AdminProviderConfig{
+					DefaultValueCel: defaultValueCel,
+					ShowToUser:      showToUser,
+				}
+			}
 			var boolField *shared.BoolField
-			if fieldsItem.BoolField != nil {
+			if r.Fields[fieldsIndex1].BoolField != nil {
 				var checkboxField *shared.CheckboxField
-				if fieldsItem.BoolField.CheckboxField != nil {
+				if r.Fields[fieldsIndex1].BoolField.CheckboxField != nil {
 					checkboxField = &shared.CheckboxField{}
 				}
 				defaultValue := new(bool)
-				if !fieldsItem.BoolField.DefaultValue.IsUnknown() && !fieldsItem.BoolField.DefaultValue.IsNull() {
-					*defaultValue = fieldsItem.BoolField.DefaultValue.ValueBool()
+				if !r.Fields[fieldsIndex1].BoolField.DefaultValue.IsUnknown() && !r.Fields[fieldsIndex1].BoolField.DefaultValue.IsNull() {
+					*defaultValue = r.Fields[fieldsIndex1].BoolField.DefaultValue.ValueBool()
 				} else {
 					defaultValue = nil
 				}
 				var boolRules *shared.BoolRules
-				if fieldsItem.BoolField.BoolRules != nil {
+				if r.Fields[fieldsIndex1].BoolField.BoolRules != nil {
 					constVar := new(bool)
-					if !fieldsItem.BoolField.BoolRules.Const.IsUnknown() && !fieldsItem.BoolField.BoolRules.Const.IsNull() {
-						*constVar = fieldsItem.BoolField.BoolRules.Const.ValueBool()
+					if !r.Fields[fieldsIndex1].BoolField.BoolRules.Const.IsUnknown() && !r.Fields[fieldsIndex1].BoolField.BoolRules.Const.IsNull() {
+						*constVar = r.Fields[fieldsIndex1].BoolField.BoolRules.Const.ValueBool()
 					} else {
 						constVar = nil
 					}
@@ -448,40 +672,45 @@ func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.
 						Const: constVar,
 					}
 				}
+				var toggleField *shared.ToggleField
+				if r.Fields[fieldsIndex1].BoolField.ToggleField != nil {
+					toggleField = &shared.ToggleField{}
+				}
 				boolField = &shared.BoolField{
 					CheckboxField: checkboxField,
 					DefaultValue:  defaultValue,
 					BoolRules:     boolRules,
+					ToggleField:   toggleField,
 				}
 			}
 			description1 := new(string)
-			if !fieldsItem.Description.IsUnknown() && !fieldsItem.Description.IsNull() {
-				*description1 = fieldsItem.Description.ValueString()
+			if !r.Fields[fieldsIndex1].Description.IsUnknown() && !r.Fields[fieldsIndex1].Description.IsNull() {
+				*description1 = r.Fields[fieldsIndex1].Description.ValueString()
 			} else {
 				description1 = nil
 			}
-			displayName := new(string)
-			if !fieldsItem.DisplayName.IsUnknown() && !fieldsItem.DisplayName.IsNull() {
-				*displayName = fieldsItem.DisplayName.ValueString()
+			displayName1 := new(string)
+			if !r.Fields[fieldsIndex1].DisplayName.IsUnknown() && !r.Fields[fieldsIndex1].DisplayName.IsNull() {
+				*displayName1 = r.Fields[fieldsIndex1].DisplayName.ValueString()
 			} else {
-				displayName = nil
+				displayName1 = nil
 			}
 			var fileField *shared.FileField
-			if fieldsItem.FileField != nil {
+			if r.Fields[fieldsIndex1].FileField != nil {
 				var acceptedFileTypes []string
-				if fieldsItem.FileField.AcceptedFileTypes != nil {
-					acceptedFileTypes = make([]string, 0, len(fieldsItem.FileField.AcceptedFileTypes))
-					for _, acceptedFileTypesItem := range fieldsItem.FileField.AcceptedFileTypes {
-						acceptedFileTypes = append(acceptedFileTypes, acceptedFileTypesItem.ValueString())
+				if r.Fields[fieldsIndex1].FileField.AcceptedFileTypes != nil {
+					acceptedFileTypes = make([]string, 0, len(r.Fields[fieldsIndex1].FileField.AcceptedFileTypes))
+					for acceptedFileTypesIndex := range r.Fields[fieldsIndex1].FileField.AcceptedFileTypes {
+						acceptedFileTypes = append(acceptedFileTypes, r.Fields[fieldsIndex1].FileField.AcceptedFileTypes[acceptedFileTypesIndex].ValueString())
 					}
 				}
 				var fileInputField *shared.FileInputField
-				if fieldsItem.FileField.FileInputField != nil {
+				if r.Fields[fieldsIndex1].FileField.FileInputField != nil {
 					fileInputField = &shared.FileInputField{}
 				}
 				maxFileSize := new(string)
-				if !fieldsItem.FileField.MaxFileSize.IsUnknown() && !fieldsItem.FileField.MaxFileSize.IsNull() {
-					*maxFileSize = fieldsItem.FileField.MaxFileSize.ValueString()
+				if !r.Fields[fieldsIndex1].FileField.MaxFileSize.IsUnknown() && !r.Fields[fieldsIndex1].FileField.MaxFileSize.IsNull() {
+					*maxFileSize = r.Fields[fieldsIndex1].FileField.MaxFileSize.ValueString()
 				} else {
 					maxFileSize = nil
 				}
@@ -492,30 +721,30 @@ func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.
 				}
 			}
 			var int64Field *shared.Int64Field
-			if fieldsItem.Int64Field != nil {
+			if r.Fields[fieldsIndex1].Int64Field != nil {
 				defaultValue1 := new(string)
-				if !fieldsItem.Int64Field.DefaultValue.IsUnknown() && !fieldsItem.Int64Field.DefaultValue.IsNull() {
-					*defaultValue1 = fieldsItem.Int64Field.DefaultValue.ValueString()
+				if !r.Fields[fieldsIndex1].Int64Field.DefaultValue.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.DefaultValue.IsNull() {
+					*defaultValue1 = r.Fields[fieldsIndex1].Int64Field.DefaultValue.ValueString()
 				} else {
 					defaultValue1 = nil
 				}
 				var numberField *shared.NumberField
-				if fieldsItem.Int64Field.NumberField != nil {
+				if r.Fields[fieldsIndex1].Int64Field.NumberField != nil {
 					maxValue := new(string)
-					if !fieldsItem.Int64Field.NumberField.MaxValue.IsUnknown() && !fieldsItem.Int64Field.NumberField.MaxValue.IsNull() {
-						*maxValue = fieldsItem.Int64Field.NumberField.MaxValue.ValueString()
+					if !r.Fields[fieldsIndex1].Int64Field.NumberField.MaxValue.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.NumberField.MaxValue.IsNull() {
+						*maxValue = r.Fields[fieldsIndex1].Int64Field.NumberField.MaxValue.ValueString()
 					} else {
 						maxValue = nil
 					}
 					minValue := new(string)
-					if !fieldsItem.Int64Field.NumberField.MinValue.IsUnknown() && !fieldsItem.Int64Field.NumberField.MinValue.IsNull() {
-						*minValue = fieldsItem.Int64Field.NumberField.MinValue.ValueString()
+					if !r.Fields[fieldsIndex1].Int64Field.NumberField.MinValue.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.NumberField.MinValue.IsNull() {
+						*minValue = r.Fields[fieldsIndex1].Int64Field.NumberField.MinValue.ValueString()
 					} else {
 						minValue = nil
 					}
 					step := new(string)
-					if !fieldsItem.Int64Field.NumberField.Step.IsUnknown() && !fieldsItem.Int64Field.NumberField.Step.IsNull() {
-						*step = fieldsItem.Int64Field.NumberField.Step.ValueString()
+					if !r.Fields[fieldsIndex1].Int64Field.NumberField.Step.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.NumberField.Step.IsNull() {
+						*step = r.Fields[fieldsIndex1].Int64Field.NumberField.Step.ValueString()
 					} else {
 						step = nil
 					}
@@ -526,61 +755,813 @@ func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.
 					}
 				}
 				placeholder := new(string)
-				if !fieldsItem.Int64Field.Placeholder.IsUnknown() && !fieldsItem.Int64Field.Placeholder.IsNull() {
-					*placeholder = fieldsItem.Int64Field.Placeholder.ValueString()
+				if !r.Fields[fieldsIndex1].Int64Field.Placeholder.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Placeholder.IsNull() {
+					*placeholder = r.Fields[fieldsIndex1].Int64Field.Placeholder.ValueString()
 				} else {
 					placeholder = nil
 				}
 				var int64Rules *shared.Int64Rules
-				if fieldsItem.Int64Field.Int64Rules != nil {
+				if r.Fields[fieldsIndex1].Int64Field.Int64Rules != nil {
 					constVar1 := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Const.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Const.IsNull() {
-						*constVar1 = fieldsItem.Int64Field.Int64Rules.Const.ValueString()
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Const.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Const.IsNull() {
+						*constVar1 = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Const.ValueString()
 					} else {
 						constVar1 = nil
 					}
 					gt := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Gt.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Gt.IsNull() {
-						*gt = fieldsItem.Int64Field.Int64Rules.Gt.ValueString()
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gt.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gt.IsNull() {
+						*gt = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gt.ValueString()
 					} else {
 						gt = nil
 					}
 					gte := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Gte.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Gte.IsNull() {
-						*gte = fieldsItem.Int64Field.Int64Rules.Gte.ValueString()
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gte.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gte.IsNull() {
+						*gte = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gte.ValueString()
 					} else {
 						gte = nil
 					}
 					ignoreEmpty := new(bool)
-					if !fieldsItem.Int64Field.Int64Rules.IgnoreEmpty.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.IgnoreEmpty.IsNull() {
-						*ignoreEmpty = fieldsItem.Int64Field.Int64Rules.IgnoreEmpty.ValueBool()
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.IgnoreEmpty.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.IgnoreEmpty.IsNull() {
+						*ignoreEmpty = r.Fields[fieldsIndex1].Int64Field.Int64Rules.IgnoreEmpty.ValueBool()
 					} else {
 						ignoreEmpty = nil
 					}
 					var in []string
-					if fieldsItem.Int64Field.Int64Rules.In != nil {
-						in = make([]string, 0, len(fieldsItem.Int64Field.Int64Rules.In))
-						for _, inItem := range fieldsItem.Int64Field.Int64Rules.In {
-							in = append(in, inItem.ValueString())
+					if r.Fields[fieldsIndex1].Int64Field.Int64Rules.In != nil {
+						in = make([]string, 0, len(r.Fields[fieldsIndex1].Int64Field.Int64Rules.In))
+						for inIndex := range r.Fields[fieldsIndex1].Int64Field.Int64Rules.In {
+							in = append(in, r.Fields[fieldsIndex1].Int64Field.Int64Rules.In[inIndex].ValueString())
 						}
 					}
 					lt := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Lt.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Lt.IsNull() {
-						*lt = fieldsItem.Int64Field.Int64Rules.Lt.ValueString()
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lt.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lt.IsNull() {
+						*lt = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lt.ValueString()
 					} else {
 						lt = nil
 					}
 					lte := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Lte.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Lte.IsNull() {
-						*lte = fieldsItem.Int64Field.Int64Rules.Lte.ValueString()
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lte.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lte.IsNull() {
+						*lte = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lte.ValueString()
 					} else {
 						lte = nil
 					}
 					var notIn []string
-					if fieldsItem.Int64Field.Int64Rules.NotIn != nil {
-						notIn = make([]string, 0, len(fieldsItem.Int64Field.Int64Rules.NotIn))
-						for _, notInItem := range fieldsItem.Int64Field.Int64Rules.NotIn {
-							notIn = append(notIn, notInItem.ValueString())
+					if r.Fields[fieldsIndex1].Int64Field.Int64Rules.NotIn != nil {
+						notIn = make([]string, 0, len(r.Fields[fieldsIndex1].Int64Field.Int64Rules.NotIn))
+						for notInIndex := range r.Fields[fieldsIndex1].Int64Field.Int64Rules.NotIn {
+							notIn = append(notIn, r.Fields[fieldsIndex1].Int64Field.Int64Rules.NotIn[notInIndex].ValueString())
+						}
+					}
+					int64Rules = &shared.Int64Rules{
+						Const:       constVar1,
+						Gt:          gt,
+						Gte:         gte,
+						IgnoreEmpty: ignoreEmpty,
+						In:          in,
+						Lt:          lt,
+						Lte:         lte,
+						NotIn:       notIn,
+					}
+				}
+				int64Field = &shared.Int64Field{
+					DefaultValue: defaultValue1,
+					NumberField:  numberField,
+					Placeholder:  placeholder,
+					Int64Rules:   int64Rules,
+				}
+			}
+			name2 := new(string)
+			if !r.Fields[fieldsIndex1].Name.IsUnknown() && !r.Fields[fieldsIndex1].Name.IsNull() {
+				*name2 = r.Fields[fieldsIndex1].Name.ValueString()
+			} else {
+				name2 = nil
+			}
+			var oauth2Field *shared.Oauth2Field
+			if r.Fields[fieldsIndex1].Oauth2Field != nil {
+				var oauth2FieldView *shared.Oauth2FieldView
+				if r.Fields[fieldsIndex1].Oauth2Field.Oauth2FieldView != nil {
+					oauth2FieldView = &shared.Oauth2FieldView{}
+				}
+				oauth2Field = &shared.Oauth2Field{
+					Oauth2FieldView: oauth2FieldView,
+				}
+			}
+			readOnly := new(bool)
+			if !r.Fields[fieldsIndex1].ReadOnly.IsUnknown() && !r.Fields[fieldsIndex1].ReadOnly.IsNull() {
+				*readOnly = r.Fields[fieldsIndex1].ReadOnly.ValueBool()
+			} else {
+				readOnly = nil
+			}
+			required := new(bool)
+			if !r.Fields[fieldsIndex1].Required.IsUnknown() && !r.Fields[fieldsIndex1].Required.IsNull() {
+				*required = r.Fields[fieldsIndex1].Required.ValueBool()
+			} else {
+				required = nil
+			}
+			var sharedProviderConfig *shared.SharedProviderConfig
+			if r.Fields[fieldsIndex1].SharedProviderConfig != nil {
+				defaultValueCel1 := new(string)
+				if !r.Fields[fieldsIndex1].SharedProviderConfig.DefaultValueCel.IsUnknown() && !r.Fields[fieldsIndex1].SharedProviderConfig.DefaultValueCel.IsNull() {
+					*defaultValueCel1 = r.Fields[fieldsIndex1].SharedProviderConfig.DefaultValueCel.ValueString()
+				} else {
+					defaultValueCel1 = nil
+				}
+				inputTransformationCel := new(string)
+				if !r.Fields[fieldsIndex1].SharedProviderConfig.InputTransformationCel.IsUnknown() && !r.Fields[fieldsIndex1].SharedProviderConfig.InputTransformationCel.IsNull() {
+					*inputTransformationCel = r.Fields[fieldsIndex1].SharedProviderConfig.InputTransformationCel.ValueString()
+				} else {
+					inputTransformationCel = nil
+				}
+				lockDefaultValues := new(bool)
+				if !r.Fields[fieldsIndex1].SharedProviderConfig.LockDefaultValues.IsUnknown() && !r.Fields[fieldsIndex1].SharedProviderConfig.LockDefaultValues.IsNull() {
+					*lockDefaultValues = r.Fields[fieldsIndex1].SharedProviderConfig.LockDefaultValues.ValueBool()
+				} else {
+					lockDefaultValues = nil
+				}
+				sharedProviderConfig = &shared.SharedProviderConfig{
+					DefaultValueCel:        defaultValueCel1,
+					InputTransformationCel: inputTransformationCel,
+					LockDefaultValues:      lockDefaultValues,
+				}
+			}
+			var formStringField *shared.FormStringField
+			if r.Fields[fieldsIndex1].FormStringField != nil {
+				defaultValue2 := new(string)
+				if !r.Fields[fieldsIndex1].FormStringField.DefaultValue.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.DefaultValue.IsNull() {
+					*defaultValue2 = r.Fields[fieldsIndex1].FormStringField.DefaultValue.ValueString()
+				} else {
+					defaultValue2 = nil
+				}
+				var passwordField *shared.PasswordField
+				if r.Fields[fieldsIndex1].FormStringField.PasswordField != nil {
+					passwordField = &shared.PasswordField{}
+				}
+				var pickerField *shared.PickerField
+				if r.Fields[fieldsIndex1].FormStringField.PickerField != nil {
+					var appUserFilter *shared.AppUserFilter
+					if r.Fields[fieldsIndex1].FormStringField.PickerField.AppUserFilter != nil {
+						appID := new(string)
+						if !r.Fields[fieldsIndex1].FormStringField.PickerField.AppUserFilter.AppID.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.PickerField.AppUserFilter.AppID.IsNull() {
+							*appID = r.Fields[fieldsIndex1].FormStringField.PickerField.AppUserFilter.AppID.ValueString()
+						} else {
+							appID = nil
+						}
+						appUserFilter = &shared.AppUserFilter{
+							AppID: appID,
+						}
+					}
+					var c1UserFilter *shared.C1UserFilter
+					if r.Fields[fieldsIndex1].FormStringField.PickerField.C1UserFilter != nil {
+						c1UserFilter = &shared.C1UserFilter{}
+					}
+					var appResourceFilter *shared.AppResourceFilter
+					if r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter != nil {
+						appId1 := new(string)
+						if !r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.AppID.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.AppID.IsNull() {
+							*appId1 = r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.AppID.ValueString()
+						} else {
+							appId1 = nil
+						}
+						resourceTypeID := new(string)
+						if !r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsNull() {
+							*resourceTypeID = r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.ResourceTypeID.ValueString()
+						} else {
+							resourceTypeID = nil
+						}
+						appResourceFilter = &shared.AppResourceFilter{
+							AppID:          appId1,
+							ResourceTypeID: resourceTypeID,
+						}
+					}
+					pickerField = &shared.PickerField{
+						AppUserFilter:     appUserFilter,
+						C1UserFilter:      c1UserFilter,
+						AppResourceFilter: appResourceFilter,
+					}
+				}
+				placeholder1 := new(string)
+				if !r.Fields[fieldsIndex1].FormStringField.Placeholder.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.Placeholder.IsNull() {
+					*placeholder1 = r.Fields[fieldsIndex1].FormStringField.Placeholder.ValueString()
+				} else {
+					placeholder1 = nil
+				}
+				var stringRules *shared.StringRules
+				if r.Fields[fieldsIndex1].FormStringField.StringRules != nil {
+					address := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Address.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Address.IsNull() {
+						*address = r.Fields[fieldsIndex1].FormStringField.StringRules.Address.ValueBool()
+					} else {
+						address = nil
+					}
+					constVar2 := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Const.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Const.IsNull() {
+						*constVar2 = r.Fields[fieldsIndex1].FormStringField.StringRules.Const.ValueString()
+					} else {
+						constVar2 = nil
+					}
+					contains := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Contains.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Contains.IsNull() {
+						*contains = r.Fields[fieldsIndex1].FormStringField.StringRules.Contains.ValueString()
+					} else {
+						contains = nil
+					}
+					email := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Email.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Email.IsNull() {
+						*email = r.Fields[fieldsIndex1].FormStringField.StringRules.Email.ValueBool()
+					} else {
+						email = nil
+					}
+					hostname := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Hostname.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Hostname.IsNull() {
+						*hostname = r.Fields[fieldsIndex1].FormStringField.StringRules.Hostname.ValueBool()
+					} else {
+						hostname = nil
+					}
+					ignoreEmpty1 := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.IgnoreEmpty.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.IgnoreEmpty.IsNull() {
+						*ignoreEmpty1 = r.Fields[fieldsIndex1].FormStringField.StringRules.IgnoreEmpty.ValueBool()
+					} else {
+						ignoreEmpty1 = nil
+					}
+					var in1 []string
+					if r.Fields[fieldsIndex1].FormStringField.StringRules.In != nil {
+						in1 = make([]string, 0, len(r.Fields[fieldsIndex1].FormStringField.StringRules.In))
+						for inIndex1 := range r.Fields[fieldsIndex1].FormStringField.StringRules.In {
+							in1 = append(in1, r.Fields[fieldsIndex1].FormStringField.StringRules.In[inIndex1].ValueString())
+						}
+					}
+					ip := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.IP.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.IP.IsNull() {
+						*ip = r.Fields[fieldsIndex1].FormStringField.StringRules.IP.ValueBool()
+					} else {
+						ip = nil
+					}
+					ipv4 := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv4.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv4.IsNull() {
+						*ipv4 = r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv4.ValueBool()
+					} else {
+						ipv4 = nil
+					}
+					ipv6 := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv6.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv6.IsNull() {
+						*ipv6 = r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv6.ValueBool()
+					} else {
+						ipv6 = nil
+					}
+					length := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Length.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Length.IsNull() {
+						*length = r.Fields[fieldsIndex1].FormStringField.StringRules.Length.ValueString()
+					} else {
+						length = nil
+					}
+					lenBytes := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.LenBytes.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.LenBytes.IsNull() {
+						*lenBytes = r.Fields[fieldsIndex1].FormStringField.StringRules.LenBytes.ValueString()
+					} else {
+						lenBytes = nil
+					}
+					maxBytes := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.MaxBytes.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.MaxBytes.IsNull() {
+						*maxBytes = r.Fields[fieldsIndex1].FormStringField.StringRules.MaxBytes.ValueString()
+					} else {
+						maxBytes = nil
+					}
+					maxLen := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.MaxLen.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.MaxLen.IsNull() {
+						*maxLen = r.Fields[fieldsIndex1].FormStringField.StringRules.MaxLen.ValueString()
+					} else {
+						maxLen = nil
+					}
+					minBytes := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.MinBytes.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.MinBytes.IsNull() {
+						*minBytes = r.Fields[fieldsIndex1].FormStringField.StringRules.MinBytes.ValueString()
+					} else {
+						minBytes = nil
+					}
+					minLen := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.MinLen.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.MinLen.IsNull() {
+						*minLen = r.Fields[fieldsIndex1].FormStringField.StringRules.MinLen.ValueString()
+					} else {
+						minLen = nil
+					}
+					notContains := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.NotContains.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.NotContains.IsNull() {
+						*notContains = r.Fields[fieldsIndex1].FormStringField.StringRules.NotContains.ValueString()
+					} else {
+						notContains = nil
+					}
+					var notIn1 []string
+					if r.Fields[fieldsIndex1].FormStringField.StringRules.NotIn != nil {
+						notIn1 = make([]string, 0, len(r.Fields[fieldsIndex1].FormStringField.StringRules.NotIn))
+						for notInIndex1 := range r.Fields[fieldsIndex1].FormStringField.StringRules.NotIn {
+							notIn1 = append(notIn1, r.Fields[fieldsIndex1].FormStringField.StringRules.NotIn[notInIndex1].ValueString())
+						}
+					}
+					pattern := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Pattern.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Pattern.IsNull() {
+						*pattern = r.Fields[fieldsIndex1].FormStringField.StringRules.Pattern.ValueString()
+					} else {
+						pattern = nil
+					}
+					prefix := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Prefix.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Prefix.IsNull() {
+						*prefix = r.Fields[fieldsIndex1].FormStringField.StringRules.Prefix.ValueString()
+					} else {
+						prefix = nil
+					}
+					strict := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Strict.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Strict.IsNull() {
+						*strict = r.Fields[fieldsIndex1].FormStringField.StringRules.Strict.ValueBool()
+					} else {
+						strict = nil
+					}
+					suffix := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Suffix.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Suffix.IsNull() {
+						*suffix = r.Fields[fieldsIndex1].FormStringField.StringRules.Suffix.ValueString()
+					} else {
+						suffix = nil
+					}
+					uri := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.URI.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.URI.IsNull() {
+						*uri = r.Fields[fieldsIndex1].FormStringField.StringRules.URI.ValueBool()
+					} else {
+						uri = nil
+					}
+					uriRef := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.URIRef.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.URIRef.IsNull() {
+						*uriRef = r.Fields[fieldsIndex1].FormStringField.StringRules.URIRef.ValueBool()
+					} else {
+						uriRef = nil
+					}
+					uuid := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.UUID.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.UUID.IsNull() {
+						*uuid = r.Fields[fieldsIndex1].FormStringField.StringRules.UUID.ValueBool()
+					} else {
+						uuid = nil
+					}
+					wellKnownRegex := new(shared.WellKnownRegex)
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.WellKnownRegex.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.WellKnownRegex.IsNull() {
+						*wellKnownRegex = shared.WellKnownRegex(r.Fields[fieldsIndex1].FormStringField.StringRules.WellKnownRegex.ValueString())
+					} else {
+						wellKnownRegex = nil
+					}
+					stringRules = &shared.StringRules{
+						Address:        address,
+						Const:          constVar2,
+						Contains:       contains,
+						Email:          email,
+						Hostname:       hostname,
+						IgnoreEmpty:    ignoreEmpty1,
+						In:             in1,
+						IP:             ip,
+						Ipv4:           ipv4,
+						Ipv6:           ipv6,
+						Length:         length,
+						LenBytes:       lenBytes,
+						MaxBytes:       maxBytes,
+						MaxLen:         maxLen,
+						MinBytes:       minBytes,
+						MinLen:         minLen,
+						NotContains:    notContains,
+						NotIn:          notIn1,
+						Pattern:        pattern,
+						Prefix:         prefix,
+						Strict:         strict,
+						Suffix:         suffix,
+						URI:            uri,
+						URIRef:         uriRef,
+						UUID:           uuid,
+						WellKnownRegex: wellKnownRegex,
+					}
+				}
+				var selectField *shared.SelectField
+				if r.Fields[fieldsIndex1].FormStringField.SelectField != nil {
+					var optionsVar []shared.SelectOption
+					if r.Fields[fieldsIndex1].FormStringField.SelectField.Options != nil {
+						optionsVar = make([]shared.SelectOption, 0, len(r.Fields[fieldsIndex1].FormStringField.SelectField.Options))
+						for optionsIndex := range r.Fields[fieldsIndex1].FormStringField.SelectField.Options {
+							description2 := new(string)
+							if !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Description.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Description.IsNull() {
+								*description2 = r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Description.ValueString()
+							} else {
+								description2 = nil
+							}
+							displayName2 := new(string)
+							if !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].DisplayName.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].DisplayName.IsNull() {
+								*displayName2 = r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].DisplayName.ValueString()
+							} else {
+								displayName2 = nil
+							}
+							value := new(string)
+							if !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Value.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Value.IsNull() {
+								*value = r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Value.ValueString()
+							} else {
+								value = nil
+							}
+							optionsVar = append(optionsVar, shared.SelectOption{
+								Description: description2,
+								DisplayName: displayName2,
+								Value:       value,
+							})
+						}
+					}
+					typeVar := new(shared.SelectFieldType)
+					if !r.Fields[fieldsIndex1].FormStringField.SelectField.Type.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.SelectField.Type.IsNull() {
+						*typeVar = shared.SelectFieldType(r.Fields[fieldsIndex1].FormStringField.SelectField.Type.ValueString())
+					} else {
+						typeVar = nil
+					}
+					selectField = &shared.SelectField{
+						Options: optionsVar,
+						Type:    typeVar,
+					}
+				}
+				var textField *shared.TextField
+				if r.Fields[fieldsIndex1].FormStringField.TextField != nil {
+					multiline := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringField.TextField.Multiline.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.TextField.Multiline.IsNull() {
+						*multiline = r.Fields[fieldsIndex1].FormStringField.TextField.Multiline.ValueBool()
+					} else {
+						multiline = nil
+					}
+					suffix1 := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.TextField.Suffix.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.TextField.Suffix.IsNull() {
+						*suffix1 = r.Fields[fieldsIndex1].FormStringField.TextField.Suffix.ValueString()
+					} else {
+						suffix1 = nil
+					}
+					textField = &shared.TextField{
+						Multiline: multiline,
+						Suffix:    suffix1,
+					}
+				}
+				formStringField = &shared.FormStringField{
+					DefaultValue:  defaultValue2,
+					PasswordField: passwordField,
+					PickerField:   pickerField,
+					Placeholder:   placeholder1,
+					StringRules:   stringRules,
+					SelectField:   selectField,
+					TextField:     textField,
+				}
+			}
+			var formStringMapField *shared.FormStringMapField
+			if r.Fields[fieldsIndex1].FormStringMapField != nil {
+				defaultValue3 := make(map[string]string)
+				for defaultValueKey := range r.Fields[fieldsIndex1].FormStringMapField.DefaultValue {
+					var defaultValueInst string
+					defaultValueInst = r.Fields[fieldsIndex1].FormStringMapField.DefaultValue[defaultValueKey].ValueString()
+
+					defaultValue3[defaultValueKey] = defaultValueInst
+				}
+				var stringMapRules *shared.StringMapRules
+				if r.Fields[fieldsIndex1].FormStringMapField.StringMapRules != nil {
+					isRequired := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.IsRequired.IsUnknown() && !r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.IsRequired.IsNull() {
+						*isRequired = r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.IsRequired.ValueBool()
+					} else {
+						isRequired = nil
+					}
+					validateEmpty := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.ValidateEmpty.IsUnknown() && !r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.ValidateEmpty.IsNull() {
+						*validateEmpty = r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.ValidateEmpty.ValueBool()
+					} else {
+						validateEmpty = nil
+					}
+					stringMapRules = &shared.StringMapRules{
+						IsRequired:    isRequired,
+						ValidateEmpty: validateEmpty,
+					}
+				}
+				formStringMapField = &shared.FormStringMapField{
+					DefaultValue:   defaultValue3,
+					StringMapRules: stringMapRules,
+				}
+			}
+			var userProviderConfig *shared.UserProviderConfig
+			if r.Fields[fieldsIndex1].UserProviderConfig != nil {
+				inputTransformationCel1 := new(string)
+				if !r.Fields[fieldsIndex1].UserProviderConfig.InputTransformationCel.IsUnknown() && !r.Fields[fieldsIndex1].UserProviderConfig.InputTransformationCel.IsNull() {
+					*inputTransformationCel1 = r.Fields[fieldsIndex1].UserProviderConfig.InputTransformationCel.ValueString()
+				} else {
+					inputTransformationCel1 = nil
+				}
+				userProviderConfig = &shared.UserProviderConfig{
+					InputTransformationCel: inputTransformationCel1,
+				}
+			}
+			fields1 = append(fields1, shared.FormField{
+				AdminProviderConfig:  adminProviderConfig,
+				BoolField:            boolField,
+				Description:          description1,
+				DisplayName:          displayName1,
+				FileField:            fileField,
+				Int64Field:           int64Field,
+				Name:                 name2,
+				Oauth2Field:          oauth2Field,
+				ReadOnly:             readOnly,
+				Required:             required,
+				SharedProviderConfig: sharedProviderConfig,
+				FormStringField:      formStringField,
+				FormStringMapField:   formStringMapField,
+				UserProviderConfig:   userProviderConfig,
+			})
+		}
+	}
+	out := shared.RequestSchemaForm{
+		Description:        description,
+		Name:               name,
+		FieldGroups:        fieldGroups,
+		FieldRelationships: fieldRelationships,
+		Fields:             fields1,
+	}
+
+	return &out, diags
+}
+
+func (r *RequestSchemaResourceModel) ToSharedRequestSchemaServiceCreateRequest(ctx context.Context) (*shared.RequestSchemaServiceCreateRequest, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	description := new(string)
+	if !r.Description.IsUnknown() && !r.Description.IsNull() {
+		*description = r.Description.ValueString()
+	} else {
+		description = nil
+	}
+	var fieldGroups []shared.FormFieldGroup
+	if r.FieldGroups != nil {
+		fieldGroups = make([]shared.FormFieldGroup, 0, len(r.FieldGroups))
+		for fieldGroupsIndex := range r.FieldGroups {
+			defaultVar := new(bool)
+			if !r.FieldGroups[fieldGroupsIndex].Default.IsUnknown() && !r.FieldGroups[fieldGroupsIndex].Default.IsNull() {
+				*defaultVar = r.FieldGroups[fieldGroupsIndex].Default.ValueBool()
+			} else {
+				defaultVar = nil
+			}
+			displayName := new(string)
+			if !r.FieldGroups[fieldGroupsIndex].DisplayName.IsUnknown() && !r.FieldGroups[fieldGroupsIndex].DisplayName.IsNull() {
+				*displayName = r.FieldGroups[fieldGroupsIndex].DisplayName.ValueString()
+			} else {
+				displayName = nil
+			}
+			var fields []string
+			if r.FieldGroups[fieldGroupsIndex].Fields != nil {
+				fields = make([]string, 0, len(r.FieldGroups[fieldGroupsIndex].Fields))
+				for fieldsIndex := range r.FieldGroups[fieldGroupsIndex].Fields {
+					fields = append(fields, r.FieldGroups[fieldGroupsIndex].Fields[fieldsIndex].ValueString())
+				}
+			}
+			helpText := new(string)
+			if !r.FieldGroups[fieldGroupsIndex].HelpText.IsUnknown() && !r.FieldGroups[fieldGroupsIndex].HelpText.IsNull() {
+				*helpText = r.FieldGroups[fieldGroupsIndex].HelpText.ValueString()
+			} else {
+				helpText = nil
+			}
+			name := new(string)
+			if !r.FieldGroups[fieldGroupsIndex].Name.IsUnknown() && !r.FieldGroups[fieldGroupsIndex].Name.IsNull() {
+				*name = r.FieldGroups[fieldGroupsIndex].Name.ValueString()
+			} else {
+				name = nil
+			}
+			fieldGroups = append(fieldGroups, shared.FormFieldGroup{
+				Default:     defaultVar,
+				DisplayName: displayName,
+				Fields:      fields,
+				HelpText:    helpText,
+				Name:        name,
+			})
+		}
+	}
+	var fieldRelationships []shared.FieldRelationship
+	if r.FieldRelationships != nil {
+		fieldRelationships = make([]shared.FieldRelationship, 0, len(r.FieldRelationships))
+		for fieldRelationshipsIndex := range r.FieldRelationships {
+			var atLeastOne *shared.AtLeastOne
+			if r.FieldRelationships[fieldRelationshipsIndex].AtLeastOne != nil {
+				atLeastOne = &shared.AtLeastOne{}
+			}
+			var dependentOn *shared.DependentOn
+			if r.FieldRelationships[fieldRelationshipsIndex].DependentOn != nil {
+				var dependencyFieldNames []string
+				if r.FieldRelationships[fieldRelationshipsIndex].DependentOn.DependencyFieldNames != nil {
+					dependencyFieldNames = make([]string, 0, len(r.FieldRelationships[fieldRelationshipsIndex].DependentOn.DependencyFieldNames))
+					for dependencyFieldNamesIndex := range r.FieldRelationships[fieldRelationshipsIndex].DependentOn.DependencyFieldNames {
+						dependencyFieldNames = append(dependencyFieldNames, r.FieldRelationships[fieldRelationshipsIndex].DependentOn.DependencyFieldNames[dependencyFieldNamesIndex].ValueString())
+					}
+				}
+				dependentOn = &shared.DependentOn{
+					DependencyFieldNames: dependencyFieldNames,
+				}
+			}
+			var fieldNames []string
+			if r.FieldRelationships[fieldRelationshipsIndex].FieldNames != nil {
+				fieldNames = make([]string, 0, len(r.FieldRelationships[fieldRelationshipsIndex].FieldNames))
+				for fieldNamesIndex := range r.FieldRelationships[fieldRelationshipsIndex].FieldNames {
+					fieldNames = append(fieldNames, r.FieldRelationships[fieldRelationshipsIndex].FieldNames[fieldNamesIndex].ValueString())
+				}
+			}
+			var mutuallyExclusive *shared.MutuallyExclusive
+			if r.FieldRelationships[fieldRelationshipsIndex].MutuallyExclusive != nil {
+				mutuallyExclusive = &shared.MutuallyExclusive{}
+			}
+			var requiredTogether *shared.RequiredTogether
+			if r.FieldRelationships[fieldRelationshipsIndex].RequiredTogether != nil {
+				requiredTogether = &shared.RequiredTogether{}
+			}
+			fieldRelationships = append(fieldRelationships, shared.FieldRelationship{
+				AtLeastOne:        atLeastOne,
+				DependentOn:       dependentOn,
+				FieldNames:        fieldNames,
+				MutuallyExclusive: mutuallyExclusive,
+				RequiredTogether:  requiredTogether,
+			})
+		}
+	}
+	var fields1 []shared.FormField
+	if r.Fields != nil {
+		fields1 = make([]shared.FormField, 0, len(r.Fields))
+		for fieldsIndex1 := range r.Fields {
+			var adminProviderConfig *shared.AdminProviderConfig
+			if r.Fields[fieldsIndex1].AdminProviderConfig != nil {
+				defaultValueCel := new(string)
+				if !r.Fields[fieldsIndex1].AdminProviderConfig.DefaultValueCel.IsUnknown() && !r.Fields[fieldsIndex1].AdminProviderConfig.DefaultValueCel.IsNull() {
+					*defaultValueCel = r.Fields[fieldsIndex1].AdminProviderConfig.DefaultValueCel.ValueString()
+				} else {
+					defaultValueCel = nil
+				}
+				showToUser := new(bool)
+				if !r.Fields[fieldsIndex1].AdminProviderConfig.ShowToUser.IsUnknown() && !r.Fields[fieldsIndex1].AdminProviderConfig.ShowToUser.IsNull() {
+					*showToUser = r.Fields[fieldsIndex1].AdminProviderConfig.ShowToUser.ValueBool()
+				} else {
+					showToUser = nil
+				}
+				adminProviderConfig = &shared.AdminProviderConfig{
+					DefaultValueCel: defaultValueCel,
+					ShowToUser:      showToUser,
+				}
+			}
+			var boolField *shared.BoolField
+			if r.Fields[fieldsIndex1].BoolField != nil {
+				var checkboxField *shared.CheckboxField
+				if r.Fields[fieldsIndex1].BoolField.CheckboxField != nil {
+					checkboxField = &shared.CheckboxField{}
+				}
+				defaultValue := new(bool)
+				if !r.Fields[fieldsIndex1].BoolField.DefaultValue.IsUnknown() && !r.Fields[fieldsIndex1].BoolField.DefaultValue.IsNull() {
+					*defaultValue = r.Fields[fieldsIndex1].BoolField.DefaultValue.ValueBool()
+				} else {
+					defaultValue = nil
+				}
+				var boolRules *shared.BoolRules
+				if r.Fields[fieldsIndex1].BoolField.BoolRules != nil {
+					constVar := new(bool)
+					if !r.Fields[fieldsIndex1].BoolField.BoolRules.Const.IsUnknown() && !r.Fields[fieldsIndex1].BoolField.BoolRules.Const.IsNull() {
+						*constVar = r.Fields[fieldsIndex1].BoolField.BoolRules.Const.ValueBool()
+					} else {
+						constVar = nil
+					}
+					boolRules = &shared.BoolRules{
+						Const: constVar,
+					}
+				}
+				var toggleField *shared.ToggleField
+				if r.Fields[fieldsIndex1].BoolField.ToggleField != nil {
+					toggleField = &shared.ToggleField{}
+				}
+				boolField = &shared.BoolField{
+					CheckboxField: checkboxField,
+					DefaultValue:  defaultValue,
+					BoolRules:     boolRules,
+					ToggleField:   toggleField,
+				}
+			}
+			description1 := new(string)
+			if !r.Fields[fieldsIndex1].Description.IsUnknown() && !r.Fields[fieldsIndex1].Description.IsNull() {
+				*description1 = r.Fields[fieldsIndex1].Description.ValueString()
+			} else {
+				description1 = nil
+			}
+			displayName1 := new(string)
+			if !r.Fields[fieldsIndex1].DisplayName.IsUnknown() && !r.Fields[fieldsIndex1].DisplayName.IsNull() {
+				*displayName1 = r.Fields[fieldsIndex1].DisplayName.ValueString()
+			} else {
+				displayName1 = nil
+			}
+			var fileField *shared.FileField
+			if r.Fields[fieldsIndex1].FileField != nil {
+				var acceptedFileTypes []string
+				if r.Fields[fieldsIndex1].FileField.AcceptedFileTypes != nil {
+					acceptedFileTypes = make([]string, 0, len(r.Fields[fieldsIndex1].FileField.AcceptedFileTypes))
+					for acceptedFileTypesIndex := range r.Fields[fieldsIndex1].FileField.AcceptedFileTypes {
+						acceptedFileTypes = append(acceptedFileTypes, r.Fields[fieldsIndex1].FileField.AcceptedFileTypes[acceptedFileTypesIndex].ValueString())
+					}
+				}
+				var fileInputField *shared.FileInputField
+				if r.Fields[fieldsIndex1].FileField.FileInputField != nil {
+					fileInputField = &shared.FileInputField{}
+				}
+				maxFileSize := new(string)
+				if !r.Fields[fieldsIndex1].FileField.MaxFileSize.IsUnknown() && !r.Fields[fieldsIndex1].FileField.MaxFileSize.IsNull() {
+					*maxFileSize = r.Fields[fieldsIndex1].FileField.MaxFileSize.ValueString()
+				} else {
+					maxFileSize = nil
+				}
+				fileField = &shared.FileField{
+					AcceptedFileTypes: acceptedFileTypes,
+					FileInputField:    fileInputField,
+					MaxFileSize:       maxFileSize,
+				}
+			}
+			var int64Field *shared.Int64Field
+			if r.Fields[fieldsIndex1].Int64Field != nil {
+				defaultValue1 := new(string)
+				if !r.Fields[fieldsIndex1].Int64Field.DefaultValue.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.DefaultValue.IsNull() {
+					*defaultValue1 = r.Fields[fieldsIndex1].Int64Field.DefaultValue.ValueString()
+				} else {
+					defaultValue1 = nil
+				}
+				var numberField *shared.NumberField
+				if r.Fields[fieldsIndex1].Int64Field.NumberField != nil {
+					maxValue := new(string)
+					if !r.Fields[fieldsIndex1].Int64Field.NumberField.MaxValue.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.NumberField.MaxValue.IsNull() {
+						*maxValue = r.Fields[fieldsIndex1].Int64Field.NumberField.MaxValue.ValueString()
+					} else {
+						maxValue = nil
+					}
+					minValue := new(string)
+					if !r.Fields[fieldsIndex1].Int64Field.NumberField.MinValue.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.NumberField.MinValue.IsNull() {
+						*minValue = r.Fields[fieldsIndex1].Int64Field.NumberField.MinValue.ValueString()
+					} else {
+						minValue = nil
+					}
+					step := new(string)
+					if !r.Fields[fieldsIndex1].Int64Field.NumberField.Step.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.NumberField.Step.IsNull() {
+						*step = r.Fields[fieldsIndex1].Int64Field.NumberField.Step.ValueString()
+					} else {
+						step = nil
+					}
+					numberField = &shared.NumberField{
+						MaxValue: maxValue,
+						MinValue: minValue,
+						Step:     step,
+					}
+				}
+				placeholder := new(string)
+				if !r.Fields[fieldsIndex1].Int64Field.Placeholder.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Placeholder.IsNull() {
+					*placeholder = r.Fields[fieldsIndex1].Int64Field.Placeholder.ValueString()
+				} else {
+					placeholder = nil
+				}
+				var int64Rules *shared.Int64Rules
+				if r.Fields[fieldsIndex1].Int64Field.Int64Rules != nil {
+					constVar1 := new(string)
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Const.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Const.IsNull() {
+						*constVar1 = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Const.ValueString()
+					} else {
+						constVar1 = nil
+					}
+					gt := new(string)
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gt.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gt.IsNull() {
+						*gt = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gt.ValueString()
+					} else {
+						gt = nil
+					}
+					gte := new(string)
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gte.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gte.IsNull() {
+						*gte = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Gte.ValueString()
+					} else {
+						gte = nil
+					}
+					ignoreEmpty := new(bool)
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.IgnoreEmpty.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.IgnoreEmpty.IsNull() {
+						*ignoreEmpty = r.Fields[fieldsIndex1].Int64Field.Int64Rules.IgnoreEmpty.ValueBool()
+					} else {
+						ignoreEmpty = nil
+					}
+					var in []string
+					if r.Fields[fieldsIndex1].Int64Field.Int64Rules.In != nil {
+						in = make([]string, 0, len(r.Fields[fieldsIndex1].Int64Field.Int64Rules.In))
+						for inIndex := range r.Fields[fieldsIndex1].Int64Field.Int64Rules.In {
+							in = append(in, r.Fields[fieldsIndex1].Int64Field.Int64Rules.In[inIndex].ValueString())
+						}
+					}
+					lt := new(string)
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lt.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lt.IsNull() {
+						*lt = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lt.ValueString()
+					} else {
+						lt = nil
+					}
+					lte := new(string)
+					if !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lte.IsUnknown() && !r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lte.IsNull() {
+						*lte = r.Fields[fieldsIndex1].Int64Field.Int64Rules.Lte.ValueString()
+					} else {
+						lte = nil
+					}
+					var notIn []string
+					if r.Fields[fieldsIndex1].Int64Field.Int64Rules.NotIn != nil {
+						notIn = make([]string, 0, len(r.Fields[fieldsIndex1].Int64Field.Int64Rules.NotIn))
+						for notInIndex := range r.Fields[fieldsIndex1].Int64Field.Int64Rules.NotIn {
+							notIn = append(notIn, r.Fields[fieldsIndex1].Int64Field.Int64Rules.NotIn[notInIndex].ValueString())
 						}
 					}
 					int64Rules = &shared.Int64Rules{
@@ -602,186 +1583,277 @@ func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.
 				}
 			}
 			name1 := new(string)
-			if !fieldsItem.Name.IsUnknown() && !fieldsItem.Name.IsNull() {
-				*name1 = fieldsItem.Name.ValueString()
+			if !r.Fields[fieldsIndex1].Name.IsUnknown() && !r.Fields[fieldsIndex1].Name.IsNull() {
+				*name1 = r.Fields[fieldsIndex1].Name.ValueString()
 			} else {
 				name1 = nil
 			}
-			var stringField *shared.FormStringField
-			if fieldsItem.FormStringField != nil {
+			var oauth2Field *shared.Oauth2Field
+			if r.Fields[fieldsIndex1].Oauth2Field != nil {
+				var oauth2FieldView *shared.Oauth2FieldView
+				if r.Fields[fieldsIndex1].Oauth2Field.Oauth2FieldView != nil {
+					oauth2FieldView = &shared.Oauth2FieldView{}
+				}
+				oauth2Field = &shared.Oauth2Field{
+					Oauth2FieldView: oauth2FieldView,
+				}
+			}
+			readOnly := new(bool)
+			if !r.Fields[fieldsIndex1].ReadOnly.IsUnknown() && !r.Fields[fieldsIndex1].ReadOnly.IsNull() {
+				*readOnly = r.Fields[fieldsIndex1].ReadOnly.ValueBool()
+			} else {
+				readOnly = nil
+			}
+			required := new(bool)
+			if !r.Fields[fieldsIndex1].Required.IsUnknown() && !r.Fields[fieldsIndex1].Required.IsNull() {
+				*required = r.Fields[fieldsIndex1].Required.ValueBool()
+			} else {
+				required = nil
+			}
+			var sharedProviderConfig *shared.SharedProviderConfig
+			if r.Fields[fieldsIndex1].SharedProviderConfig != nil {
+				defaultValueCel1 := new(string)
+				if !r.Fields[fieldsIndex1].SharedProviderConfig.DefaultValueCel.IsUnknown() && !r.Fields[fieldsIndex1].SharedProviderConfig.DefaultValueCel.IsNull() {
+					*defaultValueCel1 = r.Fields[fieldsIndex1].SharedProviderConfig.DefaultValueCel.ValueString()
+				} else {
+					defaultValueCel1 = nil
+				}
+				inputTransformationCel := new(string)
+				if !r.Fields[fieldsIndex1].SharedProviderConfig.InputTransformationCel.IsUnknown() && !r.Fields[fieldsIndex1].SharedProviderConfig.InputTransformationCel.IsNull() {
+					*inputTransformationCel = r.Fields[fieldsIndex1].SharedProviderConfig.InputTransformationCel.ValueString()
+				} else {
+					inputTransformationCel = nil
+				}
+				lockDefaultValues := new(bool)
+				if !r.Fields[fieldsIndex1].SharedProviderConfig.LockDefaultValues.IsUnknown() && !r.Fields[fieldsIndex1].SharedProviderConfig.LockDefaultValues.IsNull() {
+					*lockDefaultValues = r.Fields[fieldsIndex1].SharedProviderConfig.LockDefaultValues.ValueBool()
+				} else {
+					lockDefaultValues = nil
+				}
+				sharedProviderConfig = &shared.SharedProviderConfig{
+					DefaultValueCel:        defaultValueCel1,
+					InputTransformationCel: inputTransformationCel,
+					LockDefaultValues:      lockDefaultValues,
+				}
+			}
+			var formStringField *shared.FormStringField
+			if r.Fields[fieldsIndex1].FormStringField != nil {
 				defaultValue2 := new(string)
-				if !fieldsItem.FormStringField.DefaultValue.IsUnknown() && !fieldsItem.FormStringField.DefaultValue.IsNull() {
-					*defaultValue2 = fieldsItem.FormStringField.DefaultValue.ValueString()
+				if !r.Fields[fieldsIndex1].FormStringField.DefaultValue.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.DefaultValue.IsNull() {
+					*defaultValue2 = r.Fields[fieldsIndex1].FormStringField.DefaultValue.ValueString()
 				} else {
 					defaultValue2 = nil
 				}
 				var passwordField *shared.PasswordField
-				if fieldsItem.FormStringField.PasswordField != nil {
+				if r.Fields[fieldsIndex1].FormStringField.PasswordField != nil {
 					passwordField = &shared.PasswordField{}
 				}
+				var pickerField *shared.PickerField
+				if r.Fields[fieldsIndex1].FormStringField.PickerField != nil {
+					var appUserFilter *shared.AppUserFilter
+					if r.Fields[fieldsIndex1].FormStringField.PickerField.AppUserFilter != nil {
+						appID := new(string)
+						if !r.Fields[fieldsIndex1].FormStringField.PickerField.AppUserFilter.AppID.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.PickerField.AppUserFilter.AppID.IsNull() {
+							*appID = r.Fields[fieldsIndex1].FormStringField.PickerField.AppUserFilter.AppID.ValueString()
+						} else {
+							appID = nil
+						}
+						appUserFilter = &shared.AppUserFilter{
+							AppID: appID,
+						}
+					}
+					var c1UserFilter *shared.C1UserFilter
+					if r.Fields[fieldsIndex1].FormStringField.PickerField.C1UserFilter != nil {
+						c1UserFilter = &shared.C1UserFilter{}
+					}
+					var appResourceFilter *shared.AppResourceFilter
+					if r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter != nil {
+						appId1 := new(string)
+						if !r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.AppID.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.AppID.IsNull() {
+							*appId1 = r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.AppID.ValueString()
+						} else {
+							appId1 = nil
+						}
+						resourceTypeID := new(string)
+						if !r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsNull() {
+							*resourceTypeID = r.Fields[fieldsIndex1].FormStringField.PickerField.AppResourceFilter.ResourceTypeID.ValueString()
+						} else {
+							resourceTypeID = nil
+						}
+						appResourceFilter = &shared.AppResourceFilter{
+							AppID:          appId1,
+							ResourceTypeID: resourceTypeID,
+						}
+					}
+					pickerField = &shared.PickerField{
+						AppUserFilter:     appUserFilter,
+						C1UserFilter:      c1UserFilter,
+						AppResourceFilter: appResourceFilter,
+					}
+				}
 				placeholder1 := new(string)
-				if !fieldsItem.FormStringField.Placeholder.IsUnknown() && !fieldsItem.FormStringField.Placeholder.IsNull() {
-					*placeholder1 = fieldsItem.FormStringField.Placeholder.ValueString()
+				if !r.Fields[fieldsIndex1].FormStringField.Placeholder.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.Placeholder.IsNull() {
+					*placeholder1 = r.Fields[fieldsIndex1].FormStringField.Placeholder.ValueString()
 				} else {
 					placeholder1 = nil
 				}
 				var stringRules *shared.StringRules
-				if fieldsItem.FormStringField.StringRules != nil {
+				if r.Fields[fieldsIndex1].FormStringField.StringRules != nil {
 					address := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Address.IsUnknown() && !fieldsItem.FormStringField.StringRules.Address.IsNull() {
-						*address = fieldsItem.FormStringField.StringRules.Address.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Address.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Address.IsNull() {
+						*address = r.Fields[fieldsIndex1].FormStringField.StringRules.Address.ValueBool()
 					} else {
 						address = nil
 					}
 					constVar2 := new(string)
-					if !fieldsItem.FormStringField.StringRules.Const.IsUnknown() && !fieldsItem.FormStringField.StringRules.Const.IsNull() {
-						*constVar2 = fieldsItem.FormStringField.StringRules.Const.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Const.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Const.IsNull() {
+						*constVar2 = r.Fields[fieldsIndex1].FormStringField.StringRules.Const.ValueString()
 					} else {
 						constVar2 = nil
 					}
 					contains := new(string)
-					if !fieldsItem.FormStringField.StringRules.Contains.IsUnknown() && !fieldsItem.FormStringField.StringRules.Contains.IsNull() {
-						*contains = fieldsItem.FormStringField.StringRules.Contains.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Contains.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Contains.IsNull() {
+						*contains = r.Fields[fieldsIndex1].FormStringField.StringRules.Contains.ValueString()
 					} else {
 						contains = nil
 					}
 					email := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Email.IsUnknown() && !fieldsItem.FormStringField.StringRules.Email.IsNull() {
-						*email = fieldsItem.FormStringField.StringRules.Email.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Email.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Email.IsNull() {
+						*email = r.Fields[fieldsIndex1].FormStringField.StringRules.Email.ValueBool()
 					} else {
 						email = nil
 					}
 					hostname := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Hostname.IsUnknown() && !fieldsItem.FormStringField.StringRules.Hostname.IsNull() {
-						*hostname = fieldsItem.FormStringField.StringRules.Hostname.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Hostname.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Hostname.IsNull() {
+						*hostname = r.Fields[fieldsIndex1].FormStringField.StringRules.Hostname.ValueBool()
 					} else {
 						hostname = nil
 					}
 					ignoreEmpty1 := new(bool)
-					if !fieldsItem.FormStringField.StringRules.IgnoreEmpty.IsUnknown() && !fieldsItem.FormStringField.StringRules.IgnoreEmpty.IsNull() {
-						*ignoreEmpty1 = fieldsItem.FormStringField.StringRules.IgnoreEmpty.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.IgnoreEmpty.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.IgnoreEmpty.IsNull() {
+						*ignoreEmpty1 = r.Fields[fieldsIndex1].FormStringField.StringRules.IgnoreEmpty.ValueBool()
 					} else {
 						ignoreEmpty1 = nil
 					}
 					var in1 []string
-					if fieldsItem.FormStringField.StringRules.In != nil {
-						in1 = make([]string, 0, len(fieldsItem.FormStringField.StringRules.In))
-						for _, inItem1 := range fieldsItem.FormStringField.StringRules.In {
-							in1 = append(in1, inItem1.ValueString())
+					if r.Fields[fieldsIndex1].FormStringField.StringRules.In != nil {
+						in1 = make([]string, 0, len(r.Fields[fieldsIndex1].FormStringField.StringRules.In))
+						for inIndex1 := range r.Fields[fieldsIndex1].FormStringField.StringRules.In {
+							in1 = append(in1, r.Fields[fieldsIndex1].FormStringField.StringRules.In[inIndex1].ValueString())
 						}
 					}
 					ip := new(bool)
-					if !fieldsItem.FormStringField.StringRules.IP.IsUnknown() && !fieldsItem.FormStringField.StringRules.IP.IsNull() {
-						*ip = fieldsItem.FormStringField.StringRules.IP.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.IP.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.IP.IsNull() {
+						*ip = r.Fields[fieldsIndex1].FormStringField.StringRules.IP.ValueBool()
 					} else {
 						ip = nil
 					}
 					ipv4 := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Ipv4.IsUnknown() && !fieldsItem.FormStringField.StringRules.Ipv4.IsNull() {
-						*ipv4 = fieldsItem.FormStringField.StringRules.Ipv4.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv4.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv4.IsNull() {
+						*ipv4 = r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv4.ValueBool()
 					} else {
 						ipv4 = nil
 					}
 					ipv6 := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Ipv6.IsUnknown() && !fieldsItem.FormStringField.StringRules.Ipv6.IsNull() {
-						*ipv6 = fieldsItem.FormStringField.StringRules.Ipv6.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv6.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv6.IsNull() {
+						*ipv6 = r.Fields[fieldsIndex1].FormStringField.StringRules.Ipv6.ValueBool()
 					} else {
 						ipv6 = nil
 					}
 					length := new(string)
-					if !fieldsItem.FormStringField.StringRules.Length.IsUnknown() && !fieldsItem.FormStringField.StringRules.Length.IsNull() {
-						*length = fieldsItem.FormStringField.StringRules.Length.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Length.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Length.IsNull() {
+						*length = r.Fields[fieldsIndex1].FormStringField.StringRules.Length.ValueString()
 					} else {
 						length = nil
 					}
 					lenBytes := new(string)
-					if !fieldsItem.FormStringField.StringRules.LenBytes.IsUnknown() && !fieldsItem.FormStringField.StringRules.LenBytes.IsNull() {
-						*lenBytes = fieldsItem.FormStringField.StringRules.LenBytes.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.LenBytes.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.LenBytes.IsNull() {
+						*lenBytes = r.Fields[fieldsIndex1].FormStringField.StringRules.LenBytes.ValueString()
 					} else {
 						lenBytes = nil
 					}
 					maxBytes := new(string)
-					if !fieldsItem.FormStringField.StringRules.MaxBytes.IsUnknown() && !fieldsItem.FormStringField.StringRules.MaxBytes.IsNull() {
-						*maxBytes = fieldsItem.FormStringField.StringRules.MaxBytes.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.MaxBytes.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.MaxBytes.IsNull() {
+						*maxBytes = r.Fields[fieldsIndex1].FormStringField.StringRules.MaxBytes.ValueString()
 					} else {
 						maxBytes = nil
 					}
 					maxLen := new(string)
-					if !fieldsItem.FormStringField.StringRules.MaxLen.IsUnknown() && !fieldsItem.FormStringField.StringRules.MaxLen.IsNull() {
-						*maxLen = fieldsItem.FormStringField.StringRules.MaxLen.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.MaxLen.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.MaxLen.IsNull() {
+						*maxLen = r.Fields[fieldsIndex1].FormStringField.StringRules.MaxLen.ValueString()
 					} else {
 						maxLen = nil
 					}
 					minBytes := new(string)
-					if !fieldsItem.FormStringField.StringRules.MinBytes.IsUnknown() && !fieldsItem.FormStringField.StringRules.MinBytes.IsNull() {
-						*minBytes = fieldsItem.FormStringField.StringRules.MinBytes.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.MinBytes.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.MinBytes.IsNull() {
+						*minBytes = r.Fields[fieldsIndex1].FormStringField.StringRules.MinBytes.ValueString()
 					} else {
 						minBytes = nil
 					}
 					minLen := new(string)
-					if !fieldsItem.FormStringField.StringRules.MinLen.IsUnknown() && !fieldsItem.FormStringField.StringRules.MinLen.IsNull() {
-						*minLen = fieldsItem.FormStringField.StringRules.MinLen.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.MinLen.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.MinLen.IsNull() {
+						*minLen = r.Fields[fieldsIndex1].FormStringField.StringRules.MinLen.ValueString()
 					} else {
 						minLen = nil
 					}
 					notContains := new(string)
-					if !fieldsItem.FormStringField.StringRules.NotContains.IsUnknown() && !fieldsItem.FormStringField.StringRules.NotContains.IsNull() {
-						*notContains = fieldsItem.FormStringField.StringRules.NotContains.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.NotContains.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.NotContains.IsNull() {
+						*notContains = r.Fields[fieldsIndex1].FormStringField.StringRules.NotContains.ValueString()
 					} else {
 						notContains = nil
 					}
 					var notIn1 []string
-					if fieldsItem.FormStringField.StringRules.NotIn != nil {
-						notIn1 = make([]string, 0, len(fieldsItem.FormStringField.StringRules.NotIn))
-						for _, notInItem1 := range fieldsItem.FormStringField.StringRules.NotIn {
-							notIn1 = append(notIn1, notInItem1.ValueString())
+					if r.Fields[fieldsIndex1].FormStringField.StringRules.NotIn != nil {
+						notIn1 = make([]string, 0, len(r.Fields[fieldsIndex1].FormStringField.StringRules.NotIn))
+						for notInIndex1 := range r.Fields[fieldsIndex1].FormStringField.StringRules.NotIn {
+							notIn1 = append(notIn1, r.Fields[fieldsIndex1].FormStringField.StringRules.NotIn[notInIndex1].ValueString())
 						}
 					}
 					pattern := new(string)
-					if !fieldsItem.FormStringField.StringRules.Pattern.IsUnknown() && !fieldsItem.FormStringField.StringRules.Pattern.IsNull() {
-						*pattern = fieldsItem.FormStringField.StringRules.Pattern.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Pattern.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Pattern.IsNull() {
+						*pattern = r.Fields[fieldsIndex1].FormStringField.StringRules.Pattern.ValueString()
 					} else {
 						pattern = nil
 					}
 					prefix := new(string)
-					if !fieldsItem.FormStringField.StringRules.Prefix.IsUnknown() && !fieldsItem.FormStringField.StringRules.Prefix.IsNull() {
-						*prefix = fieldsItem.FormStringField.StringRules.Prefix.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Prefix.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Prefix.IsNull() {
+						*prefix = r.Fields[fieldsIndex1].FormStringField.StringRules.Prefix.ValueString()
 					} else {
 						prefix = nil
 					}
 					strict := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Strict.IsUnknown() && !fieldsItem.FormStringField.StringRules.Strict.IsNull() {
-						*strict = fieldsItem.FormStringField.StringRules.Strict.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Strict.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Strict.IsNull() {
+						*strict = r.Fields[fieldsIndex1].FormStringField.StringRules.Strict.ValueBool()
 					} else {
 						strict = nil
 					}
 					suffix := new(string)
-					if !fieldsItem.FormStringField.StringRules.Suffix.IsUnknown() && !fieldsItem.FormStringField.StringRules.Suffix.IsNull() {
-						*suffix = fieldsItem.FormStringField.StringRules.Suffix.ValueString()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.Suffix.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.Suffix.IsNull() {
+						*suffix = r.Fields[fieldsIndex1].FormStringField.StringRules.Suffix.ValueString()
 					} else {
 						suffix = nil
 					}
 					uri := new(bool)
-					if !fieldsItem.FormStringField.StringRules.URI.IsUnknown() && !fieldsItem.FormStringField.StringRules.URI.IsNull() {
-						*uri = fieldsItem.FormStringField.StringRules.URI.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.URI.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.URI.IsNull() {
+						*uri = r.Fields[fieldsIndex1].FormStringField.StringRules.URI.ValueBool()
 					} else {
 						uri = nil
 					}
 					uriRef := new(bool)
-					if !fieldsItem.FormStringField.StringRules.URIRef.IsUnknown() && !fieldsItem.FormStringField.StringRules.URIRef.IsNull() {
-						*uriRef = fieldsItem.FormStringField.StringRules.URIRef.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.URIRef.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.URIRef.IsNull() {
+						*uriRef = r.Fields[fieldsIndex1].FormStringField.StringRules.URIRef.ValueBool()
 					} else {
 						uriRef = nil
 					}
 					uuid := new(bool)
-					if !fieldsItem.FormStringField.StringRules.UUID.IsUnknown() && !fieldsItem.FormStringField.StringRules.UUID.IsNull() {
-						*uuid = fieldsItem.FormStringField.StringRules.UUID.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.UUID.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.UUID.IsNull() {
+						*uuid = r.Fields[fieldsIndex1].FormStringField.StringRules.UUID.ValueBool()
 					} else {
 						uuid = nil
 					}
 					wellKnownRegex := new(shared.WellKnownRegex)
-					if !fieldsItem.FormStringField.StringRules.WellKnownRegex.IsUnknown() && !fieldsItem.FormStringField.StringRules.WellKnownRegex.IsNull() {
-						*wellKnownRegex = shared.WellKnownRegex(fieldsItem.FormStringField.StringRules.WellKnownRegex.ValueString())
+					if !r.Fields[fieldsIndex1].FormStringField.StringRules.WellKnownRegex.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.StringRules.WellKnownRegex.IsNull() {
+						*wellKnownRegex = shared.WellKnownRegex(r.Fields[fieldsIndex1].FormStringField.StringRules.WellKnownRegex.ValueString())
 					} else {
 						wellKnownRegex = nil
 					}
@@ -815,913 +1887,167 @@ func (r *RequestSchemaResourceModel) ToSharedForm(ctx context.Context) (*shared.
 					}
 				}
 				var selectField *shared.SelectField
-				if fieldsItem.FormStringField.SelectField != nil {
+				if r.Fields[fieldsIndex1].FormStringField.SelectField != nil {
 					var optionsVar []shared.SelectOption
-					if fieldsItem.FormStringField.SelectField.Options != nil {
-						optionsVar = make([]shared.SelectOption, 0, len(fieldsItem.FormStringField.SelectField.Options))
-						for _, optionsItem := range fieldsItem.FormStringField.SelectField.Options {
-							displayName1 := new(string)
-							if !optionsItem.DisplayName.IsUnknown() && !optionsItem.DisplayName.IsNull() {
-								*displayName1 = optionsItem.DisplayName.ValueString()
+					if r.Fields[fieldsIndex1].FormStringField.SelectField.Options != nil {
+						optionsVar = make([]shared.SelectOption, 0, len(r.Fields[fieldsIndex1].FormStringField.SelectField.Options))
+						for optionsIndex := range r.Fields[fieldsIndex1].FormStringField.SelectField.Options {
+							description2 := new(string)
+							if !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Description.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Description.IsNull() {
+								*description2 = r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Description.ValueString()
 							} else {
-								displayName1 = nil
+								description2 = nil
+							}
+							displayName2 := new(string)
+							if !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].DisplayName.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].DisplayName.IsNull() {
+								*displayName2 = r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].DisplayName.ValueString()
+							} else {
+								displayName2 = nil
 							}
 							value := new(string)
-							if !optionsItem.Value.IsUnknown() && !optionsItem.Value.IsNull() {
-								*value = optionsItem.Value.ValueString()
+							if !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Value.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Value.IsNull() {
+								*value = r.Fields[fieldsIndex1].FormStringField.SelectField.Options[optionsIndex].Value.ValueString()
 							} else {
 								value = nil
 							}
 							optionsVar = append(optionsVar, shared.SelectOption{
-								DisplayName: displayName1,
+								Description: description2,
+								DisplayName: displayName2,
 								Value:       value,
 							})
 						}
 					}
+					typeVar := new(shared.SelectFieldType)
+					if !r.Fields[fieldsIndex1].FormStringField.SelectField.Type.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.SelectField.Type.IsNull() {
+						*typeVar = shared.SelectFieldType(r.Fields[fieldsIndex1].FormStringField.SelectField.Type.ValueString())
+					} else {
+						typeVar = nil
+					}
 					selectField = &shared.SelectField{
 						Options: optionsVar,
+						Type:    typeVar,
 					}
 				}
 				var textField *shared.TextField
-				if fieldsItem.FormStringField.TextField != nil {
+				if r.Fields[fieldsIndex1].FormStringField.TextField != nil {
 					multiline := new(bool)
-					if !fieldsItem.FormStringField.TextField.Multiline.IsUnknown() && !fieldsItem.FormStringField.TextField.Multiline.IsNull() {
-						*multiline = fieldsItem.FormStringField.TextField.Multiline.ValueBool()
+					if !r.Fields[fieldsIndex1].FormStringField.TextField.Multiline.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.TextField.Multiline.IsNull() {
+						*multiline = r.Fields[fieldsIndex1].FormStringField.TextField.Multiline.ValueBool()
 					} else {
 						multiline = nil
 					}
+					suffix1 := new(string)
+					if !r.Fields[fieldsIndex1].FormStringField.TextField.Suffix.IsUnknown() && !r.Fields[fieldsIndex1].FormStringField.TextField.Suffix.IsNull() {
+						*suffix1 = r.Fields[fieldsIndex1].FormStringField.TextField.Suffix.ValueString()
+					} else {
+						suffix1 = nil
+					}
 					textField = &shared.TextField{
 						Multiline: multiline,
+						Suffix:    suffix1,
 					}
 				}
-				var pickerField *shared.PickerField
-				if fieldsItem.FormStringField.PickerField != nil {
-					var appResourceFilter *shared.AppResourceFilter
-					if fieldsItem.FormStringField.PickerField.AppResourceFilter != nil {
-						appResourceFilterAppID := new(string)
-						if !fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.IsNull() {
-							*appResourceFilterAppID = fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.ValueString()
-						} else {
-							appResourceFilterAppID = nil
-						}
-						appResourceFilterResourceTypeID := new(string)
-						if !fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsNull() {
-							*appResourceFilterResourceTypeID = fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.ValueString()
-						} else {
-							appResourceFilterResourceTypeID = nil
-						}
-						appResourceFilter = &shared.AppResourceFilter{
-							AppID:          appResourceFilterAppID,
-							ResourceTypeID: appResourceFilterResourceTypeID,
-						}
-					}
-					var appUserFilter *shared.AppUserFilter
-					if fieldsItem.FormStringField.PickerField.AppUserFilter != nil {
-						appUserFilterAppID := new(string)
-						if !fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.IsNull() {
-							*appUserFilterAppID = fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.ValueString()
-						} else {
-							appUserFilterAppID = nil
-						}
-						appUserFilter = &shared.AppUserFilter{
-							AppID: appUserFilterAppID,
-						}
-					}
-					var c1UserFilter *shared.C1UserFilter
-					if fieldsItem.FormStringField.PickerField.C1UserFilter != nil {
-						c1UserFilter = &shared.C1UserFilter{}
-					}
-					pickerField = &shared.PickerField{
-						AppUserFilter:     appUserFilter,
-						C1UserFilter:      c1UserFilter,
-						AppResourceFilter: appResourceFilter,
-					}
-				}
-				stringField = &shared.FormStringField{
+				formStringField = &shared.FormStringField{
 					DefaultValue:  defaultValue2,
 					PasswordField: passwordField,
+					PickerField:   pickerField,
 					Placeholder:   placeholder1,
 					StringRules:   stringRules,
 					SelectField:   selectField,
 					TextField:     textField,
-					PickerField:   pickerField,
-				}
-			}
-			var adminProviderConfig *shared.AdminProviderConfig
-			if fieldsItem.AdminProviderConfig != nil {
-				adminDefaultValueCel := new(string)
-				if !fieldsItem.AdminProviderConfig.DefaultValueCel.IsUnknown() && !fieldsItem.AdminProviderConfig.DefaultValueCel.IsNull() {
-					*adminDefaultValueCel = fieldsItem.AdminProviderConfig.DefaultValueCel.ValueString()
-				} else {
-					adminDefaultValueCel = nil
-				}
-				adminShowToUser := new(bool)
-				if !fieldsItem.AdminProviderConfig.ShowToUser.IsUnknown() && !fieldsItem.AdminProviderConfig.ShowToUser.IsNull() {
-					*adminShowToUser = fieldsItem.AdminProviderConfig.ShowToUser.ValueBool()
-				} else {
-					adminShowToUser = nil
-				}
-				adminProviderConfig = &shared.AdminProviderConfig{
-					DefaultValueCel: adminDefaultValueCel,
-					ShowToUser:      adminShowToUser,
-				}
-			}
-			var sharedProviderConfig *shared.SharedProviderConfig
-			if fieldsItem.SharedProviderConfig != nil {
-				sharedDefaultValueCel := new(string)
-				if !fieldsItem.SharedProviderConfig.DefaultValueCel.IsUnknown() && !fieldsItem.SharedProviderConfig.DefaultValueCel.IsNull() {
-					*sharedDefaultValueCel = fieldsItem.SharedProviderConfig.DefaultValueCel.ValueString()
-				} else {
-					sharedDefaultValueCel = nil
-				}
-				sharedInputTransformationCel := new(string)
-				if !fieldsItem.SharedProviderConfig.InputTransformationCel.IsUnknown() && !fieldsItem.SharedProviderConfig.InputTransformationCel.IsNull() {
-					*sharedInputTransformationCel = fieldsItem.SharedProviderConfig.InputTransformationCel.ValueString()
-				} else {
-					sharedInputTransformationCel = nil
-				}
-				sharedLockDefaultValues := new(bool)
-				if !fieldsItem.SharedProviderConfig.LockDefaultValues.IsUnknown() && !fieldsItem.SharedProviderConfig.LockDefaultValues.IsNull() {
-					*sharedLockDefaultValues = fieldsItem.SharedProviderConfig.LockDefaultValues.ValueBool()
-				} else {
-					sharedLockDefaultValues = nil
-				}
-				sharedProviderConfig = &shared.SharedProviderConfig{
-					DefaultValueCel:        sharedDefaultValueCel,
-					InputTransformationCel: sharedInputTransformationCel,
-					LockDefaultValues:      sharedLockDefaultValues,
-				}
-			}
-			var userProviderConfig *shared.UserProviderConfig
-			if fieldsItem.UserProviderConfig != nil {
-				userInputTransformationCel := new(string)
-				if !fieldsItem.UserProviderConfig.InputTransformationCel.IsUnknown() && !fieldsItem.UserProviderConfig.InputTransformationCel.IsNull() {
-					*userInputTransformationCel = fieldsItem.UserProviderConfig.InputTransformationCel.ValueString()
-				} else {
-					userInputTransformationCel = nil
-				}
-				userProviderConfig = &shared.UserProviderConfig{
-					InputTransformationCel: userInputTransformationCel,
-				}
-			}
-			var oauth2Field *shared.Oauth2Field
-			if fieldsItem.Oauth2Field != nil {
-				var oauth2FieldView *shared.Oauth2FieldView
-				if fieldsItem.Oauth2Field.Oauth2FieldView != nil {
-					oauth2FieldView = &shared.Oauth2FieldView{}
-				}
-				oauth2Field = &shared.Oauth2Field{
-					Oauth2FieldView: oauth2FieldView,
 				}
 			}
 			var formStringMapField *shared.FormStringMapField
-			if fieldsItem.FormStringMapField != nil {
-				var stringMapDefaultValue map[string]string
-				if fieldsItem.FormStringMapField.DefaultValue != nil {
-					stringMapDefaultValue = make(map[string]string, len(fieldsItem.FormStringMapField.DefaultValue))
-					for stringMapKey, stringMapVal := range fieldsItem.FormStringMapField.DefaultValue {
-						stringMapDefaultValue[stringMapKey] = stringMapVal.ValueString()
-					}
+			if r.Fields[fieldsIndex1].FormStringMapField != nil {
+				defaultValue3 := make(map[string]string)
+				for defaultValueKey := range r.Fields[fieldsIndex1].FormStringMapField.DefaultValue {
+					var defaultValueInst string
+					defaultValueInst = r.Fields[fieldsIndex1].FormStringMapField.DefaultValue[defaultValueKey].ValueString()
+
+					defaultValue3[defaultValueKey] = defaultValueInst
 				}
 				var stringMapRules *shared.StringMapRules
-				if fieldsItem.FormStringMapField.StringMapRules != nil {
-					stringMapIsRequired := new(bool)
-					if !fieldsItem.FormStringMapField.StringMapRules.IsRequired.IsUnknown() && !fieldsItem.FormStringMapField.StringMapRules.IsRequired.IsNull() {
-						*stringMapIsRequired = fieldsItem.FormStringMapField.StringMapRules.IsRequired.ValueBool()
+				if r.Fields[fieldsIndex1].FormStringMapField.StringMapRules != nil {
+					isRequired := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.IsRequired.IsUnknown() && !r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.IsRequired.IsNull() {
+						*isRequired = r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.IsRequired.ValueBool()
 					} else {
-						stringMapIsRequired = nil
+						isRequired = nil
 					}
-					stringMapValidateEmpty := new(bool)
-					if !fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.IsUnknown() && !fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.IsNull() {
-						*stringMapValidateEmpty = fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.ValueBool()
+					validateEmpty := new(bool)
+					if !r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.ValidateEmpty.IsUnknown() && !r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.ValidateEmpty.IsNull() {
+						*validateEmpty = r.Fields[fieldsIndex1].FormStringMapField.StringMapRules.ValidateEmpty.ValueBool()
 					} else {
-						stringMapValidateEmpty = nil
+						validateEmpty = nil
 					}
 					stringMapRules = &shared.StringMapRules{
-						IsRequired:    stringMapIsRequired,
-						ValidateEmpty: stringMapValidateEmpty,
+						IsRequired:    isRequired,
+						ValidateEmpty: validateEmpty,
 					}
 				}
 				formStringMapField = &shared.FormStringMapField{
-					DefaultValue:   stringMapDefaultValue,
+					DefaultValue:   defaultValue3,
 					StringMapRules: stringMapRules,
 				}
 			}
-			readOnly := new(bool)
-			if !fieldsItem.ReadOnly.IsUnknown() && !fieldsItem.ReadOnly.IsNull() {
-				*readOnly = fieldsItem.ReadOnly.ValueBool()
-			} else {
-				readOnly = nil
+			var userProviderConfig *shared.UserProviderConfig
+			if r.Fields[fieldsIndex1].UserProviderConfig != nil {
+				inputTransformationCel1 := new(string)
+				if !r.Fields[fieldsIndex1].UserProviderConfig.InputTransformationCel.IsUnknown() && !r.Fields[fieldsIndex1].UserProviderConfig.InputTransformationCel.IsNull() {
+					*inputTransformationCel1 = r.Fields[fieldsIndex1].UserProviderConfig.InputTransformationCel.ValueString()
+				} else {
+					inputTransformationCel1 = nil
+				}
+				userProviderConfig = &shared.UserProviderConfig{
+					InputTransformationCel: inputTransformationCel1,
+				}
 			}
-			required := new(bool)
-			if !fieldsItem.Required.IsUnknown() && !fieldsItem.Required.IsNull() {
-				*required = fieldsItem.Required.ValueBool()
-			} else {
-				required = nil
-			}
-			fields = append(fields, shared.FormField{
+			fields1 = append(fields1, shared.FormField{
 				AdminProviderConfig:  adminProviderConfig,
-				Oauth2Field:          oauth2Field,
-				ReadOnly:             readOnly,
-				Required:             required,
-				SharedProviderConfig: sharedProviderConfig,
-				FormStringMapField:   formStringMapField,
-				UserProviderConfig:   userProviderConfig,
 				BoolField:            boolField,
 				Description:          description1,
-				DisplayName:          displayName,
+				DisplayName:          displayName1,
 				FileField:            fileField,
 				Int64Field:           int64Field,
 				Name:                 name1,
-				FormStringField:      stringField,
-			})
-		}
-	}
-	out := shared.RequestSchemaForm{
-		Description:        description,
-		Name:               name,
-		FieldRelationships: fieldRelationships,
-		Fields:             fields,
-	}
-
-	return &out, diags
-}
-
-func (r *RequestSchemaResourceModel) ToSharedRequestSchema(ctx context.Context) (*shared.RequestSchema, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	createdAt := new(time.Time)
-	if !r.CreatedAt.IsUnknown() && !r.CreatedAt.IsNull() {
-		*createdAt, _ = time.Parse(time.RFC3339Nano, r.CreatedAt.ValueString())
-	} else {
-		createdAt = nil
-	}
-	deletedAt := new(time.Time)
-	if !r.DeletedAt.IsUnknown() && !r.DeletedAt.IsNull() {
-		*deletedAt, _ = time.Parse(time.RFC3339Nano, r.DeletedAt.ValueString())
-	} else {
-		deletedAt = nil
-	}
-	form, formDiags := r.ToSharedForm(ctx)
-	diags.Append(formDiags...)
-
-	if diags.HasError() {
-		return nil, diags
-	}
-
-	id := new(string)
-	if !r.ID.IsUnknown() && !r.ID.IsNull() {
-		*id = r.ID.ValueString()
-	} else {
-		id = nil
-	}
-	out := shared.RequestSchema{
-		CreatedAt:         createdAt,
-		DeletedAt:         deletedAt,
-		RequestSchemaForm: form,
-		ID:                id,
-	}
-
-	return &out, diags
-}
-
-func (r *RequestSchemaResourceModel) ToSharedRequestSchemaServiceCreateRequest(ctx context.Context) (*shared.RequestSchemaServiceCreateRequest, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	description := new(string)
-	if !r.Description.IsUnknown() && !r.Description.IsNull() {
-		*description = r.Description.ValueString()
-	} else {
-		description = nil
-	}
-	var fields []shared.FormField
-	if r.Fields != nil {
-		fields = make([]shared.FormField, 0, len(r.Fields))
-		for _, fieldsItem := range r.Fields {
-			var boolField *shared.BoolField
-			if fieldsItem.BoolField != nil {
-				var checkboxField *shared.CheckboxField
-				if fieldsItem.BoolField.CheckboxField != nil {
-					checkboxField = &shared.CheckboxField{}
-				}
-				defaultValue := new(bool)
-				if !fieldsItem.BoolField.DefaultValue.IsUnknown() && !fieldsItem.BoolField.DefaultValue.IsNull() {
-					*defaultValue = fieldsItem.BoolField.DefaultValue.ValueBool()
-				} else {
-					defaultValue = nil
-				}
-				var boolRules *shared.BoolRules
-				if fieldsItem.BoolField.BoolRules != nil {
-					constVar := new(bool)
-					if !fieldsItem.BoolField.BoolRules.Const.IsUnknown() && !fieldsItem.BoolField.BoolRules.Const.IsNull() {
-						*constVar = fieldsItem.BoolField.BoolRules.Const.ValueBool()
-					} else {
-						constVar = nil
-					}
-					boolRules = &shared.BoolRules{
-						Const: constVar,
-					}
-				}
-				boolField = &shared.BoolField{
-					CheckboxField: checkboxField,
-					DefaultValue:  defaultValue,
-					BoolRules:     boolRules,
-				}
-			}
-			description1 := new(string)
-			if !fieldsItem.Description.IsUnknown() && !fieldsItem.Description.IsNull() {
-				*description1 = fieldsItem.Description.ValueString()
-			} else {
-				description1 = nil
-			}
-			displayName := new(string)
-			if !fieldsItem.DisplayName.IsUnknown() && !fieldsItem.DisplayName.IsNull() {
-				*displayName = fieldsItem.DisplayName.ValueString()
-			} else {
-				displayName = nil
-			}
-			var fileField *shared.FileField
-			if fieldsItem.FileField != nil {
-				var acceptedFileTypes []string
-				if fieldsItem.FileField.AcceptedFileTypes != nil {
-					acceptedFileTypes = make([]string, 0, len(fieldsItem.FileField.AcceptedFileTypes))
-					for _, acceptedFileTypesItem := range fieldsItem.FileField.AcceptedFileTypes {
-						acceptedFileTypes = append(acceptedFileTypes, acceptedFileTypesItem.ValueString())
-					}
-				}
-				var fileInputField *shared.FileInputField
-				if fieldsItem.FileField.FileInputField != nil {
-					fileInputField = &shared.FileInputField{}
-				}
-				maxFileSize := new(string)
-				if !fieldsItem.FileField.MaxFileSize.IsUnknown() && !fieldsItem.FileField.MaxFileSize.IsNull() {
-					*maxFileSize = fieldsItem.FileField.MaxFileSize.ValueString()
-				} else {
-					maxFileSize = nil
-				}
-				fileField = &shared.FileField{
-					AcceptedFileTypes: acceptedFileTypes,
-					FileInputField:    fileInputField,
-					MaxFileSize:       maxFileSize,
-				}
-			}
-			var int64Field *shared.Int64Field
-			if fieldsItem.Int64Field != nil {
-				defaultValue1 := new(string)
-				if !fieldsItem.Int64Field.DefaultValue.IsUnknown() && !fieldsItem.Int64Field.DefaultValue.IsNull() {
-					*defaultValue1 = fieldsItem.Int64Field.DefaultValue.ValueString()
-				} else {
-					defaultValue1 = nil
-				}
-				var numberField *shared.NumberField
-				if fieldsItem.Int64Field.NumberField != nil {
-					maxValue := new(string)
-					if !fieldsItem.Int64Field.NumberField.MaxValue.IsUnknown() && !fieldsItem.Int64Field.NumberField.MaxValue.IsNull() {
-						*maxValue = fieldsItem.Int64Field.NumberField.MaxValue.ValueString()
-					} else {
-						maxValue = nil
-					}
-					minValue := new(string)
-					if !fieldsItem.Int64Field.NumberField.MinValue.IsUnknown() && !fieldsItem.Int64Field.NumberField.MinValue.IsNull() {
-						*minValue = fieldsItem.Int64Field.NumberField.MinValue.ValueString()
-					} else {
-						minValue = nil
-					}
-					step := new(string)
-					if !fieldsItem.Int64Field.NumberField.Step.IsUnknown() && !fieldsItem.Int64Field.NumberField.Step.IsNull() {
-						*step = fieldsItem.Int64Field.NumberField.Step.ValueString()
-					} else {
-						step = nil
-					}
-					numberField = &shared.NumberField{
-						MaxValue: maxValue,
-						MinValue: minValue,
-						Step:     step,
-					}
-				}
-				placeholder := new(string)
-				if !fieldsItem.Int64Field.Placeholder.IsUnknown() && !fieldsItem.Int64Field.Placeholder.IsNull() {
-					*placeholder = fieldsItem.Int64Field.Placeholder.ValueString()
-				} else {
-					placeholder = nil
-				}
-				var int64Rules *shared.Int64Rules
-				if fieldsItem.Int64Field.Int64Rules != nil {
-					constVar1 := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Const.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Const.IsNull() {
-						*constVar1 = fieldsItem.Int64Field.Int64Rules.Const.ValueString()
-					} else {
-						constVar1 = nil
-					}
-					gt := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Gt.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Gt.IsNull() {
-						*gt = fieldsItem.Int64Field.Int64Rules.Gt.ValueString()
-					} else {
-						gt = nil
-					}
-					gte := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Gte.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Gte.IsNull() {
-						*gte = fieldsItem.Int64Field.Int64Rules.Gte.ValueString()
-					} else {
-						gte = nil
-					}
-					ignoreEmpty := new(bool)
-					if !fieldsItem.Int64Field.Int64Rules.IgnoreEmpty.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.IgnoreEmpty.IsNull() {
-						*ignoreEmpty = fieldsItem.Int64Field.Int64Rules.IgnoreEmpty.ValueBool()
-					} else {
-						ignoreEmpty = nil
-					}
-					var in []string
-					if fieldsItem.Int64Field.Int64Rules.In != nil {
-						in = make([]string, 0, len(fieldsItem.Int64Field.Int64Rules.In))
-						for _, inItem := range fieldsItem.Int64Field.Int64Rules.In {
-							in = append(in, inItem.ValueString())
-						}
-					}
-					lt := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Lt.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Lt.IsNull() {
-						*lt = fieldsItem.Int64Field.Int64Rules.Lt.ValueString()
-					} else {
-						lt = nil
-					}
-					lte := new(string)
-					if !fieldsItem.Int64Field.Int64Rules.Lte.IsUnknown() && !fieldsItem.Int64Field.Int64Rules.Lte.IsNull() {
-						*lte = fieldsItem.Int64Field.Int64Rules.Lte.ValueString()
-					} else {
-						lte = nil
-					}
-					var notIn []string
-					if fieldsItem.Int64Field.Int64Rules.NotIn != nil {
-						notIn = make([]string, 0, len(fieldsItem.Int64Field.Int64Rules.NotIn))
-						for _, notInItem := range fieldsItem.Int64Field.Int64Rules.NotIn {
-							notIn = append(notIn, notInItem.ValueString())
-						}
-					}
-					int64Rules = &shared.Int64Rules{
-						Const:       constVar1,
-						Gt:          gt,
-						Gte:         gte,
-						IgnoreEmpty: ignoreEmpty,
-						In:          in,
-						Lt:          lt,
-						Lte:         lte,
-						NotIn:       notIn,
-					}
-				}
-				int64Field = &shared.Int64Field{
-					DefaultValue: defaultValue1,
-					NumberField:  numberField,
-					Placeholder:  placeholder,
-					Int64Rules:   int64Rules,
-				}
-			}
-			name := new(string)
-			if !fieldsItem.Name.IsUnknown() && !fieldsItem.Name.IsNull() {
-				*name = fieldsItem.Name.ValueString()
-			} else {
-				name = nil
-			}
-			var stringField *shared.FormStringField
-			if fieldsItem.FormStringField != nil {
-				defaultValue2 := new(string)
-				if !fieldsItem.FormStringField.DefaultValue.IsUnknown() && !fieldsItem.FormStringField.DefaultValue.IsNull() {
-					*defaultValue2 = fieldsItem.FormStringField.DefaultValue.ValueString()
-				} else {
-					defaultValue2 = nil
-				}
-				var passwordField *shared.PasswordField
-				if fieldsItem.FormStringField.PasswordField != nil {
-					passwordField = &shared.PasswordField{}
-				}
-				placeholder1 := new(string)
-				if !fieldsItem.FormStringField.Placeholder.IsUnknown() && !fieldsItem.FormStringField.Placeholder.IsNull() {
-					*placeholder1 = fieldsItem.FormStringField.Placeholder.ValueString()
-				} else {
-					placeholder1 = nil
-				}
-				var stringRules *shared.StringRules
-				if fieldsItem.FormStringField.StringRules != nil {
-					address := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Address.IsUnknown() && !fieldsItem.FormStringField.StringRules.Address.IsNull() {
-						*address = fieldsItem.FormStringField.StringRules.Address.ValueBool()
-					} else {
-						address = nil
-					}
-					constVar2 := new(string)
-					if !fieldsItem.FormStringField.StringRules.Const.IsUnknown() && !fieldsItem.FormStringField.StringRules.Const.IsNull() {
-						*constVar2 = fieldsItem.FormStringField.StringRules.Const.ValueString()
-					} else {
-						constVar2 = nil
-					}
-					contains := new(string)
-					if !fieldsItem.FormStringField.StringRules.Contains.IsUnknown() && !fieldsItem.FormStringField.StringRules.Contains.IsNull() {
-						*contains = fieldsItem.FormStringField.StringRules.Contains.ValueString()
-					} else {
-						contains = nil
-					}
-					email := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Email.IsUnknown() && !fieldsItem.FormStringField.StringRules.Email.IsNull() {
-						*email = fieldsItem.FormStringField.StringRules.Email.ValueBool()
-					} else {
-						email = nil
-					}
-					hostname := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Hostname.IsUnknown() && !fieldsItem.FormStringField.StringRules.Hostname.IsNull() {
-						*hostname = fieldsItem.FormStringField.StringRules.Hostname.ValueBool()
-					} else {
-						hostname = nil
-					}
-					ignoreEmpty1 := new(bool)
-					if !fieldsItem.FormStringField.StringRules.IgnoreEmpty.IsUnknown() && !fieldsItem.FormStringField.StringRules.IgnoreEmpty.IsNull() {
-						*ignoreEmpty1 = fieldsItem.FormStringField.StringRules.IgnoreEmpty.ValueBool()
-					} else {
-						ignoreEmpty1 = nil
-					}
-					var in1 []string
-					if fieldsItem.FormStringField.StringRules.In != nil {
-						in1 = make([]string, 0, len(fieldsItem.FormStringField.StringRules.In))
-						for _, inItem1 := range fieldsItem.FormStringField.StringRules.In {
-							in1 = append(in1, inItem1.ValueString())
-						}
-					}
-					ip := new(bool)
-					if !fieldsItem.FormStringField.StringRules.IP.IsUnknown() && !fieldsItem.FormStringField.StringRules.IP.IsNull() {
-						*ip = fieldsItem.FormStringField.StringRules.IP.ValueBool()
-					} else {
-						ip = nil
-					}
-					ipv4 := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Ipv4.IsUnknown() && !fieldsItem.FormStringField.StringRules.Ipv4.IsNull() {
-						*ipv4 = fieldsItem.FormStringField.StringRules.Ipv4.ValueBool()
-					} else {
-						ipv4 = nil
-					}
-					ipv6 := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Ipv6.IsUnknown() && !fieldsItem.FormStringField.StringRules.Ipv6.IsNull() {
-						*ipv6 = fieldsItem.FormStringField.StringRules.Ipv6.ValueBool()
-					} else {
-						ipv6 = nil
-					}
-					length := new(string)
-					if !fieldsItem.FormStringField.StringRules.Length.IsUnknown() && !fieldsItem.FormStringField.StringRules.Length.IsNull() {
-						*length = fieldsItem.FormStringField.StringRules.Length.ValueString()
-					} else {
-						length = nil
-					}
-					lenBytes := new(string)
-					if !fieldsItem.FormStringField.StringRules.LenBytes.IsUnknown() && !fieldsItem.FormStringField.StringRules.LenBytes.IsNull() {
-						*lenBytes = fieldsItem.FormStringField.StringRules.LenBytes.ValueString()
-					} else {
-						lenBytes = nil
-					}
-					maxBytes := new(string)
-					if !fieldsItem.FormStringField.StringRules.MaxBytes.IsUnknown() && !fieldsItem.FormStringField.StringRules.MaxBytes.IsNull() {
-						*maxBytes = fieldsItem.FormStringField.StringRules.MaxBytes.ValueString()
-					} else {
-						maxBytes = nil
-					}
-					maxLen := new(string)
-					if !fieldsItem.FormStringField.StringRules.MaxLen.IsUnknown() && !fieldsItem.FormStringField.StringRules.MaxLen.IsNull() {
-						*maxLen = fieldsItem.FormStringField.StringRules.MaxLen.ValueString()
-					} else {
-						maxLen = nil
-					}
-					minBytes := new(string)
-					if !fieldsItem.FormStringField.StringRules.MinBytes.IsUnknown() && !fieldsItem.FormStringField.StringRules.MinBytes.IsNull() {
-						*minBytes = fieldsItem.FormStringField.StringRules.MinBytes.ValueString()
-					} else {
-						minBytes = nil
-					}
-					minLen := new(string)
-					if !fieldsItem.FormStringField.StringRules.MinLen.IsUnknown() && !fieldsItem.FormStringField.StringRules.MinLen.IsNull() {
-						*minLen = fieldsItem.FormStringField.StringRules.MinLen.ValueString()
-					} else {
-						minLen = nil
-					}
-					notContains := new(string)
-					if !fieldsItem.FormStringField.StringRules.NotContains.IsUnknown() && !fieldsItem.FormStringField.StringRules.NotContains.IsNull() {
-						*notContains = fieldsItem.FormStringField.StringRules.NotContains.ValueString()
-					} else {
-						notContains = nil
-					}
-					var notIn1 []string
-					if fieldsItem.FormStringField.StringRules.NotIn != nil {
-						notIn1 = make([]string, 0, len(fieldsItem.FormStringField.StringRules.NotIn))
-						for _, notInItem1 := range fieldsItem.FormStringField.StringRules.NotIn {
-							notIn1 = append(notIn1, notInItem1.ValueString())
-						}
-					}
-					pattern := new(string)
-					if !fieldsItem.FormStringField.StringRules.Pattern.IsUnknown() && !fieldsItem.FormStringField.StringRules.Pattern.IsNull() {
-						*pattern = fieldsItem.FormStringField.StringRules.Pattern.ValueString()
-					} else {
-						pattern = nil
-					}
-					prefix := new(string)
-					if !fieldsItem.FormStringField.StringRules.Prefix.IsUnknown() && !fieldsItem.FormStringField.StringRules.Prefix.IsNull() {
-						*prefix = fieldsItem.FormStringField.StringRules.Prefix.ValueString()
-					} else {
-						prefix = nil
-					}
-					strict := new(bool)
-					if !fieldsItem.FormStringField.StringRules.Strict.IsUnknown() && !fieldsItem.FormStringField.StringRules.Strict.IsNull() {
-						*strict = fieldsItem.FormStringField.StringRules.Strict.ValueBool()
-					} else {
-						strict = nil
-					}
-					suffix := new(string)
-					if !fieldsItem.FormStringField.StringRules.Suffix.IsUnknown() && !fieldsItem.FormStringField.StringRules.Suffix.IsNull() {
-						*suffix = fieldsItem.FormStringField.StringRules.Suffix.ValueString()
-					} else {
-						suffix = nil
-					}
-					uri := new(bool)
-					if !fieldsItem.FormStringField.StringRules.URI.IsUnknown() && !fieldsItem.FormStringField.StringRules.URI.IsNull() {
-						*uri = fieldsItem.FormStringField.StringRules.URI.ValueBool()
-					} else {
-						uri = nil
-					}
-					uriRef := new(bool)
-					if !fieldsItem.FormStringField.StringRules.URIRef.IsUnknown() && !fieldsItem.FormStringField.StringRules.URIRef.IsNull() {
-						*uriRef = fieldsItem.FormStringField.StringRules.URIRef.ValueBool()
-					} else {
-						uriRef = nil
-					}
-					uuid := new(bool)
-					if !fieldsItem.FormStringField.StringRules.UUID.IsUnknown() && !fieldsItem.FormStringField.StringRules.UUID.IsNull() {
-						*uuid = fieldsItem.FormStringField.StringRules.UUID.ValueBool()
-					} else {
-						uuid = nil
-					}
-					wellKnownRegex := new(shared.WellKnownRegex)
-					if !fieldsItem.FormStringField.StringRules.WellKnownRegex.IsUnknown() && !fieldsItem.FormStringField.StringRules.WellKnownRegex.IsNull() {
-						*wellKnownRegex = shared.WellKnownRegex(fieldsItem.FormStringField.StringRules.WellKnownRegex.ValueString())
-					} else {
-						wellKnownRegex = nil
-					}
-					stringRules = &shared.StringRules{
-						Address:        address,
-						Const:          constVar2,
-						Contains:       contains,
-						Email:          email,
-						Hostname:       hostname,
-						IgnoreEmpty:    ignoreEmpty1,
-						In:             in1,
-						IP:             ip,
-						Ipv4:           ipv4,
-						Ipv6:           ipv6,
-						Length:         length,
-						LenBytes:       lenBytes,
-						MaxBytes:       maxBytes,
-						MaxLen:         maxLen,
-						MinBytes:       minBytes,
-						MinLen:         minLen,
-						NotContains:    notContains,
-						NotIn:          notIn1,
-						Pattern:        pattern,
-						Prefix:         prefix,
-						Strict:         strict,
-						Suffix:         suffix,
-						URI:            uri,
-						URIRef:         uriRef,
-						UUID:           uuid,
-						WellKnownRegex: wellKnownRegex,
-					}
-				}
-				var selectField *shared.SelectField
-				if fieldsItem.FormStringField.SelectField != nil {
-					var optionsVar []shared.SelectOption
-					if fieldsItem.FormStringField.SelectField.Options != nil {
-						optionsVar = make([]shared.SelectOption, 0, len(fieldsItem.FormStringField.SelectField.Options))
-						for _, optionsItem := range fieldsItem.FormStringField.SelectField.Options {
-							displayName1 := new(string)
-							if !optionsItem.DisplayName.IsUnknown() && !optionsItem.DisplayName.IsNull() {
-								*displayName1 = optionsItem.DisplayName.ValueString()
-							} else {
-								displayName1 = nil
-							}
-							value := new(string)
-							if !optionsItem.Value.IsUnknown() && !optionsItem.Value.IsNull() {
-								*value = optionsItem.Value.ValueString()
-							} else {
-								value = nil
-							}
-							optionsVar = append(optionsVar, shared.SelectOption{
-								DisplayName: displayName1,
-								Value:       value,
-							})
-						}
-					}
-					selectField = &shared.SelectField{
-						Options: optionsVar,
-					}
-				}
-				var textField *shared.TextField
-				if fieldsItem.FormStringField.TextField != nil {
-					multiline := new(bool)
-					if !fieldsItem.FormStringField.TextField.Multiline.IsUnknown() && !fieldsItem.FormStringField.TextField.Multiline.IsNull() {
-						*multiline = fieldsItem.FormStringField.TextField.Multiline.ValueBool()
-					} else {
-						multiline = nil
-					}
-					textField = &shared.TextField{
-						Multiline: multiline,
-					}
-				}
-				var pickerField *shared.PickerField
-				if fieldsItem.FormStringField.PickerField != nil {
-					var appResourceFilter *shared.AppResourceFilter
-					if fieldsItem.FormStringField.PickerField.AppResourceFilter != nil {
-						appResourceFilterAppID := new(string)
-						if !fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.IsNull() {
-							*appResourceFilterAppID = fieldsItem.FormStringField.PickerField.AppResourceFilter.AppID.ValueString()
-						} else {
-							appResourceFilterAppID = nil
-						}
-						appResourceFilterResourceTypeID := new(string)
-						if !fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.IsNull() {
-							*appResourceFilterResourceTypeID = fieldsItem.FormStringField.PickerField.AppResourceFilter.ResourceTypeID.ValueString()
-						} else {
-							appResourceFilterResourceTypeID = nil
-						}
-						appResourceFilter = &shared.AppResourceFilter{
-							AppID:          appResourceFilterAppID,
-							ResourceTypeID: appResourceFilterResourceTypeID,
-						}
-					}
-					var appUserFilter *shared.AppUserFilter
-					if fieldsItem.FormStringField.PickerField.AppUserFilter != nil {
-						appUserFilterAppID := new(string)
-						if !fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.IsUnknown() && !fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.IsNull() {
-							*appUserFilterAppID = fieldsItem.FormStringField.PickerField.AppUserFilter.AppID.ValueString()
-						} else {
-							appUserFilterAppID = nil
-						}
-						appUserFilter = &shared.AppUserFilter{
-							AppID: appUserFilterAppID,
-						}
-					}
-					var c1UserFilter *shared.C1UserFilter
-					if fieldsItem.FormStringField.PickerField.C1UserFilter != nil {
-						c1UserFilter = &shared.C1UserFilter{}
-					}
-					pickerField = &shared.PickerField{
-						AppUserFilter:     appUserFilter,
-						C1UserFilter:      c1UserFilter,
-						AppResourceFilter: appResourceFilter,
-					}
-				}
-				stringField = &shared.FormStringField{
-					DefaultValue:  defaultValue2,
-					PasswordField: passwordField,
-					Placeholder:   placeholder1,
-					StringRules:   stringRules,
-					SelectField:   selectField,
-					TextField:     textField,
-					PickerField:   pickerField,
-				}
-			}
-			var adminProviderConfig *shared.AdminProviderConfig
-			if fieldsItem.AdminProviderConfig != nil {
-				adminDefaultValueCel := new(string)
-				if !fieldsItem.AdminProviderConfig.DefaultValueCel.IsUnknown() && !fieldsItem.AdminProviderConfig.DefaultValueCel.IsNull() {
-					*adminDefaultValueCel = fieldsItem.AdminProviderConfig.DefaultValueCel.ValueString()
-				} else {
-					adminDefaultValueCel = nil
-				}
-				adminShowToUser := new(bool)
-				if !fieldsItem.AdminProviderConfig.ShowToUser.IsUnknown() && !fieldsItem.AdminProviderConfig.ShowToUser.IsNull() {
-					*adminShowToUser = fieldsItem.AdminProviderConfig.ShowToUser.ValueBool()
-				} else {
-					adminShowToUser = nil
-				}
-				adminProviderConfig = &shared.AdminProviderConfig{
-					DefaultValueCel: adminDefaultValueCel,
-					ShowToUser:      adminShowToUser,
-				}
-			}
-			var sharedProviderConfig *shared.SharedProviderConfig
-			if fieldsItem.SharedProviderConfig != nil {
-				sharedDefaultValueCel := new(string)
-				if !fieldsItem.SharedProviderConfig.DefaultValueCel.IsUnknown() && !fieldsItem.SharedProviderConfig.DefaultValueCel.IsNull() {
-					*sharedDefaultValueCel = fieldsItem.SharedProviderConfig.DefaultValueCel.ValueString()
-				} else {
-					sharedDefaultValueCel = nil
-				}
-				sharedInputTransformationCel := new(string)
-				if !fieldsItem.SharedProviderConfig.InputTransformationCel.IsUnknown() && !fieldsItem.SharedProviderConfig.InputTransformationCel.IsNull() {
-					*sharedInputTransformationCel = fieldsItem.SharedProviderConfig.InputTransformationCel.ValueString()
-				} else {
-					sharedInputTransformationCel = nil
-				}
-				sharedLockDefaultValues := new(bool)
-				if !fieldsItem.SharedProviderConfig.LockDefaultValues.IsUnknown() && !fieldsItem.SharedProviderConfig.LockDefaultValues.IsNull() {
-					*sharedLockDefaultValues = fieldsItem.SharedProviderConfig.LockDefaultValues.ValueBool()
-				} else {
-					sharedLockDefaultValues = nil
-				}
-				sharedProviderConfig = &shared.SharedProviderConfig{
-					DefaultValueCel:        sharedDefaultValueCel,
-					InputTransformationCel: sharedInputTransformationCel,
-					LockDefaultValues:      sharedLockDefaultValues,
-				}
-			}
-			var userProviderConfig *shared.UserProviderConfig
-			if fieldsItem.UserProviderConfig != nil {
-				userInputTransformationCel := new(string)
-				if !fieldsItem.UserProviderConfig.InputTransformationCel.IsUnknown() && !fieldsItem.UserProviderConfig.InputTransformationCel.IsNull() {
-					*userInputTransformationCel = fieldsItem.UserProviderConfig.InputTransformationCel.ValueString()
-				} else {
-					userInputTransformationCel = nil
-				}
-				userProviderConfig = &shared.UserProviderConfig{
-					InputTransformationCel: userInputTransformationCel,
-				}
-			}
-			var oauth2Field *shared.Oauth2Field
-			if fieldsItem.Oauth2Field != nil {
-				var oauth2FieldView *shared.Oauth2FieldView
-				if fieldsItem.Oauth2Field.Oauth2FieldView != nil {
-					oauth2FieldView = &shared.Oauth2FieldView{}
-				}
-				oauth2Field = &shared.Oauth2Field{
-					Oauth2FieldView: oauth2FieldView,
-				}
-			}
-			var formStringMapField *shared.FormStringMapField
-			if fieldsItem.FormStringMapField != nil {
-				var stringMapDefaultValue map[string]string
-				if fieldsItem.FormStringMapField.DefaultValue != nil {
-					stringMapDefaultValue = make(map[string]string, len(fieldsItem.FormStringMapField.DefaultValue))
-					for stringMapKey, stringMapVal := range fieldsItem.FormStringMapField.DefaultValue {
-						stringMapDefaultValue[stringMapKey] = stringMapVal.ValueString()
-					}
-				}
-				var stringMapRules *shared.StringMapRules
-				if fieldsItem.FormStringMapField.StringMapRules != nil {
-					stringMapIsRequired := new(bool)
-					if !fieldsItem.FormStringMapField.StringMapRules.IsRequired.IsUnknown() && !fieldsItem.FormStringMapField.StringMapRules.IsRequired.IsNull() {
-						*stringMapIsRequired = fieldsItem.FormStringMapField.StringMapRules.IsRequired.ValueBool()
-					} else {
-						stringMapIsRequired = nil
-					}
-					stringMapValidateEmpty := new(bool)
-					if !fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.IsUnknown() && !fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.IsNull() {
-						*stringMapValidateEmpty = fieldsItem.FormStringMapField.StringMapRules.ValidateEmpty.ValueBool()
-					} else {
-						stringMapValidateEmpty = nil
-					}
-					stringMapRules = &shared.StringMapRules{
-						IsRequired:    stringMapIsRequired,
-						ValidateEmpty: stringMapValidateEmpty,
-					}
-				}
-				formStringMapField = &shared.FormStringMapField{
-					DefaultValue:   stringMapDefaultValue,
-					StringMapRules: stringMapRules,
-				}
-			}
-			readOnly := new(bool)
-			if !fieldsItem.ReadOnly.IsUnknown() && !fieldsItem.ReadOnly.IsNull() {
-				*readOnly = fieldsItem.ReadOnly.ValueBool()
-			} else {
-				readOnly = nil
-			}
-			required := new(bool)
-			if !fieldsItem.Required.IsUnknown() && !fieldsItem.Required.IsNull() {
-				*required = fieldsItem.Required.ValueBool()
-			} else {
-				required = nil
-			}
-			fields = append(fields, shared.FormField{
-				AdminProviderConfig:  adminProviderConfig,
 				Oauth2Field:          oauth2Field,
 				ReadOnly:             readOnly,
 				Required:             required,
 				SharedProviderConfig: sharedProviderConfig,
+				FormStringField:      formStringField,
 				FormStringMapField:   formStringMapField,
 				UserProviderConfig:   userProviderConfig,
-				BoolField:            boolField,
-				Description:          description1,
-				DisplayName:          displayName,
-				FileField:            fileField,
-				Int64Field:           int64Field,
-				Name:                 name,
-				FormStringField:      stringField,
 			})
 		}
 	}
-	name1 := new(string)
-	if !r.Name.IsUnknown() && !r.Name.IsNull() {
-		*name1 = r.Name.ValueString()
+	justificationVisibility := new(shared.JustificationVisibility)
+	if !r.JustificationVisibility.IsUnknown() && !r.JustificationVisibility.IsNull() {
+		*justificationVisibility = shared.JustificationVisibility(r.JustificationVisibility.ValueString())
 	} else {
-		name1 = nil
+		justificationVisibility = nil
+	}
+	name2 := new(string)
+	if !r.Name.IsUnknown() && !r.Name.IsNull() {
+		*name2 = r.Name.ValueString()
+	} else {
+		name2 = nil
 	}
 	out := shared.RequestSchemaServiceCreateRequest{
-		Description: description,
-		Fields:      fields,
-		Name:        name1,
+		Description:             description,
+		FieldGroups:             fieldGroups,
+		FieldRelationships:      fieldRelationships,
+		Fields:                  fields1,
+		JustificationVisibility: justificationVisibility,
+		Name:                    name2,
 	}
+
+	return &out, diags
+}
+
+func (r *RequestSchemaResourceModel) ToSharedRequestSchemaServiceDeleteRequest(ctx context.Context) (*shared.RequestSchemaServiceDeleteRequest, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	out := shared.RequestSchemaServiceDeleteRequest{}
 
 	return &out, diags
 }

--- a/internal/provider/request_schema_resource_test.go
+++ b/internal/provider/request_schema_resource_test.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// TestAccRequestSchemaResource is the IGA-743 convergence acceptance test: it
+// proves against a live ConductorOne API that a conductorone_request_schema
+// reaches an EMPTY post-apply plan. This is the live counterpart to the
+// schema-level unit assertion in request_schema_convergence_test.go, which can
+// only confirm the SuppressDiff plan modifiers are wired — not that they
+// actually settle the plan against real server-derived values.
+//
+// The crash fix on this branch stopped the "Value Conversion Error", but
+// several server-derived computed attributes still re-planned as
+// "(known after apply)" on every plan after the first apply, so a config that
+// already matched the read-back never converged. The fix marks each via
+// x-speakeasy-param-suppress-computed-diff in overlay.yaml:
+//
+//	created_at, justification_visibility, field_groups, field_relationships,
+//	and the nested fields[].name.
+//
+// The config below mirrors the original repro (a single bool_field with
+// default_value) and intentionally leaves every server-derived attribute
+// UNSET — including the nested fields[].name, which the API derives and
+// normalizes server-side. That is what makes this a real convergence test:
+// those attributes are populated only by the server, so an empty plan can hold
+// only if their SuppressDiff modifiers propagate the prior state value when the
+// planned value is unknown, instead of re-planning as "(known after apply)".
+// (Setting fields[].name explicitly would not exercise the fix — SuppressDiff
+// is a no-op for an explicit config value, and the server's normalized name
+// would then perpetually mismatch the literal.) The empty-plan assertion runs
+// on BOTH the pre-refresh plan (state vs config) and the post-refresh plan
+// (live read-back vs config).
+//
+// ExpectEmptyPlanWithDriftLog is used instead of plancheck.ExpectEmptyPlan so
+// that, on a non-empty plan, the CI log names the exact attribute path(s) that
+// drifted (paths only, never values) rather than the bare
+// "...has planned action(s): [update]".
+func TestAccRequestSchemaResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+				resource "conductorone_request_schema" "test" {
+					name = "tf-acc-request-schema-iga-743"
+					fields = [
+						{
+							display_name = "Approved"
+							description  = "Approve the request"
+							bool_field = {
+								default_value = true
+							}
+						}
+					]
+				}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("conductorone_request_schema.test", "name", "tf-acc-request-schema-iga-743"),
+					resource.TestCheckResourceAttr("conductorone_request_schema.test", "fields.0.display_name", "Approved"),
+					resource.TestCheckResourceAttr("conductorone_request_schema.test", "fields.0.bool_field.default_value", "true"),
+					// Server-derived; left unset in config. Presence in state proves
+					// the read-back populated them and the plan still converged.
+					resource.TestCheckResourceAttrSet("conductorone_request_schema.test", "id"),
+					resource.TestCheckResourceAttrSet("conductorone_request_schema.test", "created_at"),
+				),
+				// The convergence assertion: no diff on either the pre-refresh
+				// plan or the post-refresh plan immediately after apply.
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						ExpectEmptyPlanWithDriftLog(t),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						ExpectEmptyPlanWithDriftLog(t),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/request_schema_roundtrip_test.go
+++ b/internal/provider/request_schema_roundtrip_test.go
@@ -11,8 +11,8 @@ import (
 
 // TestRequestSchemaFormFieldRoundTrips exercises the full Terraform <-> API
 // conversion for every FormField union variant. For each case we build a
-// resource model, convert it to the shared API model (ToSharedForm), convert
-// the result back (RefreshFromSharedForm), and assert the field survives the
+// resource model, convert it to the shared API model (ToSharedRequestSchemaForm), convert
+// the result back (RefreshFromSharedRequestSchemaForm), and assert the field survives the
 // round-trip unchanged.
 //
 // This covers the IGA-743 customer repro (a bool_field with default_value), the
@@ -106,14 +106,14 @@ func TestRequestSchemaFormFieldRoundTrips(t *testing.T) {
 				Fields: []tfTypes.FormField{field},
 			}
 
-			apiForm, diags := in.ToSharedForm(ctx)
+			apiForm, diags := in.ToSharedRequestSchemaForm(ctx)
 			if diags.HasError() {
-				t.Fatalf("ToSharedForm: %v", diags)
+				t.Fatalf("ToSharedRequestSchemaForm: %v", diags)
 			}
 
 			out := &RequestSchemaResourceModel{}
-			if d := out.RefreshFromSharedForm(ctx, apiForm); d.HasError() {
-				t.Fatalf("RefreshFromSharedForm: %v", d)
+			if d := out.RefreshFromSharedRequestSchemaForm(ctx, apiForm); d.HasError() {
+				t.Fatalf("RefreshFromSharedRequestSchemaForm: %v", d)
 			}
 
 			if len(out.Fields) != 1 {

--- a/internal/provider/request_schema_roundtrip_test.go
+++ b/internal/provider/request_schema_roundtrip_test.go
@@ -1,0 +1,127 @@
+package provider
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestRequestSchemaFormFieldRoundTrips exercises the full Terraform <-> API
+// conversion for every FormField union variant. For each case we build a
+// resource model, convert it to the shared API model (ToSharedForm), convert
+// the result back (RefreshFromSharedForm), and assert the field survives the
+// round-trip unchanged.
+//
+// This covers the IGA-743 customer repro (a bool_field with default_value), the
+// the all-variants-null workaround (a field with all union variants left null), and one field of
+// each remaining union variant — including the new variants added at v1.3.0
+// (oauth2_field, *_provider_config, form_string_map_field, read_only, required)
+// that the genignored conversion previously dropped.
+func TestRequestSchemaFormFieldRoundTrips(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]tfTypes.FormField{
+		// IGA-743 customer repro.
+		"bool_field": {
+			Name:        types.StringValue("approved"),
+			Description: types.StringValue("Approve the request"),
+			DisplayName: types.StringValue("Approved"),
+			BoolField:   &tfTypes.BoolField{DefaultValue: types.BoolValue(true)},
+		},
+		// All-variants-null workaround: every union variant explicitly null, only metadata set.
+		"all_variants_null": {
+			Name:        types.StringValue("justification"),
+			Description: types.StringValue("Why do you need this?"),
+			DisplayName: types.StringValue("Justification"),
+		},
+		"form_string_field": {
+			Name: types.StringValue("reason"),
+			FormStringField: &tfTypes.FormStringField{
+				DefaultValue: types.StringValue("n/a"),
+				Placeholder:  types.StringValue("enter a reason"),
+			},
+		},
+		"form_string_field_picker": {
+			Name: types.StringValue("owner"),
+			FormStringField: &tfTypes.FormStringField{
+				PickerField: &tfTypes.PickerField{
+					AppResourceFilter: &tfTypes.AppResourceFilter{
+						AppID:          types.StringValue("app-123"),
+						ResourceTypeID: types.StringValue("rt-456"),
+					},
+					AppUserFilter: &tfTypes.AppUserFilter{AppID: types.StringValue("app-789")},
+					C1UserFilter:  &tfTypes.C1UserFilter{},
+				},
+			},
+		},
+		"int64_field": {
+			Name:       types.StringValue("count"),
+			Int64Field: &tfTypes.Int64Field{DefaultValue: types.StringValue("7")},
+		},
+		"file_field": {
+			Name:      types.StringValue("attachment"),
+			FileField: &tfTypes.FileField{MaxFileSize: types.StringValue("1048576")},
+		},
+		"form_string_map_field": {
+			Name: types.StringValue("labels"),
+			FormStringMapField: &tfTypes.FormStringMapField{
+				DefaultValue:   map[string]types.String{"team": types.StringValue("platform")},
+				StringMapRules: &tfTypes.StringMapRules{IsRequired: types.BoolValue(true), ValidateEmpty: types.BoolValue(false)},
+			},
+		},
+		"oauth2_field": {
+			Name:        types.StringValue("oauth"),
+			Oauth2Field: &tfTypes.Oauth2Field{Oauth2FieldView: &tfTypes.Oauth2FieldView{}},
+		},
+		"admin_provider_config": {
+			Name:                types.StringValue("admin_cfg"),
+			AdminProviderConfig: &tfTypes.AdminProviderConfig{DefaultValueCel: types.StringValue("true"), ShowToUser: types.BoolValue(true)},
+		},
+		"shared_provider_config": {
+			Name: types.StringValue("shared_cfg"),
+			SharedProviderConfig: &tfTypes.SharedProviderConfig{
+				DefaultValueCel:        types.StringValue("a"),
+				InputTransformationCel: types.StringValue("b"),
+				LockDefaultValues:      types.BoolValue(true),
+			},
+		},
+		"user_provider_config": {
+			Name:               types.StringValue("user_cfg"),
+			UserProviderConfig: &tfTypes.UserProviderConfig{InputTransformationCel: types.StringValue("c")},
+		},
+		"read_only_and_required": {
+			Name:     types.StringValue("ro_req"),
+			ReadOnly: types.BoolValue(true),
+			Required: types.BoolValue(true),
+		},
+	}
+
+	for name, field := range cases {
+		t.Run(name, func(t *testing.T) {
+			in := &RequestSchemaResourceModel{
+				Name:   types.StringValue("schema"),
+				Fields: []tfTypes.FormField{field},
+			}
+
+			apiForm, diags := in.ToSharedForm(ctx)
+			if diags.HasError() {
+				t.Fatalf("ToSharedForm: %v", diags)
+			}
+
+			out := &RequestSchemaResourceModel{}
+			if d := out.RefreshFromSharedForm(ctx, apiForm); d.HasError() {
+				t.Fatalf("RefreshFromSharedForm: %v", d)
+			}
+
+			if len(out.Fields) != 1 {
+				t.Fatalf("expected 1 field after round-trip, got %d", len(out.Fields))
+			}
+			if !reflect.DeepEqual(in.Fields[0], out.Fields[0]) {
+				t.Errorf("field did not round-trip\n in: %#v\nout: %#v", in.Fields[0], out.Fields[0])
+			}
+		})
+	}
+}

--- a/internal/provider/request_schema_schema_symmetry_test.go
+++ b/internal/provider/request_schema_schema_symmetry_test.go
@@ -1,0 +1,81 @@
+package provider
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+
+	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// TestRequestSchemaFieldsMatchFormFieldStruct guards against the IGA-743 drift.
+//
+// request_schema_resource.go and request_schema_resource_sdk.go are listed in
+// .genignore, so Speakeasy does not regenerate them. The conversion type
+// tfTypes.FormField (internal/provider/types/form_field.go) is generated and
+// NOT genignored, so it moves forward on every regen. When the two diverge,
+// the terraform-plugin-framework reflection that maps the schema's "fields"
+// object onto []tfTypes.FormField fails at runtime with:
+//
+//	mismatch between struct and object: Struct defines fields not found in
+//	object: ... Object defines fields not found in struct: ...
+//
+// This is exactly the customer-facing "Value Conversion Error" reported in
+// IGA-743 / GitHub #196 (broken 1.0.30 .. 1.3.0). This test asserts the
+// invariant directly: every tfsdk tag on FormField has a matching attribute in
+// the resource schema's "fields" nested object, and vice versa.
+func TestRequestSchemaFieldsMatchFormFieldStruct(t *testing.T) {
+	ctx := context.Background()
+	resp := &resource.SchemaResponse{}
+	NewRequestSchemaResource().Schema(ctx, resource.SchemaRequest{}, resp)
+
+	fieldsAttr, ok := resp.Schema.Attributes["fields"]
+	if !ok {
+		t.Fatal(`resource schema has no "fields" attribute`)
+	}
+	listNested, ok := fieldsAttr.(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf(`"fields" is %T, want schema.ListNestedAttribute`, fieldsAttr)
+	}
+
+	schemaAttrs := map[string]bool{}
+	for name := range listNested.NestedObject.Attributes {
+		schemaAttrs[name] = true
+	}
+
+	structTags := map[string]bool{}
+	rt := reflect.TypeOf(tfTypes.FormField{})
+	for i := 0; i < rt.NumField(); i++ {
+		if tag, ok := rt.Field(i).Tag.Lookup("tfsdk"); ok {
+			structTags[tag] = true
+		}
+	}
+
+	for tag := range structTags {
+		if !schemaAttrs[tag] {
+			t.Errorf("FormField struct defines tfsdk:%q with no matching attribute in the resource schema \"fields\" object", tag)
+		}
+	}
+	for name := range schemaAttrs {
+		if !structTags[name] {
+			t.Errorf("resource schema \"fields\" object defines attribute %q with no matching field on the FormField struct", name)
+		}
+	}
+
+	if t.Failed() {
+		t.Logf("schema \"fields\" attributes: %v", sortedKeys(schemaAttrs))
+		t.Logf("FormField struct tfsdk tags: %v", sortedKeys(structTags))
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/provider/taskgrant_resource.go
+++ b/internal/provider/taskgrant_resource.go
@@ -5,6 +5,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	speakeasy_boolplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/boolplanmodifier"
+	speakeasy_listplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/listplanmodifier"
+	speakeasy_objectplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/objectplanmodifier"
+	speakeasy_stringplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -1160,27 +1164,48 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 																},
 																"field_groups": schema.ListNestedAttribute{
 																	Computed: true,
+																	PlanModifiers: []planmodifier.List{
+																		speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																	},
 																	NestedObject: schema.NestedAttributeObject{
+																		PlanModifiers: []planmodifier.Object{
+																			speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																		},
 																		Attributes: map[string]schema.Attribute{
 																			"default": schema.BoolAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Bool{
+																					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The default field.`,
 																			},
 																			"display_name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The displayName field.`,
 																			},
 																			"fields": schema.ListAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.List{
+																					speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																				},
 																				ElementType: types.StringType,
 																				Description: `The fields field.`,
 																			},
 																			"help_text": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The helpText field.`,
 																			},
 																			"name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The name field.`,
 																			},
 																		},
@@ -1189,17 +1214,32 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 																},
 																"field_relationships": schema.ListNestedAttribute{
 																	Computed: true,
+																	PlanModifiers: []planmodifier.List{
+																		speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																	},
 																	NestedObject: schema.NestedAttributeObject{
+																		PlanModifiers: []planmodifier.Object{
+																			speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																		},
 																		Attributes: map[string]schema.Attribute{
 																			"at_least_one": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The AtLeastOne message.`,
 																			},
 																			"dependent_on": schema.SingleNestedAttribute{
 																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Attributes: map[string]schema.Attribute{
 																					"dependency_field_names": schema.ListAttribute{
-																						Computed:    true,
+																						Computed: true,
+																						PlanModifiers: []planmodifier.List{
+																							speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																						},
 																						ElementType: types.StringType,
 																						Description: `The fields that must be present for the primary field_names to be valid`,
 																					},
@@ -1208,16 +1248,25 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 																					` in dependency_field_names are also present`,
 																			},
 																			"field_names": schema.ListAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.List{
+																					speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																				},
 																				ElementType: types.StringType,
 																				Description: `The names of the fields that share this relationship`,
 																			},
 																			"mutually_exclusive": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The MutuallyExclusive message.`,
 																			},
 																			"required_together": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The RequiredTogether message.`,
 																			},
 																		},
@@ -1698,7 +1747,10 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 																					`  - numberField`,
 																			},
 																			"name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The name field.`,
 																			},
 																			"oauth2_field": schema.SingleNestedAttribute{
@@ -5188,27 +5240,48 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 															},
 															"field_groups": schema.ListNestedAttribute{
 																Computed: true,
+																PlanModifiers: []planmodifier.List{
+																	speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																},
 																NestedObject: schema.NestedAttributeObject{
+																	PlanModifiers: []planmodifier.Object{
+																		speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																	},
 																	Attributes: map[string]schema.Attribute{
 																		"default": schema.BoolAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Bool{
+																				speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The default field.`,
 																		},
 																		"display_name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The displayName field.`,
 																		},
 																		"fields": schema.ListAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.List{
+																				speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																			},
 																			ElementType: types.StringType,
 																			Description: `The fields field.`,
 																		},
 																		"help_text": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The helpText field.`,
 																		},
 																		"name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The name field.`,
 																		},
 																	},
@@ -5217,17 +5290,32 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 															},
 															"field_relationships": schema.ListNestedAttribute{
 																Computed: true,
+																PlanModifiers: []planmodifier.List{
+																	speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																},
 																NestedObject: schema.NestedAttributeObject{
+																	PlanModifiers: []planmodifier.Object{
+																		speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																	},
 																	Attributes: map[string]schema.Attribute{
 																		"at_least_one": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The AtLeastOne message.`,
 																		},
 																		"dependent_on": schema.SingleNestedAttribute{
 																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Attributes: map[string]schema.Attribute{
 																				"dependency_field_names": schema.ListAttribute{
-																					Computed:    true,
+																					Computed: true,
+																					PlanModifiers: []planmodifier.List{
+																						speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																					},
 																					ElementType: types.StringType,
 																					Description: `The fields that must be present for the primary field_names to be valid`,
 																				},
@@ -5236,16 +5324,25 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 																				` in dependency_field_names are also present`,
 																		},
 																		"field_names": schema.ListAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.List{
+																				speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																			},
 																			ElementType: types.StringType,
 																			Description: `The names of the fields that share this relationship`,
 																		},
 																		"mutually_exclusive": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The MutuallyExclusive message.`,
 																		},
 																		"required_together": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The RequiredTogether message.`,
 																		},
 																	},
@@ -5726,7 +5823,10 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 																				`  - numberField`,
 																		},
 																		"name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The name field.`,
 																		},
 																		"oauth2_field": schema.SingleNestedAttribute{
@@ -6461,27 +6561,48 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 									},
 									"field_groups": schema.ListNestedAttribute{
 										Computed: true,
+										PlanModifiers: []planmodifier.List{
+											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+										},
 										NestedObject: schema.NestedAttributeObject{
+											PlanModifiers: []planmodifier.Object{
+												speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+											},
 											Attributes: map[string]schema.Attribute{
 												"default": schema.BoolAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Bool{
+														speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+													},
 													Description: `The default field.`,
 												},
 												"display_name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The displayName field.`,
 												},
 												"fields": schema.ListAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.List{
+														speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+													},
 													ElementType: types.StringType,
 													Description: `The fields field.`,
 												},
 												"help_text": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The helpText field.`,
 												},
 												"name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The name field.`,
 												},
 											},
@@ -6490,17 +6611,32 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 									},
 									"field_relationships": schema.ListNestedAttribute{
 										Computed: true,
+										PlanModifiers: []planmodifier.List{
+											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+										},
 										NestedObject: schema.NestedAttributeObject{
+											PlanModifiers: []planmodifier.Object{
+												speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+											},
 											Attributes: map[string]schema.Attribute{
 												"at_least_one": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The AtLeastOne message.`,
 												},
 												"dependent_on": schema.SingleNestedAttribute{
 													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Attributes: map[string]schema.Attribute{
 														"dependency_field_names": schema.ListAttribute{
-															Computed:    true,
+															Computed: true,
+															PlanModifiers: []planmodifier.List{
+																speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+															},
 															ElementType: types.StringType,
 															Description: `The fields that must be present for the primary field_names to be valid`,
 														},
@@ -6509,16 +6645,25 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 														` in dependency_field_names are also present`,
 												},
 												"field_names": schema.ListAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.List{
+														speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+													},
 													ElementType: types.StringType,
 													Description: `The names of the fields that share this relationship`,
 												},
 												"mutually_exclusive": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The MutuallyExclusive message.`,
 												},
 												"required_together": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The RequiredTogether message.`,
 												},
 											},
@@ -6999,7 +7144,10 @@ func (r *TaskGrantResource) Schema(ctx context.Context, req resource.SchemaReque
 														`  - numberField`,
 												},
 												"name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The name field.`,
 												},
 												"oauth2_field": schema.SingleNestedAttribute{

--- a/internal/provider/taskoffboarding_resource.go
+++ b/internal/provider/taskoffboarding_resource.go
@@ -5,6 +5,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	speakeasy_boolplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/boolplanmodifier"
+	speakeasy_listplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/listplanmodifier"
+	speakeasy_objectplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/objectplanmodifier"
+	speakeasy_stringplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -1065,27 +1069,48 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 																},
 																"field_groups": schema.ListNestedAttribute{
 																	Computed: true,
+																	PlanModifiers: []planmodifier.List{
+																		speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																	},
 																	NestedObject: schema.NestedAttributeObject{
+																		PlanModifiers: []planmodifier.Object{
+																			speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																		},
 																		Attributes: map[string]schema.Attribute{
 																			"default": schema.BoolAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Bool{
+																					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The default field.`,
 																			},
 																			"display_name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The displayName field.`,
 																			},
 																			"fields": schema.ListAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.List{
+																					speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																				},
 																				ElementType: types.StringType,
 																				Description: `The fields field.`,
 																			},
 																			"help_text": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The helpText field.`,
 																			},
 																			"name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The name field.`,
 																			},
 																		},
@@ -1094,17 +1119,32 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 																},
 																"field_relationships": schema.ListNestedAttribute{
 																	Computed: true,
+																	PlanModifiers: []planmodifier.List{
+																		speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																	},
 																	NestedObject: schema.NestedAttributeObject{
+																		PlanModifiers: []planmodifier.Object{
+																			speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																		},
 																		Attributes: map[string]schema.Attribute{
 																			"at_least_one": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The AtLeastOne message.`,
 																			},
 																			"dependent_on": schema.SingleNestedAttribute{
 																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Attributes: map[string]schema.Attribute{
 																					"dependency_field_names": schema.ListAttribute{
-																						Computed:    true,
+																						Computed: true,
+																						PlanModifiers: []planmodifier.List{
+																							speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																						},
 																						ElementType: types.StringType,
 																						Description: `The fields that must be present for the primary field_names to be valid`,
 																					},
@@ -1113,16 +1153,25 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 																					` in dependency_field_names are also present`,
 																			},
 																			"field_names": schema.ListAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.List{
+																					speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																				},
 																				ElementType: types.StringType,
 																				Description: `The names of the fields that share this relationship`,
 																			},
 																			"mutually_exclusive": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The MutuallyExclusive message.`,
 																			},
 																			"required_together": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The RequiredTogether message.`,
 																			},
 																		},
@@ -1603,7 +1652,10 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 																					`  - numberField`,
 																			},
 																			"name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The name field.`,
 																			},
 																			"oauth2_field": schema.SingleNestedAttribute{
@@ -5093,27 +5145,48 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 															},
 															"field_groups": schema.ListNestedAttribute{
 																Computed: true,
+																PlanModifiers: []planmodifier.List{
+																	speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																},
 																NestedObject: schema.NestedAttributeObject{
+																	PlanModifiers: []planmodifier.Object{
+																		speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																	},
 																	Attributes: map[string]schema.Attribute{
 																		"default": schema.BoolAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Bool{
+																				speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The default field.`,
 																		},
 																		"display_name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The displayName field.`,
 																		},
 																		"fields": schema.ListAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.List{
+																				speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																			},
 																			ElementType: types.StringType,
 																			Description: `The fields field.`,
 																		},
 																		"help_text": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The helpText field.`,
 																		},
 																		"name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The name field.`,
 																		},
 																	},
@@ -5122,17 +5195,32 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 															},
 															"field_relationships": schema.ListNestedAttribute{
 																Computed: true,
+																PlanModifiers: []planmodifier.List{
+																	speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																},
 																NestedObject: schema.NestedAttributeObject{
+																	PlanModifiers: []planmodifier.Object{
+																		speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																	},
 																	Attributes: map[string]schema.Attribute{
 																		"at_least_one": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The AtLeastOne message.`,
 																		},
 																		"dependent_on": schema.SingleNestedAttribute{
 																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Attributes: map[string]schema.Attribute{
 																				"dependency_field_names": schema.ListAttribute{
-																					Computed:    true,
+																					Computed: true,
+																					PlanModifiers: []planmodifier.List{
+																						speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																					},
 																					ElementType: types.StringType,
 																					Description: `The fields that must be present for the primary field_names to be valid`,
 																				},
@@ -5141,16 +5229,25 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 																				` in dependency_field_names are also present`,
 																		},
 																		"field_names": schema.ListAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.List{
+																				speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																			},
 																			ElementType: types.StringType,
 																			Description: `The names of the fields that share this relationship`,
 																		},
 																		"mutually_exclusive": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The MutuallyExclusive message.`,
 																		},
 																		"required_together": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The RequiredTogether message.`,
 																		},
 																	},
@@ -5631,7 +5728,10 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 																				`  - numberField`,
 																		},
 																		"name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The name field.`,
 																		},
 																		"oauth2_field": schema.SingleNestedAttribute{
@@ -6366,27 +6466,48 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 									},
 									"field_groups": schema.ListNestedAttribute{
 										Computed: true,
+										PlanModifiers: []planmodifier.List{
+											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+										},
 										NestedObject: schema.NestedAttributeObject{
+											PlanModifiers: []planmodifier.Object{
+												speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+											},
 											Attributes: map[string]schema.Attribute{
 												"default": schema.BoolAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Bool{
+														speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+													},
 													Description: `The default field.`,
 												},
 												"display_name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The displayName field.`,
 												},
 												"fields": schema.ListAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.List{
+														speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+													},
 													ElementType: types.StringType,
 													Description: `The fields field.`,
 												},
 												"help_text": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The helpText field.`,
 												},
 												"name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The name field.`,
 												},
 											},
@@ -6395,17 +6516,32 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 									},
 									"field_relationships": schema.ListNestedAttribute{
 										Computed: true,
+										PlanModifiers: []planmodifier.List{
+											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+										},
 										NestedObject: schema.NestedAttributeObject{
+											PlanModifiers: []planmodifier.Object{
+												speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+											},
 											Attributes: map[string]schema.Attribute{
 												"at_least_one": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The AtLeastOne message.`,
 												},
 												"dependent_on": schema.SingleNestedAttribute{
 													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Attributes: map[string]schema.Attribute{
 														"dependency_field_names": schema.ListAttribute{
-															Computed:    true,
+															Computed: true,
+															PlanModifiers: []planmodifier.List{
+																speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+															},
 															ElementType: types.StringType,
 															Description: `The fields that must be present for the primary field_names to be valid`,
 														},
@@ -6414,16 +6550,25 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 														` in dependency_field_names are also present`,
 												},
 												"field_names": schema.ListAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.List{
+														speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+													},
 													ElementType: types.StringType,
 													Description: `The names of the fields that share this relationship`,
 												},
 												"mutually_exclusive": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The MutuallyExclusive message.`,
 												},
 												"required_together": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The RequiredTogether message.`,
 												},
 											},
@@ -6904,7 +7049,10 @@ func (r *TaskOffboardingResource) Schema(ctx context.Context, req resource.Schem
 														`  - numberField`,
 												},
 												"name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The name field.`,
 												},
 												"oauth2_field": schema.SingleNestedAttribute{

--- a/internal/provider/taskrevoke_resource.go
+++ b/internal/provider/taskrevoke_resource.go
@@ -5,6 +5,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	speakeasy_boolplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/boolplanmodifier"
+	speakeasy_listplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/listplanmodifier"
+	speakeasy_objectplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/objectplanmodifier"
+	speakeasy_stringplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -1089,27 +1093,48 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 																},
 																"field_groups": schema.ListNestedAttribute{
 																	Computed: true,
+																	PlanModifiers: []planmodifier.List{
+																		speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																	},
 																	NestedObject: schema.NestedAttributeObject{
+																		PlanModifiers: []planmodifier.Object{
+																			speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																		},
 																		Attributes: map[string]schema.Attribute{
 																			"default": schema.BoolAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Bool{
+																					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The default field.`,
 																			},
 																			"display_name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The displayName field.`,
 																			},
 																			"fields": schema.ListAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.List{
+																					speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																				},
 																				ElementType: types.StringType,
 																				Description: `The fields field.`,
 																			},
 																			"help_text": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The helpText field.`,
 																			},
 																			"name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The name field.`,
 																			},
 																		},
@@ -1118,17 +1143,32 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 																},
 																"field_relationships": schema.ListNestedAttribute{
 																	Computed: true,
+																	PlanModifiers: []planmodifier.List{
+																		speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																	},
 																	NestedObject: schema.NestedAttributeObject{
+																		PlanModifiers: []planmodifier.Object{
+																			speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																		},
 																		Attributes: map[string]schema.Attribute{
 																			"at_least_one": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The AtLeastOne message.`,
 																			},
 																			"dependent_on": schema.SingleNestedAttribute{
 																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Attributes: map[string]schema.Attribute{
 																					"dependency_field_names": schema.ListAttribute{
-																						Computed:    true,
+																						Computed: true,
+																						PlanModifiers: []planmodifier.List{
+																							speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																						},
 																						ElementType: types.StringType,
 																						Description: `The fields that must be present for the primary field_names to be valid`,
 																					},
@@ -1137,16 +1177,25 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 																					` in dependency_field_names are also present`,
 																			},
 																			"field_names": schema.ListAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.List{
+																					speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																				},
 																				ElementType: types.StringType,
 																				Description: `The names of the fields that share this relationship`,
 																			},
 																			"mutually_exclusive": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The MutuallyExclusive message.`,
 																			},
 																			"required_together": schema.SingleNestedAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.Object{
+																					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The RequiredTogether message.`,
 																			},
 																		},
@@ -1627,7 +1676,10 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 																					`  - numberField`,
 																			},
 																			"name": schema.StringAttribute{
-																				Computed:    true,
+																				Computed: true,
+																				PlanModifiers: []planmodifier.String{
+																					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																				},
 																				Description: `The name field.`,
 																			},
 																			"oauth2_field": schema.SingleNestedAttribute{
@@ -5117,27 +5169,48 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 															},
 															"field_groups": schema.ListNestedAttribute{
 																Computed: true,
+																PlanModifiers: []planmodifier.List{
+																	speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																},
 																NestedObject: schema.NestedAttributeObject{
+																	PlanModifiers: []planmodifier.Object{
+																		speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																	},
 																	Attributes: map[string]schema.Attribute{
 																		"default": schema.BoolAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Bool{
+																				speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The default field.`,
 																		},
 																		"display_name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The displayName field.`,
 																		},
 																		"fields": schema.ListAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.List{
+																				speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																			},
 																			ElementType: types.StringType,
 																			Description: `The fields field.`,
 																		},
 																		"help_text": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The helpText field.`,
 																		},
 																		"name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The name field.`,
 																		},
 																	},
@@ -5146,17 +5219,32 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 															},
 															"field_relationships": schema.ListNestedAttribute{
 																Computed: true,
+																PlanModifiers: []planmodifier.List{
+																	speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																},
 																NestedObject: schema.NestedAttributeObject{
+																	PlanModifiers: []planmodifier.Object{
+																		speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																	},
 																	Attributes: map[string]schema.Attribute{
 																		"at_least_one": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The AtLeastOne message.`,
 																		},
 																		"dependent_on": schema.SingleNestedAttribute{
 																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Attributes: map[string]schema.Attribute{
 																				"dependency_field_names": schema.ListAttribute{
-																					Computed:    true,
+																					Computed: true,
+																					PlanModifiers: []planmodifier.List{
+																						speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																					},
 																					ElementType: types.StringType,
 																					Description: `The fields that must be present for the primary field_names to be valid`,
 																				},
@@ -5165,16 +5253,25 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 																				` in dependency_field_names are also present`,
 																		},
 																		"field_names": schema.ListAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.List{
+																				speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+																			},
 																			ElementType: types.StringType,
 																			Description: `The names of the fields that share this relationship`,
 																		},
 																		"mutually_exclusive": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The MutuallyExclusive message.`,
 																		},
 																		"required_together": schema.SingleNestedAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.Object{
+																				speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The RequiredTogether message.`,
 																		},
 																	},
@@ -5655,7 +5752,10 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 																				`  - numberField`,
 																		},
 																		"name": schema.StringAttribute{
-																			Computed:    true,
+																			Computed: true,
+																			PlanModifiers: []planmodifier.String{
+																				speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+																			},
 																			Description: `The name field.`,
 																		},
 																		"oauth2_field": schema.SingleNestedAttribute{
@@ -6390,27 +6490,48 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 									},
 									"field_groups": schema.ListNestedAttribute{
 										Computed: true,
+										PlanModifiers: []planmodifier.List{
+											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+										},
 										NestedObject: schema.NestedAttributeObject{
+											PlanModifiers: []planmodifier.Object{
+												speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+											},
 											Attributes: map[string]schema.Attribute{
 												"default": schema.BoolAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Bool{
+														speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
+													},
 													Description: `The default field.`,
 												},
 												"display_name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The displayName field.`,
 												},
 												"fields": schema.ListAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.List{
+														speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+													},
 													ElementType: types.StringType,
 													Description: `The fields field.`,
 												},
 												"help_text": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The helpText field.`,
 												},
 												"name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The name field.`,
 												},
 											},
@@ -6419,17 +6540,32 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 									},
 									"field_relationships": schema.ListNestedAttribute{
 										Computed: true,
+										PlanModifiers: []planmodifier.List{
+											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+										},
 										NestedObject: schema.NestedAttributeObject{
+											PlanModifiers: []planmodifier.Object{
+												speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+											},
 											Attributes: map[string]schema.Attribute{
 												"at_least_one": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The AtLeastOne message.`,
 												},
 												"dependent_on": schema.SingleNestedAttribute{
 													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Attributes: map[string]schema.Attribute{
 														"dependency_field_names": schema.ListAttribute{
-															Computed:    true,
+															Computed: true,
+															PlanModifiers: []planmodifier.List{
+																speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+															},
 															ElementType: types.StringType,
 															Description: `The fields that must be present for the primary field_names to be valid`,
 														},
@@ -6438,16 +6574,25 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 														` in dependency_field_names are also present`,
 												},
 												"field_names": schema.ListAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.List{
+														speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
+													},
 													ElementType: types.StringType,
 													Description: `The names of the fields that share this relationship`,
 												},
 												"mutually_exclusive": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The MutuallyExclusive message.`,
 												},
 												"required_together": schema.SingleNestedAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.Object{
+														speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+													},
 													Description: `The RequiredTogether message.`,
 												},
 											},
@@ -6928,7 +7073,10 @@ func (r *TaskRevokeResource) Schema(ctx context.Context, req resource.SchemaRequ
 														`  - numberField`,
 												},
 												"name": schema.StringAttribute{
-													Computed:    true,
+													Computed: true,
+													PlanModifiers: []planmodifier.String{
+														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+													},
 													Description: `The name field.`,
 												},
 												"oauth2_field": schema.SingleNestedAttribute{

--- a/internal/sdk/conductoroneapi.go
+++ b/internal/sdk/conductoroneapi.go
@@ -236,9 +236,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *ConductoroneAPI {
 	sdk := &ConductoroneAPI{
-		SDKVersion: "1.4.0",
+		SDKVersion: "1.4.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.4.0 2.882.0 0.1.0-alpha github.com/conductorone/terraform-provider-conductorone/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.4.1 2.882.0 0.1.0-alpha github.com/conductorone/terraform-provider-conductorone/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: []map[string]string{
 				{

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -619,6 +619,28 @@ actions:
   - target: $["components"]["schemas"]["c1.api.request_schema.v1.RequestSchema"]["properties"]["id"]
     update:
       x-speakeasy-param-suppress-computed-diff: allow
+  # IGA-743 convergence: these attributes are server-derived/computed. Without a
+  # plan-stability modifier they re-plan as "(known after apply)" on every plan
+  # after the first apply, so a config that matches the read-back never reaches
+  # an empty plan. Mirror the `id` treatment above so the prior state value is
+  # carried forward when the planned value is unknown (SuppressDiff == the
+  # framework's UseStateForUnknown). A field the user explicitly sets is left
+  # untouched (the modifier is a no-op when the planned value is known).
+  - target: $["components"]["schemas"]["c1.api.request_schema.v1.RequestSchema"]["properties"]["createdAt"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: allow
+  - target: $["components"]["schemas"]["c1.api.request_schema.v1.RequestSchema"]["properties"]["justificationVisibility"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: allow
+  - target: $["components"]["schemas"]["c1.api.form.v1.Form"]["properties"]["fieldGroups"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: allow
+  - target: $["components"]["schemas"]["c1.api.form.v1.Form"]["properties"]["fieldRelationships"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: allow
+  - target: $["components"]["schemas"]["c1.api.form.v1.Field"]["properties"]["name"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: allow
   - target: $["components"]["schemas"]["c1.api.form.v1.Field"]["properties"]["stringSliceField"]
     remove: true
   ## len is a builtin function in golang, we have to rename `len` with a different name.


### PR DESCRIPTION
## IGA-743 — `conductorone_request_schema` Value Conversion Error + plan convergence (non-breaking, provider-side)

### Root cause
The bug is provider-side and self-inflicted by `.genignore`. Two files — `internal/provider/request_schema_resource.go` and `request_schema_resource_sdk.go` — were frozen in `.genignore` at v1.1.1 (#213), while their generated dependency `FormField` kept evolving (gained `oauth2_field`, `*_provider_config`, `read_only`, `required`, `form_string_field`, `form_string_map_field`, …, and dropped the orphan `string_field`). The frozen schema/conversion drifted out of sync with the regenerated `FormField` Go struct, so the terraform-plugin-framework refused to map the schema object onto the struct → the customer-facing `Value Conversion Error` from 1.0.30 onward.

The non-frozen data source (`request_schema_data_source.go`) regenerated correctly at v1.3.0 and carries the full, correct field set — proving the generator handles the entity fine and the `.genignore` freeze is the sole cause.

### Fix
- **Durable:** removed both files from `.genignore` so future regens keep them in lockstep with `FormField` (permanently stops the drift).
- **Crash:** the `fields` schema and the TF↔API conversion are now produced by a real Speakeasy regen, ending the schema↔struct mismatch that raised the conversion error.
- **Plan convergence:** several attributes the server owns/derives — `created_at`, `justification_visibility`, `field_groups`, `field_relationships`, and the nested `fields[].name` — re-planned as `(known after apply)` on every plan after the first apply, so a config that already matched the read-back never reached an empty plan. Each is now marked `x-speakeasy-param-suppress-computed-diff` in `overlay.yaml`, so the provider retains the prior state value when the planned value is unknown → empty plan. (`fields[].name` is derived and normalized server-side from `display_name`; suppressing its computed diff is what lets a config that omits `name` converge.)
- Regression tripwires: `TestRequestSchemaFieldsMatchFormFieldStruct` (schema↔struct symmetry), `TestRequestSchemaFormFieldRoundTrips` (every union variant), and `request_schema_convergence_test.go` (asserts the server-owned attributes carry their suppress-diff plan modifiers, so the convergence cannot silently regress on a future regen).

### Regen ✅ (head `477686053e81683710fd3767805a86177b8b6cd9`)
The fix was produced by `speakeasy run` on the **pinned `speakeasy 1.762.0`** against the committed `openapi.yaml` + overlays (not `make gen` — no live-API drift mixed in):

- **Canonical method names:** the generator emits `ToSharedRequestSchemaForm` / `RefreshFromSharedRequestSchemaForm`; the hand-written round-trip test matches these.
- **Complete schema:** the regenerated `request_schema_resource.go` surfaces `field_groups`, `justification_visibility`, and the `field_relationships.dependent_on` block, plus enum-value docs and real spec descriptions. Docs regenerated to match.
- `gen.lock` now tracks `request_schema_resource{,_sdk}.go`, confirming they have left `.genignore`.
- **Post-regen patches re-applied** via `patches/` (`speakeasy run` does not run `make apply-patches`): `01` (ActorObjectPermissions `BoolNull` else-branch) and `02` (`deleted_at` on nested resources, IGA-1774). After patch 02 + tfplugindocs the `deleted_at` + doc churn resolves to **zero diff**.
- SDK version auto-bumped **1.4.0 → 1.4.1** (`gen.yaml versioningStrategy: automatic`) across `conductoroneapi.go`, `provider.tf`, `docs/index.md`.

### Evidence
- All `speakeasy_regen_test.go` tripwires pass against the regenerated code: schema↔struct symmetry, union-variant round-trips (incl. the IGA-743 repro from the issue + the all-variants-null explicit-nulls case), the nullable-nested-struct else-branch check, and the nested `deleted_at` check.
- `request_schema_convergence_test.go` passes — the server-owned attributes carry their suppress-diff plan modifiers.
- **`TestAccRequestSchemaResource`** (new, acceptance): against a live ConductorOne API, a `conductorone_request_schema` reaches an **empty post-apply plan** on both the pre-refresh and post-refresh plans — the live proof of convergence.
- `make pre-commit` (build, lint, test, generate/tfplugindocs) **PASS**.
- **Verified end-to-end:** a fresh `terraform apply` at the fixed provider succeeds where the prior release raised the conversion error; upgrading state from 1.0.28/1.0.29 no longer plan-errors (the prior release errored and also blocked `terraform destroy`); the plan now converges with no residual drift.

### Note on long-term handling
The server-owned/derived attributes above are kept plan-stable via provider-side overlay (`x-speakeasy-param-suppress-computed-diff`). The cleaner long-term home is to mark these fields read-only in the API spec so they generate as read-only/computed without the overlay — a possible future minor-release improvement that does not affect this fix.
