### PR TITLE
Fix function and access_review update: set UpdateMask field

### DIFF
--- a/internal/provider/access_review_resource_sdk.go
+++ b/internal/provider/access_review_resource_sdk.go
@@ -1872,8 +1872,18 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
 		return nil, diags
 	}
 
+	// scope_v2 and policy_id are deliberately excluded: the backend rejects
+	// any update carrying either path in update_mask once the campaign has
+	// left PENDING state, regardless of whether the value actually changed.
+	// Including them here would break every other-field update (e.g. just
+	// display_name) on a running campaign. See IGA-2302 follow-up discussion.
+	updateMask := "displayName,description,reviewInstructions,defaultView,completionDate,autoResolve," +
+		"usePolicyOverride,autoGenerateReport,scopeType,exemptCertifiedAccessConflicts,autoStartCampaign," +
+		"scheduledStartDate,accuracyIssueAction,autoCloseCampaign,autoCloseDecision,columnConfig," +
+		"reviewerAttributeConfig,notificationConfig,signatureConfig,inclusionScope"
 	out := shared.AccessReviewServiceUpdateRequest{
 		AccessReview: accessReview,
+		UpdateMask:   &updateMask,
 	}
 
 	return &out, diags

--- a/internal/provider/function_resource_sdk.go
+++ b/internal/provider/function_resource_sdk.go
@@ -285,8 +285,11 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
 		return nil, diags
 	}
 
+	updateMask := "displayName,description,functionType,publishedCommitId,isDraft,secret," +
+		"outboundNetworkAllowlist,scopedRoleIds,provisionedConcurrency"
 	out := shared.FunctionsServiceUpdateFunctionRequest{
-		Function: function,
+		Function:   function,
+		UpdateMask: &updateMask,
 	}
 
 	return &out, diags

--- a/internal/provider/speakeasy_regen_test.go
+++ b/internal/provider/speakeasy_regen_test.go
@@ -200,3 +200,62 @@ func TestAppEntitlementSDKMirrorsManualProvisionSchema(t *testing.T) {
 		}
 	}
 }
+
+// TestUpdateRequestsSetUpdateMask verifies that every listed resource's
+// ToShared*ServiceUpdateRequest / ToShared*ServiceUpdateFunctionRequest
+// function actually populates UpdateMask on the outgoing shared request.
+//
+// Regression: Speakeasy does not auto-generate update_mask population for
+// these operations (nothing in the OAS distinguishes them from
+// access_review_template, which Speakeasy also doesn't handle — that one is
+// hand-patched too, see patches/03). The backend RPCs behind Function and
+// AccessReview hard-reject a request with a nil/empty update_mask
+// (InvalidArgument: "update_mask is required"), so without this, every
+// terraform apply that updates an existing conductorone_function or
+// conductorone_access_review fails outright. Fixed by patches/04 and
+// patches/05, which set UpdateMask to a static comma-joined list of every
+// writable field. AccessReview's list deliberately omits scope_v2 and
+// policy_id: the backend rejects those paths in update_mask once a campaign
+// leaves PENDING state regardless of whether the value changed, so a static
+// full mask would break unrelated field updates (e.g. display_name) on any
+// running campaign.
+func TestUpdateRequestsSetUpdateMask(t *testing.T) {
+	cases := []struct {
+		file     string
+		funcName string
+	}{
+		{"function_resource_sdk.go", "ToSharedFunctionsServiceUpdateFunctionRequest"},
+		{"access_review_resource_sdk.go", "ToSharedAccessReviewServiceUpdateRequest"},
+	}
+
+	funcBody := regexp.MustCompile(`(?s)func \(r \*\w+\) (\w+)\(ctx context\.Context\).*?\n}\n`)
+
+	for _, c := range cases {
+		data, err := os.ReadFile(c.file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", c.file, err)
+		}
+		content := string(data)
+
+		matches := funcBody.FindAllStringSubmatch(content, -1)
+		var body string
+		found := false
+		for _, m := range matches {
+			if m[1] == c.funcName {
+				body = m[0]
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("%s: could not find function %s", c.file, c.funcName)
+		}
+
+		if !strings.Contains(body, "UpdateMask:") {
+			t.Errorf("%s: %s does not set UpdateMask on the outgoing request. "+
+				"The backend requires a non-empty update_mask and will reject every "+
+				"Update() call with InvalidArgument otherwise. Re-apply patches/04-function-update-mask.patch "+
+				"or patches/05-access-review-update-mask.patch (whichever matches %s).", c.file, c.funcName, c.file)
+		}
+	}
+}

--- a/internal/provider/speakeasy_regen_test.go
+++ b/internal/provider/speakeasy_regen_test.go
@@ -206,14 +206,16 @@ func TestAppEntitlementSDKMirrorsManualProvisionSchema(t *testing.T) {
 // function actually populates UpdateMask on the outgoing shared request.
 //
 // Regression: Speakeasy does not auto-generate update_mask population for
-// these operations (nothing in the OAS distinguishes them from
-// access_review_template, which Speakeasy also doesn't handle — that one is
-// hand-patched too, see patches/03). The backend RPCs behind Function and
-// AccessReview hard-reject a request with a nil/empty update_mask
-// (InvalidArgument: "update_mask is required"), so without this, every
-// terraform apply that updates an existing conductorone_function or
-// conductorone_access_review fails outright. Fixed by patches/04 and
-// patches/05, which set UpdateMask to a static comma-joined list of every
+// these operations — nothing in the OAS distinguishes any of the three
+// resources below from each other. access_review_template hit this first
+// and was hand-patched (patches/03, PR #231 / IGA-2302) with no tripwire
+// test added at the time; function and access_review hit the identical bug
+// later (patches/04, patches/05). All three backend RPCs hard-reject a
+// request with a nil/empty update_mask (InvalidArgument: "update_mask is
+// required"), so without this, every terraform apply that updates an
+// existing resource of any of these three types fails outright.
+//
+// Each patch sets UpdateMask to a static comma-joined list of every
 // writable field. AccessReview's list deliberately omits scope_v2 and
 // policy_id: the backend rejects those paths in update_mask once a campaign
 // leaves PENDING state regardless of whether the value changed, so a static
@@ -226,6 +228,7 @@ func TestUpdateRequestsSetUpdateMask(t *testing.T) {
 	}{
 		{"function_resource_sdk.go", "ToSharedFunctionsServiceUpdateFunctionRequest"},
 		{"access_review_resource_sdk.go", "ToSharedAccessReviewServiceUpdateRequest"},
+		{"access_review_template_resource_sdk.go", "ToSharedAccessReviewTemplateServiceUpdateRequest"},
 	}
 
 	funcBody := regexp.MustCompile(`(?s)func \(r \*\w+\) (\w+)\(ctx context\.Context\).*?\n}\n`)

--- a/patches/04-function-update-mask.patch
+++ b/patches/04-function-update-mask.patch
@@ -1,0 +1,17 @@
+diff --git a/internal/provider/function_resource_sdk.go b/internal/provider/function_resource_sdk.go
+index ca09e5d0..2cc9ff38 100644
+--- a/internal/provider/function_resource_sdk.go
++++ b/internal/provider/function_resource_sdk.go
+@@ -285,8 +285,11 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
+ 		return nil, diags
+ 	}
+ 
++	updateMask := "displayName,description,functionType,publishedCommitId,isDraft,secret," +
++		"outboundNetworkAllowlist,scopedRoleIds,provisionedConcurrency"
+ 	out := shared.FunctionsServiceUpdateFunctionRequest{
+-		Function: function,
++		Function:   function,
++		UpdateMask: &updateMask,
+ 	}
+ 
+ 	return &out, diags

--- a/patches/05-access-review-update-mask.patch
+++ b/patches/05-access-review-update-mask.patch
@@ -1,0 +1,23 @@
+diff --git a/internal/provider/access_review_resource_sdk.go b/internal/provider/access_review_resource_sdk.go
+index 83cf6273..4f2398cd 100644
+--- a/internal/provider/access_review_resource_sdk.go
++++ b/internal/provider/access_review_resource_sdk.go
+@@ -1872,8 +1872,18 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
+ 		return nil, diags
+ 	}
+ 
++	// scope_v2 and policy_id are deliberately excluded: the backend rejects
++	// any update carrying either path in update_mask once the campaign has
++	// left PENDING state, regardless of whether the value actually changed.
++	// Including them here would break every other-field update (e.g. just
++	// display_name) on a running campaign. See IGA-2302 follow-up discussion.
++	updateMask := "displayName,description,reviewInstructions,defaultView,completionDate,autoResolve," +
++		"usePolicyOverride,autoGenerateReport,scopeType,exemptCertifiedAccessConflicts,autoStartCampaign," +
++		"scheduledStartDate,accuracyIssueAction,autoCloseCampaign,autoCloseDecision,columnConfig," +
++		"reviewerAttributeConfig,notificationConfig,signatureConfig,inclusionScope"
+ 	out := shared.AccessReviewServiceUpdateRequest{
+ 		AccessReview: accessReview,
++		UpdateMask:   &updateMask,
+ 	}
+ 
+ 	return &out, diags


### PR DESCRIPTION
## Summary

`conductorone_function` and `conductorone_access_review` can currently be **created** via Terraform but never **updated** — `ToSharedFunctionsServiceUpdateFunctionRequest` and `ToSharedAccessReviewServiceUpdateRequest` never set `UpdateMask`, and both backend RPCs hard-reject a nil/empty mask with `InvalidArgument: update_mask is required`. Every `terraform apply` that touches an existing resource of either type fails outright.

This is the identical bug already hit (and fixed) on `access_review_template` in #231 / IGA-2302 — Speakeasy gives itself no signal to generate `update_mask` population correctly, since the OAS shape for all three resources' Update operations is byte-identical. It's a recurring gap, not a one-off.

- `patches/04-function-update-mask.patch` — sets `UpdateMask` to a static comma-joined list of every writable `Function` field (verified against the actual `switch` in the backend's `MutateFromAPI`, not guessed from the schema).
- `patches/05-access-review-update-mask.patch` — same for `AccessReview`, **with one deliberate omission**: `scope_v2` and `policy_id` are left out of the mask. The backend rejects those two paths in `update_mask` whenever the campaign has left `PENDING` state, regardless of whether the value actually changed — so a static "always include everything" mask (the pattern used for `access_review_template`) would break unrelated field updates (e.g. just `display_name`) on any running campaign. Excluding them is safe but means those two fields are create-only via Terraform for now; enabling them later needs either a real diff-based mask or a value-aware backend check, which is a bigger change than this PR.
- Extends `TestUpdateRequestsSetUpdateMask` (new, generalized) to cover all three resources, including `access_review_template` — patch 03 shipped without a tripwire test, so a future regen could have silently dropped it with nothing to catch it.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/provider/...` — all pass, including the new tripwire test
- [x] Verified the new tripwire test actually fails without the fix (temporarily reverted via `git stash`, confirmed both error messages fire) and passes with it
- [x] `git apply --check` both new patch files against a clean checkout — apply cleanly
- [x] `bin/check all` — identical warning output before/after (all pre-existing, unrelated to this change)
- [ ] Not verified against a live tenant / real `terraform apply` — this is based on static analysis of the backend's mask-validation code, not a live repro. Would appreciate a smoke test against a real access review campaign (esp. one that's left PENDING state) before merge, given the `scope_v2`/`policy_id` exclusion is safety-critical and I don't own that resource.

## Notes for the AccessReview owning team

The `scope_v2`/`policy_id` exclusion means those fields won't be updatable via `conductorone_access_review` after creation — flagging this explicitly since I'm not on that team and want a second pair of eyes on whether that tradeoff is acceptable, or whether a smaller/different mask (or backend change) is preferred.