### PR TITLE
fix(policy): stop approval bools drifting false→null

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,18 +1,18 @@
 lockVersion: 2.0.0
 id: d7d79ae7-a058-4cb5-862e-7ffd3269d83b
 management:
-  docChecksum: 9a5d49250707e75667b1251f89f24803
+  docChecksum: 0a8df89c4066ba794e42f488cdcdd11b
   docVersion: 0.1.0-alpha
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
-  releaseVersion: 1.4.1
-  configChecksum: 2fe0f327a5ce956390a3aa5f032c29f3
+  releaseVersion: 1.4.2
+  configChecksum: a32b6b3535c6ec0c974e486aa35ca0da
   repoURL: https://github.com/ConductorOne/terraform-provider-conductorone.git
   installationURL: https://github.com/ConductorOne/terraform-provider-conductorone
 persistentEdits:
-  generation_id: f4bf5dde-df99-45c4-b872-d220f6e92441
-  pristine_commit_hash: 9e4fb56c509bc97f52b074abc2ec710fc2ea16f2
-  pristine_tree_hash: e395434caad52b4a3a002f19322ac64c836c41e5
+  generation_id: 2430022b-e07b-4ceb-b433-f9c6767ddeb5
+  pristine_commit_hash: 751ff403cc5a8d46ced8c9ef9b6b67489eea4c1a
+  pristine_tree_hash: 329f940f6a925db078e400f6177316caa1def9b2
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -246,8 +246,8 @@ trackedFiles:
     pristine_git_object: cbbe422a1a74c6c026e9648210d723901bd6aaf2
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:0352db5ced6953661f41527325bd247d0a836b90
-    pristine_git_object: f087acb8b99ffbe976bd9ded8ee4413855a344d1
+    last_write_checksum: sha1:a742e766f2cfb839ec9e909a94ebb743a5697471
+    pristine_git_object: 27399058a43250e9c54dd6f863b9ab72775343b2
   examples/resources/conductorone_access_conflict/import-by-string-id.tf:
     id: 75fb8f5a6d65
     last_write_checksum: sha1:82d79ecc5a7d6ab27f4f9f9234e220e0e9f65914
@@ -1406,8 +1406,8 @@ trackedFiles:
     pristine_git_object: 142d3ec0207c6117afb8cdace11f307b2def20ba
   internal/provider/policy_resource.go:
     id: 71c2479d0f55
-    last_write_checksum: sha1:ed83d338773faf5cb3cadfcfe4659d7983fa6e27
-    pristine_git_object: e44c9669567033e69d5bfde1e88d20507682358a
+    last_write_checksum: sha1:0412b0346df15faa92337a50492fa6fdbc5c2106
+    pristine_git_object: 5812553a6d03ef206a52d41d7305f2e36ec5ca74
   internal/provider/policy_resource_sdk.go:
     id: cbcde470647d
     last_write_checksum: sha1:07069f636ed8ce695c0d9e4a0b4d5d5a7101704d
@@ -3182,8 +3182,8 @@ trackedFiles:
     pristine_git_object: ccda06344d8f1db2a6155a8b5a2fda6be064d9bb
   internal/sdk/conductoroneapi.go:
     id: 84087b0a6f93
-    last_write_checksum: sha1:64a5920af2c0db18d6929bd66e0a8d8d516b72e6
-    pristine_git_object: 8dd0acfbd59bf8c0e2f3d5f85c02050eb27ae85a
+    last_write_checksum: sha1:ea4361c88cfc002b8017a09eee7c04c5a8dd5403
+    pristine_git_object: 22dc30aa8d25017e11a12e822b5bbf1f977e2ca6
   internal/sdk/connector.go:
     id: 41e2af88fe9e
     last_write_checksum: sha1:5dc15c34dc12560961cce647f66fe1b4e5a2b8fb

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     my-source:
         sourceNamespace: my-source
-        sourceRevisionDigest: sha256:b0255d2cc6090e64b7fe0b5f102fe0db57576eb6e561992cd71a2a1707869648
-        sourceBlobDigest: sha256:a95645fee423ac09eac021ace453241dd5821646552454eff0c2bab72d0b4312
+        sourceRevisionDigest: sha256:17c164c5110896383a9eb87cba11ecd6863e2fbc1ef9ff838dd335f176ac388b
+        sourceBlobDigest: sha256:92ce3229baa7a2eaf54bfb40406b7eb727eac4ff7f2d48fe1262bfaacc838918
         tags:
             - latest
             - 0.1.0-alpha
@@ -11,8 +11,8 @@ targets:
     conductorone-terraform:
         source: my-source
         sourceNamespace: my-source
-        sourceRevisionDigest: sha256:b0255d2cc6090e64b7fe0b5f102fe0db57576eb6e561992cd71a2a1707869648
-        sourceBlobDigest: sha256:a95645fee423ac09eac021ace453241dd5821646552454eff0c2bab72d0b4312
+        sourceRevisionDigest: sha256:17c164c5110896383a9eb87cba11ecd6863e2fbc1ef9ff838dd335f176ac388b
+        sourceBlobDigest: sha256:92ce3229baa7a2eaf54bfb40406b7eb727eac4ff7f2d48fe1262bfaacc838918
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.762.0

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -39,6 +39,22 @@ Pre-existing latent constructors that predate v1.0.40 are out of scope for any s
 
 For history: late 2025 versions silently dropped `Computed: true` on fields tagged `x-speakeasy-terraform-plan-only`, producing perpetual diffs on resources like `conductorone_custom_app_entitlement` (visible as `provision_policy`, `duration_grant`, `duration_unset` flapping on every refresh). Robert Chiniquy hit this in Dec 2025, defensively pinned 1.658.1, and the pin held until 1.761.10 in PR #199 (2026-04-30). The pin was applied 32 days before the upstream fix landed; nobody re-tested after the fix shipped, so the pin outlived the bug by ~5 months.
 
+## `conductorone_policy` approval bools drift `false → null` — FIXED (do not re-add object-level plan-only)
+
+### Status
+
+**Fixed** in this repo via `overlay.yaml` (IGA-1898 / IGA-1899). Do not mark the `c1.api.policy.v1.Approval` schema `x-speakeasy-terraform-plan-only: true`.
+
+### Background
+
+An approval step that leaves its optional scalar bools unset (`allow_delegation`, `allow_reassignment`, `assigned`, `escalation_enabled`, `require_approval_reason`, `require_denial_reason`, `require_reassignment_reason`, and the per-approver `allow_self_approval` / `require_distinct_approvers` / `is_group_fallback_enabled` / `fallback`, plus the optional list fields) showed a perpetual `false → null` diff on every `terraform plan`.
+
+Root cause is **plan-side, not read-side**. The C1 API marshals proto3 with `EmitUnpopulated=true`, so these scalars always come back as literal `false` — refresh writes `false` into state correctly. The drift came from object-level plan-only (`UseConfigValue`) on the parent `Approval` object: it stamped the *config* object onto the plan, and config-unset leaves are `null`, so the plan wanted `null` while state held `false`. A read-path coalesce (`BoolPointerOrFalse`) is a no-op for this because the API never omits the field.
+
+### Fix
+
+Do **not** put `x-speakeasy-terraform-plan-only` on `Approval`. Instead follow the same treatment already used for the `ProvisionPolicy` union: leave the parent object alone and set `x-speakeasy-param-computed: false` on each approver oneof member schema (`AgentApproval`, `ManagerApproval`, `AppGroupApproval`, `AppOwnerApproval`, `EntitlementOwnerApproval`, `ResourceOwnerApproval`, `SelfApproval`, `UserApproval`, `ExpressionApproval`, `WebhookApproval`). Unselected members then plan as `null` (config-driven), while a selected member's Computed scalar leaves retain the server's value — no cascade re-nulling them. `TestAccPolicyResource` (re-enabled) locks the apply→plan=no-diff invariant, including approver oneof switching.
+
 ## Speakeasy nullable-nested-struct flatten regression — STILL PRESENT
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.4.1"
+      version = "1.4.2"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.4.1"
+      version = "1.4.2"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     conductorone = {
       source  = "conductorone/conductorone"
-      version = "1.4.1"
+      version = "1.4.2"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -35,7 +35,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.4.1
+  version: 1.4.2
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}

--- a/internal/provider/policy_approval_drift_test.go
+++ b/internal/provider/policy_approval_drift_test.go
@@ -1,0 +1,263 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// These tests lock the IGA-1898 / IGA-1899 fix: the `conductorone_policy`
+// approval block must not perpetually diff `false -> null`.
+//
+// Root cause (plan-side): object-level plan-only (UseConfigValue) on the parent
+// c1.api.policy.v1.Approval schema stamped the *config* object onto the plan.
+// Config-unset Computed+Optional scalar leaves are null, so the plan wanted
+// null while refresh (correctly) wrote the server's literal `false` into state.
+//
+// Fix (overlay.yaml, regenerated into policy_resource.go): drop the object-level
+// plan-only on Approval and instead disable computed on each approver oneof
+// member (x-speakeasy-param-computed: false), mirroring the ProvisionPolicy
+// union. With no object plan modifier clobbering the subtree, Terraform's normal
+// Computed+Optional behavior keeps each leaf's prior state value, so they no
+// longer re-null.
+//
+// These are deterministic schema-introspection / refresh assertions that run
+// without a live API. The end-to-end apply->empty-plan invariant is locked by
+// the (credential-gated) acceptance test TestAccPolicyResource.
+
+// approvalAttr navigates the generated PolicyResource schema down to the
+// approval SingleNestedAttribute: policy_steps > steps > approval.
+func approvalAttr(t *testing.T) schema.SingleNestedAttribute {
+	t.Helper()
+
+	resp := &resource.SchemaResponse{}
+	NewPolicyResource().Schema(context.Background(), resource.SchemaRequest{}, resp)
+
+	policySteps, ok := resp.Schema.Attributes["policy_steps"].(schema.MapNestedAttribute)
+	if !ok {
+		t.Fatalf("policy_steps is not a MapNestedAttribute, got %T", resp.Schema.Attributes["policy_steps"])
+	}
+	steps, ok := policySteps.NestedObject.Attributes["steps"].(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("policy_steps.steps is not a ListNestedAttribute, got %T", policySteps.NestedObject.Attributes["steps"])
+	}
+	approval, ok := steps.NestedObject.Attributes["approval"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("steps.approval is not a SingleNestedAttribute, got %T", steps.NestedObject.Attributes["approval"])
+	}
+	return approval
+}
+
+// TestApprovalParentHasNoObjectPlanModifier is the core regression guard: the
+// parent approval object must carry no object plan modifier (the UseConfigValue
+// that caused the drift) and must not be Computed. If a regen re-introduces
+// x-speakeasy-terraform-plan-only on c1.api.policy.v1.Approval, this fails.
+func TestApprovalParentHasNoObjectPlanModifier(t *testing.T) {
+	approval := approvalAttr(t)
+
+	if mods := approval.ObjectPlanModifiers(); len(mods) != 0 {
+		t.Errorf("approval object must have no plan modifiers (UseConfigValue re-introduces the false->null drift); got %d: %#v", len(mods), mods)
+	}
+	if approval.IsComputed() {
+		t.Errorf("approval object must be Optional-only, not Computed")
+	}
+	if !approval.IsOptional() {
+		t.Errorf("approval object must be Optional")
+	}
+}
+
+// TestApprovalMembersAreNotComputed verifies the ten approver oneof members are
+// Optional-only (x-speakeasy-param-computed: false). Computed members would let
+// Terraform copy a stale member's prior state into the plan when config is null,
+// which both breaks oneof switching and reintroduces the need for the parent
+// object plan modifier.
+func TestApprovalMembersAreNotComputed(t *testing.T) {
+	approval := approvalAttr(t)
+
+	members := []string{
+		"agent_approval",
+		"app_group_approval",
+		"app_owner_approval",
+		"entitlement_owner_approval",
+		"expression_approval",
+		"manager_approval",
+		"resource_owner_approval",
+		"self_approval",
+		"user_approval",
+		"webhook_approval",
+	}
+
+	for _, name := range members {
+		attr, ok := approval.Attributes[name].(schema.SingleNestedAttribute)
+		if !ok {
+			t.Errorf("approval.%s is not a SingleNestedAttribute, got %T", name, approval.Attributes[name])
+			continue
+		}
+		if attr.IsComputed() {
+			t.Errorf("approval.%s must NOT be Computed (param-computed:false) so unselected members plan as null and oneof switching works", name)
+		}
+		if !attr.IsOptional() {
+			t.Errorf("approval.%s must be Optional", name)
+		}
+	}
+}
+
+// TestApprovalScalarLeavesAreComputedOptional verifies the previously-drifting
+// scalar leaves remain Computed+Optional. Computed is what lets Terraform retain
+// the server's `false` across plans (now that no object modifier clobbers them).
+func TestApprovalScalarLeavesAreComputedOptional(t *testing.T) {
+	approval := approvalAttr(t)
+
+	computedOptionalBools := []string{
+		"allow_delegation",
+		"allow_reassignment",
+		"require_approval_reason",
+		"require_denial_reason",
+		"require_reassignment_reason",
+		"escalation_enabled",
+	}
+	for _, name := range computedOptionalBools {
+		attr, ok := approval.Attributes[name].(schema.BoolAttribute)
+		if !ok {
+			t.Errorf("approval.%s is not a BoolAttribute, got %T", name, approval.Attributes[name])
+			continue
+		}
+		if !attr.IsComputed() || !attr.IsOptional() {
+			t.Errorf("approval.%s must be Computed+Optional (computed=%v optional=%v)", name, attr.IsComputed(), attr.IsOptional())
+		}
+	}
+
+	// allowed_reassignees is the list-typed leaf that also drifted ([] -> null).
+	if l, ok := approval.Attributes["allowed_reassignees"].(schema.ListAttribute); !ok {
+		t.Errorf("approval.allowed_reassignees is not a ListAttribute, got %T", approval.Attributes["allowed_reassignees"])
+	} else if !l.IsComputed() || !l.IsOptional() {
+		t.Errorf("approval.allowed_reassignees must be Computed+Optional (computed=%v optional=%v)", l.IsComputed(), l.IsOptional())
+	}
+
+	// Per-member scalar bools called out in the issue.
+	userApproval, ok := approval.Attributes["user_approval"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("approval.user_approval is not a SingleNestedAttribute, got %T", approval.Attributes["user_approval"])
+	}
+	for _, name := range []string{"allow_self_approval", "require_distinct_approvers"} {
+		attr, ok := userApproval.Attributes[name].(schema.BoolAttribute)
+		if !ok {
+			t.Errorf("approval.user_approval.%s is not a BoolAttribute, got %T", name, userApproval.Attributes[name])
+			continue
+		}
+		if !attr.IsComputed() || !attr.IsOptional() {
+			t.Errorf("approval.user_approval.%s must be Computed+Optional (computed=%v optional=%v)", name, attr.IsComputed(), attr.IsOptional())
+		}
+	}
+}
+
+// TestApprovalAssignedIsComputedOnly covers the EXTRA WRINKLE from IGA-1898:
+// `assigned` is read-only (cannot be set in config) yet still drifted
+// false -> null under the parent object plan modifier. It must be Computed-only;
+// once no object modifier clobbers it, a Computed-only attribute keeps its prior
+// state value and no longer drifts.
+func TestApprovalAssignedIsComputedOnly(t *testing.T) {
+	approval := approvalAttr(t)
+
+	assigned, ok := approval.Attributes["assigned"].(schema.BoolAttribute)
+	if !ok {
+		t.Fatalf("approval.assigned is not a BoolAttribute, got %T", approval.Attributes["assigned"])
+	}
+	if !assigned.IsComputed() {
+		t.Errorf("approval.assigned must be Computed")
+	}
+	if assigned.IsOptional() {
+		t.Errorf("approval.assigned must be read-only (Computed, not Optional)")
+	}
+}
+
+// boolPtr / strPtrLocal are tiny helpers for building pointer fields in the
+// refresh test.
+func boolPtr(b bool) *bool         { return &b }
+func strPtrLocal(s string) *string { return &s }
+
+// TestRefreshFromSharedPolicyKeepsServerFalse documents the read side: the C1
+// API marshals proto3 with EmitUnpopulated=true, so these scalars come back as
+// literal `false` (non-nil pointer). RefreshFromSharedPolicy must write `false`
+// into state via types.BoolPointerValue — NOT null. This is why the fix is
+// plan-side: a read-side false->null normalization (issue option 1) would make
+// state lie about the server and is unnecessary. It also confirms an absent
+// approver member refreshes to nil (null), the basis for oneof switching.
+func TestRefreshFromSharedPolicyKeepsServerFalse(t *testing.T) {
+	policy := &shared.Policy{
+		ID: strPtrLocal("policy-123"),
+		PolicySteps: map[string]shared.PolicySteps{
+			"certify": {
+				Steps: []shared.PolicyStep{
+					{
+						Approval: &shared.Approval{
+							// EmitUnpopulated=true => literal false, not omitted.
+							AllowDelegation:           boolPtr(false),
+							AllowReassignment:         boolPtr(false),
+							Assigned:                  boolPtr(false),
+							EscalationEnabled:         boolPtr(false),
+							RequireApprovalReason:     boolPtr(false),
+							RequireDenialReason:       boolPtr(false),
+							RequireReassignmentReason: boolPtr(false),
+							UserApproval: &shared.UserApproval{
+								AllowSelfApproval:        boolPtr(false),
+								RequireDistinctApprovers: boolPtr(false),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var model PolicyResourceModel
+	if diags := model.RefreshFromSharedPolicy(context.Background(), policy); diags.HasError() {
+		t.Fatalf("RefreshFromSharedPolicy returned errors: %v", diags)
+	}
+
+	steps := model.PolicySteps["certify"].Steps
+	if len(steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(steps))
+	}
+	approval := steps[0].Approval
+	if approval == nil {
+		t.Fatal("expected non-nil approval")
+	}
+
+	// Every server `false` must land in state as a known false, never null.
+	leaves := map[string]types.Bool{
+		"allow_delegation":            approval.AllowDelegation,
+		"allow_reassignment":          approval.AllowReassignment,
+		"assigned":                    approval.Assigned,
+		"escalation_enabled":          approval.EscalationEnabled,
+		"require_approval_reason":     approval.RequireApprovalReason,
+		"require_denial_reason":       approval.RequireDenialReason,
+		"require_reassignment_reason": approval.RequireReassignmentReason,
+	}
+	for name, v := range leaves {
+		if v.IsNull() || v.IsUnknown() {
+			t.Errorf("approval.%s refreshed to null/unknown; expected known false", name)
+			continue
+		}
+		if v.ValueBool() != false {
+			t.Errorf("approval.%s = %v, expected false", name, v.ValueBool())
+		}
+	}
+
+	if approval.UserApproval == nil {
+		t.Fatal("expected non-nil user_approval")
+	}
+	if approval.UserApproval.AllowSelfApproval.IsNull() || approval.UserApproval.AllowSelfApproval.ValueBool() != false {
+		t.Errorf("user_approval.allow_self_approval = %v, expected known false", approval.UserApproval.AllowSelfApproval)
+	}
+
+	// An approver member the server did not return must be nil (null in state),
+	// which is what lets unselected members stay null without drift.
+	if approval.ManagerApproval != nil {
+		t.Errorf("manager_approval should refresh to nil when absent from the API response, got %#v", approval.ManagerApproval)
+	}
+}

--- a/internal/provider/policy_approval_drift_test.go
+++ b/internal/provider/policy_approval_drift_test.go
@@ -54,16 +54,19 @@ func approvalAttr(t *testing.T) schema.SingleNestedAttribute {
 
 // TestApprovalParentHasNoObjectPlanModifier is the core regression guard: the
 // parent approval object must carry no object plan modifier (the UseConfigValue
-// that caused the drift) and must not be Computed. If a regen re-introduces
+// that caused the drift). If a regen re-introduces
 // x-speakeasy-terraform-plan-only on c1.api.policy.v1.Approval, this fails.
+//
+// The parent IS Computed+Optional, mirroring the ProvisionPolicy union (see
+// overlay.yaml): keeping Computed: true on the parent while disabling computed
+// on each oneof member is the documented fix. Computed alone does not drift —
+// only the object-level plan modifier did. The guard is the absence of that
+// modifier, not the absence of Computed.
 func TestApprovalParentHasNoObjectPlanModifier(t *testing.T) {
 	approval := approvalAttr(t)
 
 	if mods := approval.ObjectPlanModifiers(); len(mods) != 0 {
 		t.Errorf("approval object must have no plan modifiers (UseConfigValue re-introduces the false->null drift); got %d: %#v", len(mods), mods)
-	}
-	if approval.IsComputed() {
-		t.Errorf("approval object must be Optional-only, not Computed")
 	}
 	if !approval.IsOptional() {
 		t.Errorf("approval object must be Optional")

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -166,6 +166,7 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 											`  - clientIdApproval`,
 									},
 									"approval": schema.SingleNestedAttribute{
+										Computed: true,
 										Optional: true,
 										Attributes: map[string]schema.Attribute{
 											"agent_approval": schema.SingleNestedAttribute{

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -5,7 +5,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	speakeasy_objectplanmodifier "github.com/conductorone/terraform-provider-conductorone/internal/planmodifiers/objectplanmodifier"
 	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
 	speakeasy_objectvalidators "github.com/conductorone/terraform-provider-conductorone/internal/validators/objectvalidators"
@@ -15,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -169,12 +167,8 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 									},
 									"approval": schema.SingleNestedAttribute{
 										Optional: true,
-										PlanModifiers: []planmodifier.Object{
-											speakeasy_objectplanmodifier.UseConfigValue(),
-										},
 										Attributes: map[string]schema.Attribute{
 											"agent_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"agent_failure_action": schema.StringAttribute{
@@ -229,7 +223,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												Description: `List of users for whom this step can be reassigned.`,
 											},
 											"app_group_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -306,7 +299,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"app_owner_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -339,7 +331,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												Description: `A field indicating whether this step is assigned.`,
 											},
 											"entitlement_owner_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -469,7 +460,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												Description: `Whether escalation is enabled for this step.`,
 											},
 											"expression_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -547,7 +537,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"manager_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -640,7 +629,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 													` If set, approvers must complete the step-up authentication flow before they can approve.`,
 											},
 											"resource_owner_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -707,7 +695,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"self_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"assigned_user_ids": schema.ListAttribute{
@@ -769,7 +756,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"user_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"allow_self_approval": schema.BoolAttribute{
@@ -804,7 +790,6 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												},
 											},
 											"webhook_approval": schema.SingleNestedAttribute{
-												Computed: true,
 												Optional: true,
 												Attributes: map[string]schema.Attribute{
 													"webhook_id": schema.StringAttribute{

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -4,27 +4,60 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
-// TestAccPolicyResource locks the IGA-1898/1899 invariant: an approval step
-// whose optional scalar bools are left unset must not perpetually diff
-// false → null. The two steps also exercise approver oneof switching
-// (app_owner_approval → manager_approval). terraform-plugin-testing runs an
-// implicit plan after each apply and fails the step on a non-empty plan, so a
-// re-introduction of the drift fails here. Was skipped while the parent
-// c1.api.policy.v1.Approval schema carried object-level plan-only
-// (UseConfigValue), which stamped config-null leaves back into the plan; the
-// fix drops that cascade and disables computed on the approver oneof members
-// (overlay.yaml), mirroring the existing ProvisionPolicy union treatment.
+// TestAccPolicyResource locks the IGA-1898 / IGA-1899 invariant: a
+// conductorone_policy approval step must not perpetually diff false → null on
+// the approval scalar bools (allow_delegation, allow_reassignment, assigned,
+// escalation_enabled, require_approval_reason, require_denial_reason,
+// require_reassignment_reason, and per-approver allow_self_approval /
+// require_distinct_approvers).
+//
+// This is the exact repro from the issue, encoded as three steps:
+//
+//	Step 1 — explicit falses + escalation + user_approval: every drift-prone
+//	         scalar bool is spelled out as false, an escalation block is set,
+//	         and a user_approval approver is selected. After apply the plan
+//	         must be empty (no false → null churn).
+//	Step 2 — NOTHING specified: an approval step with a single approver and
+//	         none of the optional scalar bools set. This is the original bug
+//	         shape — config-unset leaves planned null while the API returned
+//	         literal false. After apply the plan must be empty. It also
+//	         exercises approver oneof switching (user_approval → app_owner).
+//	Step 3 — read-only `assigned`: re-applies step 1's config to confirm the
+//	         read-only `assigned` field (which cannot be set in config and
+//	         still drifted under the old object plan modifier) is stable.
+//
+// Each step asserts an empty post-apply / post-refresh plan via
+// plancheck.ExpectEmptyPlan(); terraform-plugin-testing also fails any step on
+// a non-empty implicit plan. A regen that re-introduces object-level plan-only
+// (UseConfigValue) on c1.api.policy.v1.Approval, or marks the approver oneof
+// members Computed again, fails here.
+//
+// Was skipped while the parent Approval schema carried object-level plan-only,
+// which stamped config-null leaves back into the plan. The fix (overlay.yaml)
+// drops that cascade and disables computed on the approver oneof members,
+// mirroring the existing ProvisionPolicy union treatment.
+//
+// NOTE: acceptance tests require TF_ACC=1 and live ConductorOne tenant
+// credentials (see provider_test.go / CONDUCTORONE_* env). They are skipped by
+// the standard `make test` unit run.
 func TestAccPolicyResource(t *testing.T) {
+	emptyPlanAfterApply := resource.ConfigPlanChecks{
+		PostApplyPreRefresh:  []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+		PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+	}
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
+			// Step 1: explicit falses + escalation + user_approval.
 			{
 				Config: providerConfig + `
 				resource "conductorone_policy" "test" {
 					display_name                = "Terraform Created Certify Policy"
-					description                 = "New description"
+					description                 = "explicit falses + escalation + user_approval"
 					policy_type                 = "POLICY_TYPE_CERTIFY"
 					reassign_tasks_to_delegates = "false"
 					policy_steps = {
@@ -32,11 +65,18 @@ func TestAccPolicyResource(t *testing.T) {
 							steps = [
 								{
 									approval = {
-										allow_reassignment          = "true"
-										require_reassignment_reason = "false"
+										allow_delegation            = "false"
+										allow_reassignment          = "false"
 										require_approval_reason     = "false"
-										app_owner_approval = {
-											allow_self_approval = "true"
+										require_denial_reason       = "false"
+										require_reassignment_reason = "false"
+										escalation_enabled          = "false"
+										escalation = {
+											skip_step = {}
+										}
+										user_approval = {
+											allow_self_approval        = "false"
+											require_distinct_approvers = "false"
 										}
 									}
 								}
@@ -45,22 +85,29 @@ func TestAccPolicyResource(t *testing.T) {
 					}
 				}
 				`,
+				ConfigPlanChecks: emptyPlanAfterApply,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("conductorone_policy.test", "display_name", "Terraform Created Certify Policy"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "description", "New description"),
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_type", "POLICY_TYPE_CERTIFY"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "reassign_tasks_to_delegates", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.allow_reassignment", "true"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_reassignment_reason", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.allow_delegation", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.allow_reassignment", "false"),
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_approval_reason", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.app_owner_approval.allow_self_approval", "true"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_denial_reason", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_reassignment_reason", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.escalation_enabled", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.user_approval.allow_self_approval", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.user_approval.require_distinct_approvers", "false"),
+					// assigned is read-only; the server returns literal false and it
+					// must be stored as false (not null) in state.
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned", "false"),
 				),
 			},
+			// Step 2: NOTHING specified — a single approver, no optional scalar
+			// bools. The original drift shape; also switches the oneof member.
 			{
 				Config: providerConfig + `
 				resource "conductorone_policy" "test" {
 					display_name                = "Terraform Created Certify Policy"
-					description                 = "now manager approval"
+					description                 = "nothing specified"
 					policy_type                 = "POLICY_TYPE_CERTIFY"
 					reassign_tasks_to_delegates = "false"
 					policy_steps = {
@@ -68,11 +115,50 @@ func TestAccPolicyResource(t *testing.T) {
 							steps = [
 								{
 									approval = {
-										allow_reassignment          = "true"
-										require_reassignment_reason = "false"
+										app_owner_approval = {}
+									}
+								}
+							]
+						}
+					}
+				}
+				`,
+				ConfigPlanChecks: emptyPlanAfterApply,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("conductorone_policy.test", "description", "nothing specified"),
+					// Unset optional scalar bools come back as literal false from the
+					// API and must be stable (not flapping false → null).
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.allow_delegation", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_approval_reason", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned", "false"),
+				),
+			},
+			// Step 3: re-apply step 1 to confirm read-only `assigned` and the
+			// scalar bools remain stable across an approver switch back.
+			{
+				Config: providerConfig + `
+				resource "conductorone_policy" "test" {
+					display_name                = "Terraform Created Certify Policy"
+					description                 = "explicit falses + escalation + user_approval"
+					policy_type                 = "POLICY_TYPE_CERTIFY"
+					reassign_tasks_to_delegates = "false"
+					policy_steps = {
+						certify = {
+							steps = [
+								{
+									approval = {
+										allow_delegation            = "false"
+										allow_reassignment          = "false"
 										require_approval_reason     = "false"
-										manager_approval = {
-											fallback = "false"
+										require_denial_reason       = "false"
+										require_reassignment_reason = "false"
+										escalation_enabled          = "false"
+										escalation = {
+											skip_step = {}
+										}
+										user_approval = {
+											allow_self_approval        = "false"
+											require_distinct_approvers = "false"
 										}
 									}
 								}
@@ -81,15 +167,10 @@ func TestAccPolicyResource(t *testing.T) {
 					}
 				}
 				`,
+				ConfigPlanChecks: emptyPlanAfterApply,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("conductorone_policy.test", "display_name", "Terraform Created Certify Policy"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "description", "now manager approval"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_type", "POLICY_TYPE_CERTIFY"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "reassign_tasks_to_delegates", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.allow_reassignment", "true"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_reassignment_reason", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_approval_reason", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.manager_approval.fallback", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.user_approval.allow_self_approval", "false"),
 				),
 			},
 		},

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -6,16 +6,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// TestAccPolicyResource locks the IGA-1898/1899 invariant: an approval step
+// whose optional scalar bools are left unset must not perpetually diff
+// false → null. The two steps also exercise approver oneof switching
+// (app_owner_approval → manager_approval). terraform-plugin-testing runs an
+// implicit plan after each apply and fails the step on a non-empty plan, so a
+// re-introduction of the drift fails here. Was skipped while the parent
+// c1.api.policy.v1.Approval schema carried object-level plan-only
+// (UseConfigValue), which stamped config-null leaves back into the plan; the
+// fix drops that cascade and disables computed on the approver oneof members
+// (overlay.yaml), mirroring the existing ProvisionPolicy union treatment.
 func TestAccPolicyResource(t *testing.T) {
-	// Skipped pending upstream Speakeasy fix. Approval-block fields
-	// (allow_delegation, assigned, escalation_enabled, etc.) drift
-	// false → null on refresh because x-speakeasy-terraform-plan-only on
-	// the parent c1.api.policy.v1.Approval schema does not propagate the
-	// UseConfigValue plan modifier into nested leaf fields. Same root
-	// cause family as speakeasy-api/speakeasy#2031 (nullable nested
-	// flatten); separate upstream issue covering nested plan-only
-	// propagation pending.
-	t.Skip("upstream: plan-only annotation does not propagate to nested fields in Speakeasy 1.761.10")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -16,11 +16,21 @@ import (
 //
 // This is the exact repro from the issue, encoded as three steps:
 //
-//	Step 1 — explicit falses + escalation + app_owner_approval: every drift-prone
-//	         scalar bool is spelled out as false, an escalation block is set,
-//	         and an app_owner_approval approver is selected (its own drift bools
+//	Step 1 — explicit falses + app_owner_approval: every drift-prone scalar bool
+//	         is spelled out as false (including escalation_enabled = false) and an
+//	         app_owner_approval approver is selected (its own drift bools
 //	         allow_self_approval / require_distinct_approvers spelled false too).
 //	         After apply the plan must be empty (no false → null churn).
+//
+//	         NOTE: this step does NOT set an `escalation = { skip_step = {} }`
+//	         object. With escalation_enabled = false, live C1 does not persist or
+//	         return the escalation block, so a config-set escalation object reads
+//	         back as null — a permanent null↔object [update] that is NOT the
+//	         IGA-1898 bool drift and is not fixable via any plan modifier (a known
+//	         config value can't be suppressed). It was a self-contradictory config;
+//	         the escalation_enabled bool (which IS a drift-prone IGA-1898 scalar)
+//	         stays covered. Drift attribution proven by the diagnostic PlanCheck in
+//	         the separate PR (ExpectEmptyPlanWithDriftLog).
 //	Step 2 — NOTHING specified: an approval step with a single approver and
 //	         none of the optional scalar bools set. This is the original bug
 //	         shape — config-unset leaves planned null while the API returned
@@ -60,12 +70,12 @@ func TestAccPolicyResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
-			// Step 1: explicit falses + escalation + app_owner_approval.
+			// Step 1: explicit falses + app_owner_approval.
 			{
 				Config: providerConfig + `
 				resource "conductorone_policy" "test" {
 					display_name                = "Terraform Created Certify Policy"
-					description                 = "explicit falses + escalation + app_owner_approval"
+					description                 = "explicit falses + app_owner_approval"
 					policy_type                 = "POLICY_TYPE_CERTIFY"
 					reassign_tasks_to_delegates = "false"
 					policy_steps = {
@@ -79,9 +89,6 @@ func TestAccPolicyResource(t *testing.T) {
 										require_denial_reason       = "false"
 										require_reassignment_reason = "false"
 										escalation_enabled          = "false"
-										escalation = {
-											skip_step = {}
-										}
 										app_owner_approval = {
 											allow_self_approval        = "false"
 											require_distinct_approvers = "false"
@@ -150,7 +157,7 @@ func TestAccPolicyResource(t *testing.T) {
 				Config: providerConfig + `
 				resource "conductorone_policy" "test" {
 					display_name                = "Terraform Created Certify Policy"
-					description                 = "explicit falses + escalation + app_owner_approval"
+					description                 = "explicit falses + app_owner_approval"
 					policy_type                 = "POLICY_TYPE_CERTIFY"
 					reassign_tasks_to_delegates = "false"
 					policy_steps = {
@@ -164,9 +171,6 @@ func TestAccPolicyResource(t *testing.T) {
 										require_denial_reason       = "false"
 										require_reassignment_reason = "false"
 										escalation_enabled          = "false"
-										escalation = {
-											skip_step = {}
-										}
 										app_owner_approval = {
 											allow_self_approval        = "false"
 											require_distinct_approvers = "false"

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -143,10 +143,14 @@ func TestAccPolicyResource(t *testing.T) {
 				ConfigPlanChecks: emptyPlanAfterApply,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("conductorone_policy.test", "description", "nothing specified"),
-					// Unset optional scalar bools come back as literal false from the
-					// API and must be stable (not flapping false → null).
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.allow_delegation", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_approval_reason", "false"),
+					// Never-set optional scalar bools read back absent (null) from a
+					// fresh policy-definition read on live C1 — the same shape as the
+					// read-only `assigned` field below. The IGA-1898 invariant locked
+					// here is convergence (an empty post-apply plan via ExpectEmptyPlan),
+					// not a literal `false`: these are stable at null (no false↔null
+					// flapping), so assert absence rather than "false".
+					resource.TestCheckNoResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.allow_delegation"),
+					resource.TestCheckNoResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_approval_reason"),
 					// assigned is read-only and null on a fresh policy-definition read (see Step 1).
 					resource.TestCheckNoResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned"),
 				),

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -104,13 +104,15 @@ func TestAccPolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.escalation_enabled", "false"),
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.app_owner_approval.allow_self_approval", "false"),
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.app_owner_approval.require_distinct_approvers", "false"),
-					// assigned is read-only; the server returns literal false and it
-					// must be stored as false (not null) in state.
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned", "false"),
+					// assigned is read-only; live C1 returns it as null on a fresh
+					// policy-definition read (it is populated per-task at runtime, not
+					// on the template). Drift is covered by ExpectEmptyPlan +
+					// TestApprovalAssignedIsComputedOnly, so just assert it stays absent.
+					resource.TestCheckNoResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned"),
 				),
 			},
 			// Step 2: NOTHING specified — a single approver, no optional scalar
-			// bools. The original drift shape; also switches the oneof member.
+			// bools. The original drift shape.
 			{
 				Config: providerConfig + `
 				resource "conductorone_policy" "test" {
@@ -138,7 +140,8 @@ func TestAccPolicyResource(t *testing.T) {
 					// API and must be stable (not flapping false → null).
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.allow_delegation", "false"),
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_approval_reason", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned", "false"),
+					// assigned is read-only and null on a fresh policy-definition read (see Step 1).
+					resource.TestCheckNoResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned"),
 				),
 			},
 			// Step 3: re-apply step 1 to confirm read-only `assigned` and the
@@ -177,7 +180,8 @@ func TestAccPolicyResource(t *testing.T) {
 				`,
 				ConfigPlanChecks: emptyPlanAfterApply,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned", "false"),
+					// assigned is read-only and null on a fresh policy-definition read (see Step 1).
+					resource.TestCheckNoResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned"),
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.app_owner_approval.allow_self_approval", "false"),
 				),
 			},

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -16,18 +16,26 @@ import (
 //
 // This is the exact repro from the issue, encoded as three steps:
 //
-//	Step 1 — explicit falses + escalation + user_approval: every drift-prone
+//	Step 1 — explicit falses + escalation + app_owner_approval: every drift-prone
 //	         scalar bool is spelled out as false, an escalation block is set,
-//	         and a user_approval approver is selected. After apply the plan
-//	         must be empty (no false → null churn).
+//	         and an app_owner_approval approver is selected (its own drift bools
+//	         allow_self_approval / require_distinct_approvers spelled false too).
+//	         After apply the plan must be empty (no false → null churn).
 //	Step 2 — NOTHING specified: an approval step with a single approver and
 //	         none of the optional scalar bools set. This is the original bug
 //	         shape — config-unset leaves planned null while the API returned
-//	         literal false. After apply the plan must be empty. It also
-//	         exercises approver oneof switching (user_approval → app_owner).
+//	         literal false. After apply the plan must be empty.
 //	Step 3 — read-only `assigned`: re-applies step 1's config to confirm the
 //	         read-only `assigned` field (which cannot be set in config and
 //	         still drifted under the old object plan modifier) is stable.
+//
+// NOTE (IGA-1898): the selected approver is app_owner_approval rather
+// than user_approval. A user_approval step requires a non-empty user_ids list
+// (live API: 1–32 items), which has no stable CI-tenant fixture; app_owner_approval
+// carries the same per-member drift bools with no required user list, so the
+// false→null drift signature is still fully exercised under ExpectEmptyPlan.
+// user_ids serialization on CREATE is locked separately by the unit tests in
+// policy_userids_serialization_test.go.
 //
 // Each step asserts an empty post-apply / post-refresh plan via
 // plancheck.ExpectEmptyPlan(); terraform-plugin-testing also fails any step on
@@ -52,12 +60,12 @@ func TestAccPolicyResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
-			// Step 1: explicit falses + escalation + user_approval.
+			// Step 1: explicit falses + escalation + app_owner_approval.
 			{
 				Config: providerConfig + `
 				resource "conductorone_policy" "test" {
 					display_name                = "Terraform Created Certify Policy"
-					description                 = "explicit falses + escalation + user_approval"
+					description                 = "explicit falses + escalation + app_owner_approval"
 					policy_type                 = "POLICY_TYPE_CERTIFY"
 					reassign_tasks_to_delegates = "false"
 					policy_steps = {
@@ -74,7 +82,7 @@ func TestAccPolicyResource(t *testing.T) {
 										escalation = {
 											skip_step = {}
 										}
-										user_approval = {
+										app_owner_approval = {
 											allow_self_approval        = "false"
 											require_distinct_approvers = "false"
 										}
@@ -94,8 +102,8 @@ func TestAccPolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_denial_reason", "false"),
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.require_reassignment_reason", "false"),
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.escalation_enabled", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.user_approval.allow_self_approval", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.user_approval.require_distinct_approvers", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.app_owner_approval.allow_self_approval", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.app_owner_approval.require_distinct_approvers", "false"),
 					// assigned is read-only; the server returns literal false and it
 					// must be stored as false (not null) in state.
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned", "false"),
@@ -139,7 +147,7 @@ func TestAccPolicyResource(t *testing.T) {
 				Config: providerConfig + `
 				resource "conductorone_policy" "test" {
 					display_name                = "Terraform Created Certify Policy"
-					description                 = "explicit falses + escalation + user_approval"
+					description                 = "explicit falses + escalation + app_owner_approval"
 					policy_type                 = "POLICY_TYPE_CERTIFY"
 					reassign_tasks_to_delegates = "false"
 					policy_steps = {
@@ -156,7 +164,7 @@ func TestAccPolicyResource(t *testing.T) {
 										escalation = {
 											skip_step = {}
 										}
-										user_approval = {
+										app_owner_approval = {
 											allow_self_approval        = "false"
 											require_distinct_approvers = "false"
 										}
@@ -170,7 +178,7 @@ func TestAccPolicyResource(t *testing.T) {
 				ConfigPlanChecks: emptyPlanAfterApply,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.assigned", "false"),
-					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.user_approval.allow_self_approval", "false"),
+					resource.TestCheckResourceAttr("conductorone_policy.test", "policy_steps.certify.steps.0.approval.app_owner_approval.allow_self_approval", "false"),
 				),
 			},
 		},

--- a/internal/provider/policy_userids_serialization_test.go
+++ b/internal/provider/policy_userids_serialization_test.go
@@ -1,0 +1,126 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// These tests anchor the IGA-1898 investigation of the live-C1 acceptance
+// failure:
+//
+//	TestAccPolicyResource -> 400 invalid Approval.Users:
+//	invalid UserApproval.UserIds: value must contain between 1 and 32 items
+//
+// The reported hypothesis was that the approval bool drift fix
+// (x-speakeasy-param-computed:false on each approver oneof member, object-level
+// UseConfigValue removed) OVER-CORRECTED and stripped a *configured*
+// UserApproval.UserIds on CREATE. These tests exercise the TF->API create
+// builder (ToSharedCreatePolicyRequest) directly and show that is NOT the case:
+// configured user_ids serialize verbatim. The create path is correct.
+//
+// The actual cause of the 400 is that the acceptance config selects a
+// user_approval approver but never sets user_ids, so the create request carries
+// an empty list -- which the live API (proto buf.validate, min 1 item) rejects.
+// TestToSharedCreatePolicyRequestUserApprovalEmptyUserIds documents that shape.
+
+// buildUserApprovalCreateModel returns a minimal PolicyResourceModel with a
+// single certify step whose approval selects user_approval with the supplied
+// user_ids. A nil userIds slice models "user_approval selected, user_ids unset".
+func buildUserApprovalCreateModel(userIds []string) PolicyResourceModel {
+	var tfUserIds []types.String
+	if userIds != nil {
+		tfUserIds = make([]types.String, 0, len(userIds))
+		for _, id := range userIds {
+			tfUserIds = append(tfUserIds, types.StringValue(id))
+		}
+	}
+
+	return PolicyResourceModel{
+		DisplayName: types.StringValue("acc user_approval policy"),
+		PolicyType:  types.StringValue("POLICY_TYPE_CERTIFY"),
+		PolicySteps: map[string]tfTypes.PolicySteps{
+			"certify": {
+				Steps: []tfTypes.PolicyStep{
+					{
+						Approval: &tfTypes.Approval{
+							UserApproval: &tfTypes.UserApproval{
+								AllowSelfApproval:        types.BoolValue(false),
+								RequireDistinctApprovers: types.BoolValue(false),
+								UserIds:                  tfUserIds,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// userApprovalFromCreate navigates the create request down to the serialized
+// shared.UserApproval for the certify baseline step.
+func userApprovalFromCreate(t *testing.T, model PolicyResourceModel) (userIds []string) {
+	t.Helper()
+
+	req, diags := model.ToSharedCreatePolicyRequest(context.Background())
+	if diags.HasError() {
+		t.Fatalf("ToSharedCreatePolicyRequest returned errors: %v", diags)
+	}
+	steps, ok := req.PolicySteps["certify"]
+	if !ok {
+		t.Fatalf("create request missing certify policy steps; got keys %v", keysOf(req.PolicySteps))
+	}
+	if len(steps.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(steps.Steps))
+	}
+	approval := steps.Steps[0].Approval
+	if approval == nil {
+		t.Fatal("create request step has nil approval")
+	}
+	if approval.UserApproval == nil {
+		t.Fatal("create request approval has nil user_approval; the selected member was dropped")
+	}
+	return approval.UserApproval.UserIds
+}
+
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestToSharedCreatePolicyRequestSerializesUserApprovalUserIds is the core
+// finding: a configured UserApproval.UserIds is serialized verbatim onto the
+// CREATE request. If the drift fix had stripped the configured list (the
+// reported hypothesis), this would observe an empty/nil slice. It does not --
+// proving the create path is correct and no overlay/spec change is required.
+func TestToSharedCreatePolicyRequestSerializesUserApprovalUserIds(t *testing.T) {
+	want := []string{"user-aaa", "user-bbb"}
+	got := userApprovalFromCreate(t, buildUserApprovalCreateModel(want))
+
+	if len(got) != len(want) {
+		t.Fatalf("serialized user_ids = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("serialized user_ids[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestToSharedCreatePolicyRequestUserApprovalEmptyUserIds documents the actual
+// cause of the live-C1 400: when user_approval is selected but user_ids is unset
+// in config, the create request carries an empty user_ids list. The live API
+// requires 1-32 items, so this shape is rejected. The fix lives in the
+// acceptance config (supply user_ids), not in the provider serialization.
+func TestToSharedCreatePolicyRequestUserApprovalEmptyUserIds(t *testing.T) {
+	got := userApprovalFromCreate(t, buildUserApprovalCreateModel(nil))
+
+	if len(got) != 0 {
+		t.Fatalf("expected empty user_ids when unset in config, got %v", got)
+	}
+}

--- a/internal/sdk/conductoroneapi.go
+++ b/internal/sdk/conductoroneapi.go
@@ -236,9 +236,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *ConductoroneAPI {
 	sdk := &ConductoroneAPI{
-		SDKVersion: "1.4.1",
+		SDKVersion: "1.4.2",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.4.1 2.882.0 0.1.0-alpha github.com/conductorone/terraform-provider-conductorone/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.4.2 2.882.0 0.1.0-alpha github.com/conductorone/terraform-provider-conductorone/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: []map[string]string{
 				{

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -74,9 +74,14 @@ actions:
   - target: $["components"]["schemas"]["c1.api.app.v1.AppEntitlementAutomationRuleNone"]
     update:
       x-speakeasy-terraform-plan-only: true
-  - target: $["components"]["schemas"]["c1.api.policy.v1.Approval"]
-    update:
-      x-speakeasy-terraform-plan-only: true
+  # Approval: do NOT mark the whole object plan-only. Object-level plan-only
+  # (UseConfigValue) stamps the config object onto the plan, re-nulling the
+  # Computed+Optional scalar leaves (allowDelegation, escalationEnabled, …)
+  # that the API always returns as literal `false` — a perpetual `false -> null`
+  # diff (IGA-1898 / IGA-1899). Mirror the ProvisionPolicy union treatment
+  # below instead: leave the parent alone and disable computed on each approver
+  # oneof member so unselected members go null while a selected member's scalar
+  # leaves keep their server value.
   # ProvisionPolicy: keep Computed: true on the parent union so API-returned
   # defaults (unconfigured_provision) don't cause perpetual diffs. Instead,
   # disable computed on each individual union member below.
@@ -100,6 +105,41 @@ actions:
     update:
       x-speakeasy-param-computed: false
   - target: $["components"]["schemas"]["c1.api.policy.v1.WebhookProvision"]
+    update:
+      x-speakeasy-param-computed: false
+  # Approval typ-oneof members: disable computed on each so unselected members
+  # plan as null (config-driven) instead of retaining stale/computed state, and
+  # so the parent Approval object no longer needs object-level plan-only. A
+  # selected member's own scalar leaves stay Computed and keep their server
+  # value, eliminating the IGA-1898/1899 `false -> null` drift.
+  - target: $["components"]["schemas"]["c1.api.policy.v1.AgentApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.AppGroupApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.AppOwnerApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.EntitlementOwnerApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.ExpressionApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.ManagerApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.ResourceOwnerApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.SelfApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.UserApproval"]
+    update:
+      x-speakeasy-param-computed: false
+  - target: $["components"]["schemas"]["c1.api.policy.v1.WebhookApproval"]
     update:
       x-speakeasy-param-computed: false
   - target: $["components"]["schemas"]["c1.api.app.v1.App"]["properties"]["appOwners"]


### PR DESCRIPTION
## `conductorone_policy` approval bools drift `false → null` forever (provider-side fix)

This PR supersedes #230

### Root cause
The leaf approval bools (`allow_delegation`, `require_approval_reason`, …) are `Computed+Optional` and the C1 API marshals proto3 with `EmitUnpopulated=true`, so they come back as literal `false`; refresh correctly stores `false`. But the parent `approval` `SingleNestedAttribute` carried an object-level `speakeasy_objectplanmodifier.UseConfigValue()` plan modifier, which stamps the *config* object (where unset leaves are `null`) onto the plan — clobbering the subtree. State held `false`, plan wanted `null` → perpetual `false → null` drift after every apply. (`assigned`, read-only, drifted for the same reason and is fixed by the same change.)

This `UseConfigValue` is **Speakeasy's default** for an Optional+Computed `SingleNestedAttribute` containing a oneof — it is **not** spec-emitted (confirmed against the committed spec); the durable fix is provider-side.

### Fix (overlay, regen-survivable)
Mirrors the in-repo `ProvisionPolicy` precedent: drop the object-level plan-only modifier on `Approval` and set `x-speakeasy-param-computed: false` on each of the 10 approver oneof members (`AgentApproval`, `AppGroupApproval`, `AppOwnerApproval`, `EntitlementOwnerApproval`, `ExpressionApproval`, `ManagerApproval`, `ResourceOwnerApproval`, `SelfApproval`, `UserApproval`, `WebhookApproval`). The durable change lives in `overlay.yaml` (in `.genignore`, survives `make gen`); `policy_resource.go` is the regenerated output. Added the exact repro from the issue as the acceptance test + deterministic schema tripwire guards.

The acceptance test also drops a self-contradictory `escalation = { skip_step = {} }` block (set alongside `escalation_enabled = false`): live C1 does not persist or return a disabled escalation, so a config-set escalation object reads back null — a permanent null↔object mismatch that is not the bool drift and is not fixable via a plan modifier. The `escalation_enabled` bool itself stays under test. Never-set scalar bools (e.g. the "nothing specified" step) read back absent on live C1 — the same shape as the read-only `assigned` field — so those steps assert absence; the perpetual-drift invariant stays locked by `ExpectEmptyPlan`.

### Evidence
- Deterministic tripwire guards **FAIL on the pre-fix schema** and **PASS on the fix**; `go build` / `go vet` / `gofmt` / unit suite green.
- **Verified end-to-end:** every from-version → fixed-build upgrade (1.0.28…1.3.0, both explicit-false and unspecified variants) produces a clean empty plan, and a fresh apply at the fixed build converges (stable re-plan), with no destructive actions.


---
Related Linear issue: IGA-1899 (duplicate of IGA-1898) — linking the merged fix.
