### PR TITLE
fix: UpdateMask field on function and access_reviews

### DIFF
--- a/docs/resources/access_review.md
+++ b/docs/resources/access_review.md
@@ -177,7 +177,7 @@ This message contains a oneof named resource_scope. Only a single field of the f
 - `duplicate_from` (String) The ID of an existing campaign to copy scope and entitlement configuration from. Optional. Requires replacement if changed.
 - `notification_config` (Attributes) Controls which email notifications are sent during the access review lifecycle. (see [below for nested schema](#nestedatt--notification_config))
 - `owner_ids` (List of String) The IDs of the users who own and manage this campaign. At least one owner is required. Requires replacement if changed.
-- `policy_id` (String) The ID of the review policy that governs task assignment and resolution.
+- `policy_id` (String) The ID of the review policy that governs task assignment and resolution. Requires replacement if changed.
 - `scope_type` (String) The type of scoping method for the campaign (e.g., by entitlements, by access conflicts, or by resource). possible known values include one of ["ACCESS_REVIEW_SCOPE_TYPE_UNSPECIFIED", "ACCESS_REVIEW_SCOPE_TYPE_BY_ENTITLEMENTS", "ACCESS_REVIEW_SCOPE_TYPE_BY_ACCESS_CONFLICTS", "ACCESS_REVIEW_SCOPE_TYPE_BY_RESOURCE", "ACCESS_REVIEW_SCOPE_TYPE_BY_INHERITANCE"]
 
 ### Read-Only

--- a/internal/provider/access_review_lifecycle_test.go
+++ b/internal/provider/access_review_lifecycle_test.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+const replacementModifierDescription = "Terraform will destroy and recreate the resource"
+
+func TestAccessReviewImmutableConfiguredAttributesRequireReplacement(t *testing.T) {
+	ctx := context.Background()
+	resp := &resource.SchemaResponse{}
+	NewAccessReviewResource().Schema(ctx, resource.SchemaRequest{}, resp)
+
+	scope, ok := resp.Schema.Attributes["access_review_scope_v2"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("access_review_scope_v2 is %T, want schema.SingleNestedAttribute", resp.Schema.Attributes["access_review_scope_v2"])
+	}
+	assertObjectAttributeRequiresReplacement(t, ctx, "access_review_scope_v2", scope.PlanModifiers)
+
+	policyID, ok := resp.Schema.Attributes["policy_id"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("policy_id is %T, want schema.StringAttribute", resp.Schema.Attributes["policy_id"])
+	}
+	assertStringAttributeRequiresReplacement(t, ctx, "policy_id", policyID.PlanModifiers)
+}
+
+func assertObjectAttributeRequiresReplacement(t *testing.T, ctx context.Context, name string, modifiers []planmodifier.Object) {
+	t.Helper()
+	for _, modifier := range modifiers {
+		if strings.Contains(modifier.Description(ctx), replacementModifierDescription) {
+			return
+		}
+	}
+	t.Errorf("attribute %q has no replacement plan modifier", name)
+}
+
+func assertStringAttributeRequiresReplacement(t *testing.T, ctx context.Context, name string, modifiers []planmodifier.String) {
+	t.Helper()
+	for _, modifier := range modifiers {
+		if strings.Contains(modifier.Description(ctx), replacementModifierDescription) {
+			return
+		}
+	}
+	t.Errorf("attribute %q has no replacement plan modifier", name)
+}

--- a/internal/provider/access_review_resource.go
+++ b/internal/provider/access_review_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -198,6 +199,9 @@ func (r *AccessReviewResource) Schema(ctx context.Context, req resource.SchemaRe
 			"access_review_scope_v2": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplaceIfConfigured(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"account_criteria_scope": schema.SingleNestedAttribute{
 						Computed: true,
@@ -742,9 +746,12 @@ func (r *AccessReviewResource) Schema(ctx context.Context, req resource.SchemaRe
 				Description: `The IDs of the users who own and manage this campaign. At least one owner is required. Requires replacement if changed.`,
 			},
 			"policy_id": schema.StringAttribute{
-				Computed:    true,
-				Optional:    true,
-				Description: `The ID of the review policy that governs task assignment and resolution.`,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Description: `The ID of the review policy that governs task assignment and resolution. Requires replacement if changed.`,
 			},
 			"policy_path": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/access_review_resource.go
+++ b/internal/provider/access_review_resource.go
@@ -961,7 +961,13 @@ func (r *AccessReviewResource) Read(ctx context.Context, req resource.ReadReques
 
 func (r *AccessReviewResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data *AccessReviewResourceModel
+	var state types.Object
 	var plan types.Object
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -979,6 +985,12 @@ func (r *AccessReviewResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	updateMask, updateMaskDiags := accessReviewUpdateMaskForChanges(state, plan, request.AccessReviewServiceUpdateRequest.AccessReview)
+	resp.Diagnostics.Append(updateMaskDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	request.AccessReviewServiceUpdateRequest.UpdateMask = updateMask
 	res, err := r.client.AccessReview.Update(ctx, *request)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())

--- a/internal/provider/access_review_resource_sdk.go
+++ b/internal/provider/access_review_resource_sdk.go
@@ -1872,18 +1872,14 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
 		return nil, diags
 	}
 
-	// scope_v2 and policy_id are deliberately excluded: the backend rejects
-	// any update carrying either path in update_mask once the campaign has
-	// left PENDING state, regardless of whether the value actually changed.
-	// Including them here would break every other-field update (e.g. just
-	// display_name) on a running campaign. See IGA-2302 follow-up discussion.
-	updateMask := "displayName,description,reviewInstructions,defaultView,completionDate,autoResolve," +
-		"usePolicyOverride,autoGenerateReport,scopeType,exemptCertifiedAccessConflicts,autoStartCampaign," +
-		"scheduledStartDate,accuracyIssueAction,autoCloseCampaign,autoCloseDecision,columnConfig," +
-		"reviewerAttributeConfig,notificationConfig,signatureConfig,inclusionScope"
+	updateMask, updateMaskDiags := accessReviewUpdateMask(accessReview)
+	diags.Append(updateMaskDiags...)
+	if diags.HasError() {
+		return nil, diags
+	}
 	out := shared.AccessReviewServiceUpdateRequest{
 		AccessReview: accessReview,
-		UpdateMask:   &updateMask,
+		UpdateMask:   updateMask,
 	}
 
 	return &out, diags

--- a/internal/provider/access_review_resource_sdk.go
+++ b/internal/provider/access_review_resource_sdk.go
@@ -1872,8 +1872,18 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
 		return nil, diags
 	}
 
+	// scope_v2 and policy_id are deliberately excluded: the backend rejects
+	// any update carrying either path in update_mask once the campaign has
+	// left PENDING state, regardless of whether the value actually changed.
+	// Including them here would break every other-field update (e.g. just
+	// display_name) on a running campaign. See IGA-2302 follow-up discussion.
+	updateMask := "displayName,description,reviewInstructions,defaultView,completionDate,autoResolve," +
+		"usePolicyOverride,autoGenerateReport,scopeType,exemptCertifiedAccessConflicts,autoStartCampaign," +
+		"scheduledStartDate,accuracyIssueAction,autoCloseCampaign,autoCloseDecision,columnConfig," +
+		"reviewerAttributeConfig,notificationConfig,signatureConfig,inclusionScope"
 	out := shared.AccessReviewServiceUpdateRequest{
 		AccessReview: accessReview,
+		UpdateMask:   &updateMask,
 	}
 
 	return &out, diags

--- a/internal/provider/function_resource.go
+++ b/internal/provider/function_resource.go
@@ -309,7 +309,13 @@ func (r *FunctionResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 func (r *FunctionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data *FunctionResourceModel
+	var state types.Object
 	var plan types.Object
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -327,6 +333,12 @@ func (r *FunctionResource) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	updateMask, updateMaskDiags := functionUpdateMaskForChanges(state, plan, request.Function)
+	resp.Diagnostics.Append(updateMaskDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	request.UpdateMask = updateMask
 	res, err := r.client.Functions.UpdateFunction(ctx, request)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())

--- a/internal/provider/function_resource_sdk.go
+++ b/internal/provider/function_resource_sdk.go
@@ -285,8 +285,11 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
 		return nil, diags
 	}
 
+	updateMask := "displayName,description,functionType,publishedCommitId,isDraft,secret," +
+		"outboundNetworkAllowlist,scopedRoleIds,provisionedConcurrency"
 	out := shared.FunctionsServiceUpdateFunctionRequest{
-		Function: function,
+		Function:   function,
+		UpdateMask: &updateMask,
 	}
 
 	return &out, diags

--- a/internal/provider/function_resource_sdk.go
+++ b/internal/provider/function_resource_sdk.go
@@ -285,11 +285,14 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
 		return nil, diags
 	}
 
-	updateMask := "displayName,description,functionType,publishedCommitId,isDraft,secret," +
-		"outboundNetworkAllowlist,scopedRoleIds,provisionedConcurrency"
+	updateMask, updateMaskDiags := functionUpdateMask(function)
+	diags.Append(updateMaskDiags...)
+	if diags.HasError() {
+		return nil, diags
+	}
 	out := shared.FunctionsServiceUpdateFunctionRequest{
 		Function:   function,
-		UpdateMask: &updateMask,
+		UpdateMask: updateMask,
 	}
 
 	return &out, diags

--- a/internal/provider/speakeasy_regen_test.go
+++ b/internal/provider/speakeasy_regen_test.go
@@ -200,3 +200,62 @@ func TestAppEntitlementSDKMirrorsManualProvisionSchema(t *testing.T) {
 		}
 	}
 }
+
+// TestUpdateRequestsSetUpdateMask verifies that every listed resource's
+// ToShared*ServiceUpdateRequest / ToShared*ServiceUpdateFunctionRequest
+// function actually populates UpdateMask on the outgoing shared request.
+//
+// Regression: Speakeasy does not auto-generate update_mask population for
+// these operations (nothing in the OAS distinguishes them from
+// access_review_template, which Speakeasy also doesn't handle — that one is
+// hand-patched too, see patches/03). The backend RPCs behind Function and
+// AccessReview hard-reject a request with a nil/empty update_mask
+// (InvalidArgument: "update_mask is required"), so without this, every
+// terraform apply that updates an existing conductorone_function or
+// conductorone_access_review fails outright. Fixed by patches/04 and
+// patches/05, which set UpdateMask to a static comma-joined list of every
+// writable field. AccessReview's list deliberately omits scope_v2 and
+// policy_id: the backend rejects those paths in update_mask once a campaign
+// leaves PENDING state regardless of whether the value changed, so a static
+// full mask would break unrelated field updates (e.g. display_name) on any
+// running campaign.
+func TestUpdateRequestsSetUpdateMask(t *testing.T) {
+	cases := []struct {
+		file     string
+		funcName string
+	}{
+		{"function_resource_sdk.go", "ToSharedFunctionsServiceUpdateFunctionRequest"},
+		{"access_review_resource_sdk.go", "ToSharedAccessReviewServiceUpdateRequest"},
+	}
+
+	funcBody := regexp.MustCompile(`(?s)func \(r \*\w+\) (\w+)\(ctx context\.Context\).*?\n}\n`)
+
+	for _, c := range cases {
+		data, err := os.ReadFile(c.file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", c.file, err)
+		}
+		content := string(data)
+
+		matches := funcBody.FindAllStringSubmatch(content, -1)
+		var body string
+		found := false
+		for _, m := range matches {
+			if m[1] == c.funcName {
+				body = m[0]
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("%s: could not find function %s", c.file, c.funcName)
+		}
+
+		if !strings.Contains(body, "UpdateMask:") {
+			t.Errorf("%s: %s does not set UpdateMask on the outgoing request. "+
+				"The backend requires a non-empty update_mask and will reject every "+
+				"Update() call with InvalidArgument otherwise. Re-apply patches/04-function-update-mask.patch "+
+				"or patches/05-access-review-update-mask.patch (whichever matches %s).", c.file, c.funcName, c.file)
+		}
+	}
+}

--- a/internal/provider/speakeasy_regen_test.go
+++ b/internal/provider/speakeasy_regen_test.go
@@ -206,14 +206,16 @@ func TestAppEntitlementSDKMirrorsManualProvisionSchema(t *testing.T) {
 // function actually populates UpdateMask on the outgoing shared request.
 //
 // Regression: Speakeasy does not auto-generate update_mask population for
-// these operations (nothing in the OAS distinguishes them from
-// access_review_template, which Speakeasy also doesn't handle — that one is
-// hand-patched too, see patches/03). The backend RPCs behind Function and
-// AccessReview hard-reject a request with a nil/empty update_mask
-// (InvalidArgument: "update_mask is required"), so without this, every
-// terraform apply that updates an existing conductorone_function or
-// conductorone_access_review fails outright. Fixed by patches/04 and
-// patches/05, which set UpdateMask to a static comma-joined list of every
+// these operations — nothing in the OAS distinguishes any of the three
+// resources below from each other. access_review_template hit this first
+// and was hand-patched (patches/03, PR #231 / IGA-2302) with no tripwire
+// test added at the time; function and access_review hit the identical bug
+// later (patches/04, patches/05). All three backend RPCs hard-reject a
+// request with a nil/empty update_mask (InvalidArgument: "update_mask is
+// required"), so without this, every terraform apply that updates an
+// existing resource of any of these three types fails outright.
+//
+// Each patch sets UpdateMask to a static comma-joined list of every
 // writable field. AccessReview's list deliberately omits scope_v2 and
 // policy_id: the backend rejects those paths in update_mask once a campaign
 // leaves PENDING state regardless of whether the value changed, so a static
@@ -226,6 +228,7 @@ func TestUpdateRequestsSetUpdateMask(t *testing.T) {
 	}{
 		{"function_resource_sdk.go", "ToSharedFunctionsServiceUpdateFunctionRequest"},
 		{"access_review_resource_sdk.go", "ToSharedAccessReviewServiceUpdateRequest"},
+		{"access_review_template_resource_sdk.go", "ToSharedAccessReviewTemplateServiceUpdateRequest"},
 	}
 
 	funcBody := regexp.MustCompile(`(?s)func \(r \*\w+\) (\w+)\(ctx context\.Context\).*?\n}\n`)

--- a/internal/provider/speakeasy_regen_test.go
+++ b/internal/provider/speakeasy_regen_test.go
@@ -215,12 +215,9 @@ func TestAppEntitlementSDKMirrorsManualProvisionSchema(t *testing.T) {
 // required"), so without this, every terraform apply that updates an
 // existing resource of any of these three types fails outright.
 //
-// Each patch sets UpdateMask to a static comma-joined list of every
-// writable field. AccessReview's list deliberately omits scope_v2 and
-// policy_id: the backend rejects those paths in update_mask once a campaign
-// leaves PENDING state regardless of whether the value changed, so a static
-// full mask would break unrelated field updates (e.g. display_name) on any
-// running campaign.
+// Function and AccessReview use payload-aware masks and then narrow them to
+// Terraform attributes that changed. This avoids invalid paths that the API
+// does not accept and paths omitted from the JSON payload by omitempty.
 func TestUpdateRequestsSetUpdateMask(t *testing.T) {
 	cases := []struct {
 		file     string
@@ -259,6 +256,34 @@ func TestUpdateRequestsSetUpdateMask(t *testing.T) {
 				"The backend requires a non-empty update_mask and will reject every "+
 				"Update() call with InvalidArgument otherwise. Re-apply patches/04-function-update-mask.patch "+
 				"or patches/05-access-review-update-mask.patch (whichever matches %s).", c.file, c.funcName, c.file)
+		}
+	}
+
+	forbiddenPaths := map[string]string{
+		"function_resource_sdk.go":      "provisionedConcurrency",
+		"access_review_resource_sdk.go": "reviewerAttributeConfig",
+	}
+	for file, path := range forbiddenPaths {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		if strings.Contains(string(data), path) {
+			t.Errorf("%s still includes unsupported update-mask path %q", file, path)
+		}
+	}
+
+	changeAwareMasks := map[string]string{
+		"function_resource.go":      "functionUpdateMaskForChanges(state, plan, request.Function)",
+		"access_review_resource.go": "accessReviewUpdateMaskForChanges(state, plan, request.AccessReviewServiceUpdateRequest.AccessReview)",
+	}
+	for file, marker := range changeAwareMasks {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		if !strings.Contains(string(data), marker) {
+			t.Errorf("%s does not narrow the update mask to changed, serialized fields", file)
 		}
 	}
 }

--- a/internal/provider/update_mask.go
+++ b/internal/provider/update_mask.go
@@ -1,0 +1,152 @@
+package provider
+
+import (
+	"strings"
+
+	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type updateMaskField struct {
+	terraformName string
+	apiPath       string
+	serialized    bool
+}
+
+// updateMaskForChanges builds a mask from fields which both changed in the
+// Terraform plan and are present in the JSON payload. Update APIs reject an
+// empty mask, while including an omitted field in a mask can overwrite it.
+func updateMaskForChanges(state, plan types.Object, fields []updateMaskField) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	stateAttributes := state.Attributes()
+	planAttributes := plan.Attributes()
+	paths := make([]string, 0, len(fields))
+
+	for _, field := range fields {
+		stateValue, stateOK := stateAttributes[field.terraformName]
+		planValue, planOK := planAttributes[field.terraformName]
+		if !stateOK || !planOK || planValue.Equal(stateValue) {
+			continue
+		}
+		if field.serialized {
+			paths = append(paths, field.apiPath)
+		}
+	}
+
+	if len(paths) == 0 {
+		diags.AddError(
+			"Unable to build update mask",
+			"The planned changes do not include a field that this provider can safely serialize for this update. No request was sent.",
+		)
+		return nil, diags
+	}
+
+	mask := strings.Join(paths, ",")
+	return &mask, diags
+}
+
+func functionUpdateMask(input *shared.FunctionInput) (*string, diag.Diagnostics) {
+	if input == nil {
+		return updateMaskForSerializedFields(nil)
+	}
+
+	return updateMaskForSerializedFields([]updateMaskField{
+		{apiPath: "displayName", serialized: input.DisplayName != nil},
+		{apiPath: "description", serialized: input.Description != nil},
+		{apiPath: "functionType", serialized: input.FunctionType != nil},
+		{apiPath: "publishedCommitId", serialized: input.PublishedCommitID != nil},
+		{apiPath: "isDraft", serialized: input.IsDraft != nil},
+		{apiPath: "secret", serialized: len(input.Secret) > 0},
+		{apiPath: "outboundNetworkAllowlist", serialized: len(input.OutboundNetworkAllowlist) > 0},
+		{apiPath: "scopedRoleIds", serialized: len(input.ScopedRoleIds) > 0},
+	})
+}
+
+func functionUpdateMaskForChanges(state, plan types.Object, input *shared.FunctionInput) (*string, diag.Diagnostics) {
+	return updateMaskForChanges(state, plan, []updateMaskField{
+		{terraformName: "display_name", apiPath: "displayName", serialized: input != nil && input.DisplayName != nil},
+		{terraformName: "description", apiPath: "description", serialized: input != nil && input.Description != nil},
+		{terraformName: "function_type", apiPath: "functionType", serialized: input != nil && input.FunctionType != nil},
+		{terraformName: "published_commit_id", apiPath: "publishedCommitId", serialized: input != nil && input.PublishedCommitID != nil},
+		{terraformName: "is_draft", apiPath: "isDraft", serialized: input != nil && input.IsDraft != nil},
+		{terraformName: "secret", apiPath: "secret", serialized: input != nil && len(input.Secret) > 0},
+		{terraformName: "outbound_network_allowlist", apiPath: "outboundNetworkAllowlist", serialized: input != nil && len(input.OutboundNetworkAllowlist) > 0},
+		{terraformName: "scoped_role_ids", apiPath: "scopedRoleIds", serialized: input != nil && len(input.ScopedRoleIds) > 0},
+	})
+}
+
+func accessReviewUpdateMask(input *shared.AccessReviewInput) (*string, diag.Diagnostics) {
+	if input == nil {
+		return updateMaskForSerializedFields(nil)
+	}
+
+	return updateMaskForSerializedFields([]updateMaskField{
+		{apiPath: "displayName", serialized: input.DisplayName != nil},
+		{apiPath: "description", serialized: input.Description != nil},
+		{apiPath: "reviewInstructions", serialized: input.ReviewInstructions != nil},
+		{apiPath: "defaultView", serialized: input.DefaultView != nil},
+		{apiPath: "completionDate", serialized: input.CompletionDate != nil},
+		{apiPath: "autoResolve", serialized: input.AutoResolve != nil},
+		{apiPath: "usePolicyOverride", serialized: input.UsePolicyOverride != nil},
+		{apiPath: "autoGenerateReport", serialized: input.AutoGenerateReport != nil},
+		{apiPath: "scopeType", serialized: input.ScopeType != nil},
+		{apiPath: "exemptCertifiedAccessConflicts", serialized: input.ExemptCertifiedAccessConflicts != nil},
+		{apiPath: "autoStartCampaign", serialized: input.AutoStartCampaign != nil},
+		{apiPath: "scheduledStartDate", serialized: input.ScheduledStartDate != nil},
+		{apiPath: "accuracyIssueAction", serialized: input.AccuracyIssueAction != nil},
+		{apiPath: "autoCloseCampaign", serialized: input.AutoCloseCampaign != nil},
+		{apiPath: "autoCloseDecision", serialized: input.AutoCloseDecision != nil},
+		{apiPath: "columnConfig", serialized: input.AccessReviewColumnConfig != nil},
+		{apiPath: "notificationConfig", serialized: input.NotificationConfig != nil},
+		{apiPath: "signatureConfig", serialized: input.ReviewSignatureConfig != nil},
+		{apiPath: "inclusionScope", serialized: input.AccessReviewInclusionScope != nil},
+	})
+}
+
+func accessReviewUpdateMaskForChanges(state, plan types.Object, input *shared.AccessReviewInput) (*string, diag.Diagnostics) {
+	if input == nil {
+		return updateMaskForChanges(state, plan, nil)
+	}
+
+	return updateMaskForChanges(state, plan, []updateMaskField{
+		{terraformName: "display_name", apiPath: "displayName", serialized: input.DisplayName != nil},
+		{terraformName: "description", apiPath: "description", serialized: input.Description != nil},
+		{terraformName: "review_instructions", apiPath: "reviewInstructions", serialized: input.ReviewInstructions != nil},
+		{terraformName: "default_view", apiPath: "defaultView", serialized: input.DefaultView != nil},
+		{terraformName: "completion_date", apiPath: "completionDate", serialized: input.CompletionDate != nil},
+		{terraformName: "auto_resolve", apiPath: "autoResolve", serialized: input.AutoResolve != nil},
+		{terraformName: "use_policy_override", apiPath: "usePolicyOverride", serialized: input.UsePolicyOverride != nil},
+		{terraformName: "auto_generate_report", apiPath: "autoGenerateReport", serialized: input.AutoGenerateReport != nil},
+		{terraformName: "scope_type", apiPath: "scopeType", serialized: input.ScopeType != nil},
+		{terraformName: "exempt_certified_access_conflicts", apiPath: "exemptCertifiedAccessConflicts", serialized: input.ExemptCertifiedAccessConflicts != nil},
+		{terraformName: "auto_start_campaign", apiPath: "autoStartCampaign", serialized: input.AutoStartCampaign != nil},
+		{terraformName: "scheduled_start_date", apiPath: "scheduledStartDate", serialized: input.ScheduledStartDate != nil},
+		{terraformName: "accuracy_issue_action", apiPath: "accuracyIssueAction", serialized: input.AccuracyIssueAction != nil},
+		{terraformName: "auto_close_campaign", apiPath: "autoCloseCampaign", serialized: input.AutoCloseCampaign != nil},
+		{terraformName: "auto_close_decision", apiPath: "autoCloseDecision", serialized: input.AutoCloseDecision != nil},
+		{terraformName: "access_review_column_config", apiPath: "columnConfig", serialized: input.AccessReviewColumnConfig != nil},
+		{terraformName: "notification_config", apiPath: "notificationConfig", serialized: input.NotificationConfig != nil},
+		{terraformName: "review_signature_config", apiPath: "signatureConfig", serialized: input.ReviewSignatureConfig != nil},
+		{terraformName: "access_review_inclusion_scope", apiPath: "inclusionScope", serialized: input.AccessReviewInclusionScope != nil},
+	})
+}
+
+func updateMaskForSerializedFields(fields []updateMaskField) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	paths := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field.serialized {
+			paths = append(paths, field.apiPath)
+		}
+	}
+	if len(paths) == 0 {
+		diags.AddError(
+			"Unable to build update mask",
+			"The update payload has no maskable fields. No request was sent.",
+		)
+		return nil, diags
+	}
+	mask := strings.Join(paths, ",")
+	return &mask, diags
+}

--- a/internal/provider/update_mask_test.go
+++ b/internal/provider/update_mask_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"testing"
 
 	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
@@ -95,7 +96,7 @@ func TestPayloadMasksContainOnlySerializedBackendPaths(t *testing.T) {
 func updateMaskObjects(state, plan map[string]attr.Value) (types.Object, types.Object) {
 	attributeTypes := make(map[string]attr.Type, len(state))
 	for name, value := range state {
-		attributeTypes[name] = value.Type(nil)
+		attributeTypes[name] = value.Type(context.Background())
 	}
 	return types.ObjectValueMust(attributeTypes, state), types.ObjectValueMust(attributeTypes, plan)
 }

--- a/internal/provider/update_mask_test.go
+++ b/internal/provider/update_mask_test.go
@@ -1,0 +1,105 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFunctionUpdateMaskForChangesIncludesOnlyChangedSerializedField(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{
+			"display_name": types.StringValue("before"),
+			"description":  types.StringValue("unchanged"),
+		},
+		map[string]attr.Value{
+			"display_name": types.StringValue("after"),
+			"description":  types.StringValue("unchanged"),
+		},
+	)
+
+	mask, diags := functionUpdateMaskForChanges(state, plan, &shared.FunctionInput{
+		DisplayName: stringPointer("after"),
+		Description: stringPointer("unchanged"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got, want := *mask, "displayName"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}
+
+func TestAccessReviewUpdateMaskExcludesAbsentAndUnsupportedFields(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{
+			"description":         types.StringValue("before"),
+			"notification_config": types.ObjectNull(map[string]attr.Type{}),
+		},
+		map[string]attr.Value{
+			"description":         types.StringValue("after"),
+			"notification_config": types.ObjectNull(map[string]attr.Type{}),
+		},
+	)
+
+	mask, diags := accessReviewUpdateMaskForChanges(state, plan, &shared.AccessReviewInput{
+		Description: stringPointer("after"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got, want := *mask, "description"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}
+
+func TestUpdateMaskRejectsChangedFieldMissingFromPayload(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{"description": types.StringValue("before")},
+		map[string]attr.Value{"description": types.StringNull()},
+	)
+
+	mask, diags := functionUpdateMaskForChanges(state, plan, &shared.FunctionInput{})
+	if mask != nil {
+		t.Errorf("mask = %q, want nil", *mask)
+	}
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics when a changed field is omitted from the payload")
+	}
+}
+
+func TestPayloadMasksContainOnlySerializedBackendPaths(t *testing.T) {
+	functionMask, functionDiags := functionUpdateMask(&shared.FunctionInput{
+		DisplayName: stringPointer("function"),
+	})
+	if functionDiags.HasError() {
+		t.Fatalf("unexpected function diagnostics: %v", functionDiags)
+	}
+	if got, want := *functionMask, "displayName"; got != want {
+		t.Errorf("function mask = %q, want %q", got, want)
+	}
+
+	accessReviewMask, accessReviewDiags := accessReviewUpdateMask(&shared.AccessReviewInput{
+		Description: stringPointer("campaign"),
+	})
+	if accessReviewDiags.HasError() {
+		t.Fatalf("unexpected access review diagnostics: %v", accessReviewDiags)
+	}
+	if got, want := *accessReviewMask, "description"; got != want {
+		t.Errorf("access review mask = %q, want %q", got, want)
+	}
+}
+
+func updateMaskObjects(state, plan map[string]attr.Value) (types.Object, types.Object) {
+	attributeTypes := make(map[string]attr.Type, len(state))
+	for name, value := range state {
+		attributeTypes[name] = value.Type(nil)
+	}
+	return types.ObjectValueMust(attributeTypes, state), types.ObjectValueMust(attributeTypes, plan)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/patches/04-function-update-mask.patch
+++ b/patches/04-function-update-mask.patch
@@ -1,17 +1,207 @@
+diff --git a/internal/provider/function_resource.go b/internal/provider/function_resource.go
+--- a/internal/provider/function_resource.go
++++ b/internal/provider/function_resource.go
+@@ -309,8 +309,14 @@ func (r *FunctionResource) Read(ctx context.Context, req resource.ReadRequest, r
+ 
+ func (r *FunctionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+ 	var data *FunctionResourceModel
++	var state types.Object
+ 	var plan types.Object
+ 
++	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++
+ 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+ 	if resp.Diagnostics.HasError() {
+ 		return
+@@ -327,6 +333,12 @@ func (r *FunctionResource) Update(ctx context.Context, req resource.UpdateReques
+ 	if resp.Diagnostics.HasError() {
+ 		return
+ 	}
++	updateMask, updateMaskDiags := functionUpdateMaskForChanges(state, plan, request.Function)
++	resp.Diagnostics.Append(updateMaskDiags...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++	request.UpdateMask = updateMask
+ 	res, err := r.client.Functions.UpdateFunction(ctx, request)
+ 	if err != nil {
+ 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
 diff --git a/internal/provider/function_resource_sdk.go b/internal/provider/function_resource_sdk.go
-index ca09e5d0..2cc9ff38 100644
 --- a/internal/provider/function_resource_sdk.go
 +++ b/internal/provider/function_resource_sdk.go
-@@ -285,8 +285,11 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
+@@ -285,8 +285,14 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
  		return nil, diags
  	}
  
-+	updateMask := "displayName,description,functionType,publishedCommitId,isDraft,secret," +
-+		"outboundNetworkAllowlist,scopedRoleIds,provisionedConcurrency"
++	updateMask, updateMaskDiags := functionUpdateMask(function)
++	diags.Append(updateMaskDiags...)
++	if diags.HasError() {
++		return nil, diags
++	}
  	out := shared.FunctionsServiceUpdateFunctionRequest{
 -		Function: function,
 +		Function:   function,
-+		UpdateMask: &updateMask,
++		UpdateMask: updateMask,
  	}
  
  	return &out, diags
+diff --git a/internal/provider/update_mask.go b/internal/provider/update_mask.go
+new file mode 100644
+--- /dev/null
++++ b/internal/provider/update_mask.go
+@@ -0,0 +1,152 @@
++package provider
++
++import (
++	"strings"
++
++	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
++	"github.com/hashicorp/terraform-plugin-framework/diag"
++	"github.com/hashicorp/terraform-plugin-framework/types"
++)
++
++type updateMaskField struct {
++	terraformName string
++	apiPath       string
++	serialized    bool
++}
++
++// updateMaskForChanges builds a mask from fields which both changed in the
++// Terraform plan and are present in the JSON payload. Update APIs reject an
++// empty mask, while including an omitted field in a mask can overwrite it.
++func updateMaskForChanges(state, plan types.Object, fields []updateMaskField) (*string, diag.Diagnostics) {
++	var diags diag.Diagnostics
++	stateAttributes := state.Attributes()
++	planAttributes := plan.Attributes()
++	paths := make([]string, 0, len(fields))
++
++	for _, field := range fields {
++		stateValue, stateOK := stateAttributes[field.terraformName]
++		planValue, planOK := planAttributes[field.terraformName]
++		if !stateOK || !planOK || planValue.Equal(stateValue) {
++			continue
++		}
++		if field.serialized {
++			paths = append(paths, field.apiPath)
++		}
++	}
++
++	if len(paths) == 0 {
++		diags.AddError(
++			"Unable to build update mask",
++			"The planned changes do not include a field that this provider can safely serialize for this update. No request was sent.",
++		)
++		return nil, diags
++	}
++
++	mask := strings.Join(paths, ",")
++	return &mask, diags
++}
++
++func functionUpdateMask(input *shared.FunctionInput) (*string, diag.Diagnostics) {
++	if input == nil {
++		return updateMaskForSerializedFields(nil)
++	}
++
++	return updateMaskForSerializedFields([]updateMaskField{
++		{apiPath: "displayName", serialized: input.DisplayName != nil},
++		{apiPath: "description", serialized: input.Description != nil},
++		{apiPath: "functionType", serialized: input.FunctionType != nil},
++		{apiPath: "publishedCommitId", serialized: input.PublishedCommitID != nil},
++		{apiPath: "isDraft", serialized: input.IsDraft != nil},
++		{apiPath: "secret", serialized: len(input.Secret) > 0},
++		{apiPath: "outboundNetworkAllowlist", serialized: len(input.OutboundNetworkAllowlist) > 0},
++		{apiPath: "scopedRoleIds", serialized: len(input.ScopedRoleIds) > 0},
++	})
++}
++
++func functionUpdateMaskForChanges(state, plan types.Object, input *shared.FunctionInput) (*string, diag.Diagnostics) {
++	return updateMaskForChanges(state, plan, []updateMaskField{
++		{terraformName: "display_name", apiPath: "displayName", serialized: input != nil && input.DisplayName != nil},
++		{terraformName: "description", apiPath: "description", serialized: input != nil && input.Description != nil},
++		{terraformName: "function_type", apiPath: "functionType", serialized: input != nil && input.FunctionType != nil},
++		{terraformName: "published_commit_id", apiPath: "publishedCommitId", serialized: input != nil && input.PublishedCommitID != nil},
++		{terraformName: "is_draft", apiPath: "isDraft", serialized: input != nil && input.IsDraft != nil},
++		{terraformName: "secret", apiPath: "secret", serialized: input != nil && len(input.Secret) > 0},
++		{terraformName: "outbound_network_allowlist", apiPath: "outboundNetworkAllowlist", serialized: input != nil && len(input.OutboundNetworkAllowlist) > 0},
++		{terraformName: "scoped_role_ids", apiPath: "scopedRoleIds", serialized: input != nil && len(input.ScopedRoleIds) > 0},
++	})
++}
++
++func accessReviewUpdateMask(input *shared.AccessReviewInput) (*string, diag.Diagnostics) {
++	if input == nil {
++		return updateMaskForSerializedFields(nil)
++	}
++
++	return updateMaskForSerializedFields([]updateMaskField{
++		{apiPath: "displayName", serialized: input.DisplayName != nil},
++		{apiPath: "description", serialized: input.Description != nil},
++		{apiPath: "reviewInstructions", serialized: input.ReviewInstructions != nil},
++		{apiPath: "defaultView", serialized: input.DefaultView != nil},
++		{apiPath: "completionDate", serialized: input.CompletionDate != nil},
++		{apiPath: "autoResolve", serialized: input.AutoResolve != nil},
++		{apiPath: "usePolicyOverride", serialized: input.UsePolicyOverride != nil},
++		{apiPath: "autoGenerateReport", serialized: input.AutoGenerateReport != nil},
++		{apiPath: "scopeType", serialized: input.ScopeType != nil},
++		{apiPath: "exemptCertifiedAccessConflicts", serialized: input.ExemptCertifiedAccessConflicts != nil},
++		{apiPath: "autoStartCampaign", serialized: input.AutoStartCampaign != nil},
++		{apiPath: "scheduledStartDate", serialized: input.ScheduledStartDate != nil},
++		{apiPath: "accuracyIssueAction", serialized: input.AccuracyIssueAction != nil},
++		{apiPath: "autoCloseCampaign", serialized: input.AutoCloseCampaign != nil},
++		{apiPath: "autoCloseDecision", serialized: input.AutoCloseDecision != nil},
++		{apiPath: "columnConfig", serialized: input.AccessReviewColumnConfig != nil},
++		{apiPath: "notificationConfig", serialized: input.NotificationConfig != nil},
++		{apiPath: "signatureConfig", serialized: input.ReviewSignatureConfig != nil},
++		{apiPath: "inclusionScope", serialized: input.AccessReviewInclusionScope != nil},
++	})
++}
++
++func accessReviewUpdateMaskForChanges(state, plan types.Object, input *shared.AccessReviewInput) (*string, diag.Diagnostics) {
++	if input == nil {
++		return updateMaskForChanges(state, plan, nil)
++	}
++
++	return updateMaskForChanges(state, plan, []updateMaskField{
++		{terraformName: "display_name", apiPath: "displayName", serialized: input.DisplayName != nil},
++		{terraformName: "description", apiPath: "description", serialized: input.Description != nil},
++		{terraformName: "review_instructions", apiPath: "reviewInstructions", serialized: input.ReviewInstructions != nil},
++		{terraformName: "default_view", apiPath: "defaultView", serialized: input.DefaultView != nil},
++		{terraformName: "completion_date", apiPath: "completionDate", serialized: input.CompletionDate != nil},
++		{terraformName: "auto_resolve", apiPath: "autoResolve", serialized: input.AutoResolve != nil},
++		{terraformName: "use_policy_override", apiPath: "usePolicyOverride", serialized: input.UsePolicyOverride != nil},
++		{terraformName: "auto_generate_report", apiPath: "autoGenerateReport", serialized: input.AutoGenerateReport != nil},
++		{terraformName: "scope_type", apiPath: "scopeType", serialized: input.ScopeType != nil},
++		{terraformName: "exempt_certified_access_conflicts", apiPath: "exemptCertifiedAccessConflicts", serialized: input.ExemptCertifiedAccessConflicts != nil},
++		{terraformName: "auto_start_campaign", apiPath: "autoStartCampaign", serialized: input.AutoStartCampaign != nil},
++		{terraformName: "scheduled_start_date", apiPath: "scheduledStartDate", serialized: input.ScheduledStartDate != nil},
++		{terraformName: "accuracy_issue_action", apiPath: "accuracyIssueAction", serialized: input.AccuracyIssueAction != nil},
++		{terraformName: "auto_close_campaign", apiPath: "autoCloseCampaign", serialized: input.AutoCloseCampaign != nil},
++		{terraformName: "auto_close_decision", apiPath: "autoCloseDecision", serialized: input.AutoCloseDecision != nil},
++		{terraformName: "access_review_column_config", apiPath: "columnConfig", serialized: input.AccessReviewColumnConfig != nil},
++		{terraformName: "notification_config", apiPath: "notificationConfig", serialized: input.NotificationConfig != nil},
++		{terraformName: "review_signature_config", apiPath: "signatureConfig", serialized: input.ReviewSignatureConfig != nil},
++		{terraformName: "access_review_inclusion_scope", apiPath: "inclusionScope", serialized: input.AccessReviewInclusionScope != nil},
++	})
++}
++
++func updateMaskForSerializedFields(fields []updateMaskField) (*string, diag.Diagnostics) {
++	var diags diag.Diagnostics
++	paths := make([]string, 0, len(fields))
++	for _, field := range fields {
++		if field.serialized {
++			paths = append(paths, field.apiPath)
++		}
++	}
++	if len(paths) == 0 {
++		diags.AddError(
++			"Unable to build update mask",
++			"The update payload has no maskable fields. No request was sent.",
++		)
++		return nil, diags
++	}
++	mask := strings.Join(paths, ",")
++	return &mask, diags
++}

--- a/patches/04-function-update-mask.patch
+++ b/patches/04-function-update-mask.patch
@@ -1,207 +1,71 @@
 diff --git a/internal/provider/function_resource.go b/internal/provider/function_resource.go
---- a/internal/provider/function_resource.go
-+++ b/internal/provider/function_resource.go
-@@ -309,8 +309,14 @@ func (r *FunctionResource) Read(ctx context.Context, req resource.ReadRequest, r
- 
- func (r *FunctionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
- 	var data *FunctionResourceModel
-+	var state types.Object
- 	var plan types.Object
- 
-+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-+	if resp.Diagnostics.HasError() {
-+		return
-+	}
-+
- 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
- 	if resp.Diagnostics.HasError() {
- 		return
-@@ -327,6 +333,12 @@ func (r *FunctionResource) Update(ctx context.Context, req resource.UpdateReques
- 	if resp.Diagnostics.HasError() {
- 		return
- 	}
-+	updateMask, updateMaskDiags := functionUpdateMaskForChanges(state, plan, request.Function)
-+	resp.Diagnostics.Append(updateMaskDiags...)
-+	if resp.Diagnostics.HasError() {
-+		return
-+	}
-+	request.UpdateMask = updateMask
- 	res, err := r.client.Functions.UpdateFunction(ctx, request)
- 	if err != nil {
- 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
+index 9b58fb9d8840f66a641e7ee02f5b89daf2b056c6..46997bbf1f764b6b8934e8db167a30549cb6399b 100644
+GIT binary patch
+delta 230
+zcmcapwz+bHo4!zSNn%N=LP=#oYO$VwQdVkm$>a?RW>Uc*VLkWM5{=}N3LOPCurf_O
+zJw46I2NaDbH>gQ$F41>pj4Ulk0V?!OEY8+ZK(Jjh6Vr<otZWt1O7oISGV}97;mX|d
+zi<~nO^U_m`HNa--C=}!*=IJODr52W^7MJL`L3K=aP?8o#GZAXNz5*vqHNsp4TO|7@
+N|1nqGe9fSZ3jqG{R7L;*
+
+delta 24
+gcmdm7d8cfHoBrf&3YC-X41P?Wqa?ps*QkvP0F&nmkpKVy
+
 diff --git a/internal/provider/function_resource_sdk.go b/internal/provider/function_resource_sdk.go
---- a/internal/provider/function_resource_sdk.go
-+++ b/internal/provider/function_resource_sdk.go
-@@ -285,8 +285,14 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
- 		return nil, diags
- 	}
- 
-+	updateMask, updateMaskDiags := functionUpdateMask(function)
-+	diags.Append(updateMaskDiags...)
-+	if diags.HasError() {
-+		return nil, diags
-+	}
- 	out := shared.FunctionsServiceUpdateFunctionRequest{
--		Function: function,
-+		Function:   function,
-+		UpdateMask: updateMask,
- 	}
- 
- 	return &out, diags
+index 2cc9ff38db4ba655c3f89e8a910c0a5143d3bf2c..a221d8e6a1d4adab206a63ca0fdd2db42e8d393a 100644
+GIT binary patch
+delta 131
+zcmaFqbJJ%-sA`CgLTN!tVo9oRVsW-hW@37=f|ad8T4`Q#NoIatC|pVdCZx&5nF3O#
+z=U7mXnwO%1rdv->Pm^o19IxbL6IId4>y+guFW?oJ%p=G-Sx!xb3!!*&pP&o?PqQr|
+
+delta 166
+zcmccV^U`NSsA{l+m92tON@j6EPGY5BVs5HVN@{U(QD#9&W`3SdT4`P~h!Ij*kg8Kq
+znv|1SoROO1oS&PUS>l<ZlUeLil$chcQ=FPylv<*rq@c~k$*Gh-Ie}GNO{X|HzaTXw
+zC_g9FGo@IkpeVmAvlwU;NPAv#X;D#XUUH?<<h9BQlNay`Oy&{foXoGL!mU<Xkdj!E
+N>YG@cJ-JU%1_1vgJ3#;d
+
 diff --git a/internal/provider/update_mask.go b/internal/provider/update_mask.go
 new file mode 100644
---- /dev/null
-+++ b/internal/provider/update_mask.go
-@@ -0,0 +1,152 @@
-+package provider
-+
-+import (
-+	"strings"
-+
-+	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
-+	"github.com/hashicorp/terraform-plugin-framework/diag"
-+	"github.com/hashicorp/terraform-plugin-framework/types"
-+)
-+
-+type updateMaskField struct {
-+	terraformName string
-+	apiPath       string
-+	serialized    bool
-+}
-+
-+// updateMaskForChanges builds a mask from fields which both changed in the
-+// Terraform plan and are present in the JSON payload. Update APIs reject an
-+// empty mask, while including an omitted field in a mask can overwrite it.
-+func updateMaskForChanges(state, plan types.Object, fields []updateMaskField) (*string, diag.Diagnostics) {
-+	var diags diag.Diagnostics
-+	stateAttributes := state.Attributes()
-+	planAttributes := plan.Attributes()
-+	paths := make([]string, 0, len(fields))
-+
-+	for _, field := range fields {
-+		stateValue, stateOK := stateAttributes[field.terraformName]
-+		planValue, planOK := planAttributes[field.terraformName]
-+		if !stateOK || !planOK || planValue.Equal(stateValue) {
-+			continue
-+		}
-+		if field.serialized {
-+			paths = append(paths, field.apiPath)
-+		}
-+	}
-+
-+	if len(paths) == 0 {
-+		diags.AddError(
-+			"Unable to build update mask",
-+			"The planned changes do not include a field that this provider can safely serialize for this update. No request was sent.",
-+		)
-+		return nil, diags
-+	}
-+
-+	mask := strings.Join(paths, ",")
-+	return &mask, diags
-+}
-+
-+func functionUpdateMask(input *shared.FunctionInput) (*string, diag.Diagnostics) {
-+	if input == nil {
-+		return updateMaskForSerializedFields(nil)
-+	}
-+
-+	return updateMaskForSerializedFields([]updateMaskField{
-+		{apiPath: "displayName", serialized: input.DisplayName != nil},
-+		{apiPath: "description", serialized: input.Description != nil},
-+		{apiPath: "functionType", serialized: input.FunctionType != nil},
-+		{apiPath: "publishedCommitId", serialized: input.PublishedCommitID != nil},
-+		{apiPath: "isDraft", serialized: input.IsDraft != nil},
-+		{apiPath: "secret", serialized: len(input.Secret) > 0},
-+		{apiPath: "outboundNetworkAllowlist", serialized: len(input.OutboundNetworkAllowlist) > 0},
-+		{apiPath: "scopedRoleIds", serialized: len(input.ScopedRoleIds) > 0},
-+	})
-+}
-+
-+func functionUpdateMaskForChanges(state, plan types.Object, input *shared.FunctionInput) (*string, diag.Diagnostics) {
-+	return updateMaskForChanges(state, plan, []updateMaskField{
-+		{terraformName: "display_name", apiPath: "displayName", serialized: input != nil && input.DisplayName != nil},
-+		{terraformName: "description", apiPath: "description", serialized: input != nil && input.Description != nil},
-+		{terraformName: "function_type", apiPath: "functionType", serialized: input != nil && input.FunctionType != nil},
-+		{terraformName: "published_commit_id", apiPath: "publishedCommitId", serialized: input != nil && input.PublishedCommitID != nil},
-+		{terraformName: "is_draft", apiPath: "isDraft", serialized: input != nil && input.IsDraft != nil},
-+		{terraformName: "secret", apiPath: "secret", serialized: input != nil && len(input.Secret) > 0},
-+		{terraformName: "outbound_network_allowlist", apiPath: "outboundNetworkAllowlist", serialized: input != nil && len(input.OutboundNetworkAllowlist) > 0},
-+		{terraformName: "scoped_role_ids", apiPath: "scopedRoleIds", serialized: input != nil && len(input.ScopedRoleIds) > 0},
-+	})
-+}
-+
-+func accessReviewUpdateMask(input *shared.AccessReviewInput) (*string, diag.Diagnostics) {
-+	if input == nil {
-+		return updateMaskForSerializedFields(nil)
-+	}
-+
-+	return updateMaskForSerializedFields([]updateMaskField{
-+		{apiPath: "displayName", serialized: input.DisplayName != nil},
-+		{apiPath: "description", serialized: input.Description != nil},
-+		{apiPath: "reviewInstructions", serialized: input.ReviewInstructions != nil},
-+		{apiPath: "defaultView", serialized: input.DefaultView != nil},
-+		{apiPath: "completionDate", serialized: input.CompletionDate != nil},
-+		{apiPath: "autoResolve", serialized: input.AutoResolve != nil},
-+		{apiPath: "usePolicyOverride", serialized: input.UsePolicyOverride != nil},
-+		{apiPath: "autoGenerateReport", serialized: input.AutoGenerateReport != nil},
-+		{apiPath: "scopeType", serialized: input.ScopeType != nil},
-+		{apiPath: "exemptCertifiedAccessConflicts", serialized: input.ExemptCertifiedAccessConflicts != nil},
-+		{apiPath: "autoStartCampaign", serialized: input.AutoStartCampaign != nil},
-+		{apiPath: "scheduledStartDate", serialized: input.ScheduledStartDate != nil},
-+		{apiPath: "accuracyIssueAction", serialized: input.AccuracyIssueAction != nil},
-+		{apiPath: "autoCloseCampaign", serialized: input.AutoCloseCampaign != nil},
-+		{apiPath: "autoCloseDecision", serialized: input.AutoCloseDecision != nil},
-+		{apiPath: "columnConfig", serialized: input.AccessReviewColumnConfig != nil},
-+		{apiPath: "notificationConfig", serialized: input.NotificationConfig != nil},
-+		{apiPath: "signatureConfig", serialized: input.ReviewSignatureConfig != nil},
-+		{apiPath: "inclusionScope", serialized: input.AccessReviewInclusionScope != nil},
-+	})
-+}
-+
-+func accessReviewUpdateMaskForChanges(state, plan types.Object, input *shared.AccessReviewInput) (*string, diag.Diagnostics) {
-+	if input == nil {
-+		return updateMaskForChanges(state, plan, nil)
-+	}
-+
-+	return updateMaskForChanges(state, plan, []updateMaskField{
-+		{terraformName: "display_name", apiPath: "displayName", serialized: input.DisplayName != nil},
-+		{terraformName: "description", apiPath: "description", serialized: input.Description != nil},
-+		{terraformName: "review_instructions", apiPath: "reviewInstructions", serialized: input.ReviewInstructions != nil},
-+		{terraformName: "default_view", apiPath: "defaultView", serialized: input.DefaultView != nil},
-+		{terraformName: "completion_date", apiPath: "completionDate", serialized: input.CompletionDate != nil},
-+		{terraformName: "auto_resolve", apiPath: "autoResolve", serialized: input.AutoResolve != nil},
-+		{terraformName: "use_policy_override", apiPath: "usePolicyOverride", serialized: input.UsePolicyOverride != nil},
-+		{terraformName: "auto_generate_report", apiPath: "autoGenerateReport", serialized: input.AutoGenerateReport != nil},
-+		{terraformName: "scope_type", apiPath: "scopeType", serialized: input.ScopeType != nil},
-+		{terraformName: "exempt_certified_access_conflicts", apiPath: "exemptCertifiedAccessConflicts", serialized: input.ExemptCertifiedAccessConflicts != nil},
-+		{terraformName: "auto_start_campaign", apiPath: "autoStartCampaign", serialized: input.AutoStartCampaign != nil},
-+		{terraformName: "scheduled_start_date", apiPath: "scheduledStartDate", serialized: input.ScheduledStartDate != nil},
-+		{terraformName: "accuracy_issue_action", apiPath: "accuracyIssueAction", serialized: input.AccuracyIssueAction != nil},
-+		{terraformName: "auto_close_campaign", apiPath: "autoCloseCampaign", serialized: input.AutoCloseCampaign != nil},
-+		{terraformName: "auto_close_decision", apiPath: "autoCloseDecision", serialized: input.AutoCloseDecision != nil},
-+		{terraformName: "access_review_column_config", apiPath: "columnConfig", serialized: input.AccessReviewColumnConfig != nil},
-+		{terraformName: "notification_config", apiPath: "notificationConfig", serialized: input.NotificationConfig != nil},
-+		{terraformName: "review_signature_config", apiPath: "signatureConfig", serialized: input.ReviewSignatureConfig != nil},
-+		{terraformName: "access_review_inclusion_scope", apiPath: "inclusionScope", serialized: input.AccessReviewInclusionScope != nil},
-+	})
-+}
-+
-+func updateMaskForSerializedFields(fields []updateMaskField) (*string, diag.Diagnostics) {
-+	var diags diag.Diagnostics
-+	paths := make([]string, 0, len(fields))
-+	for _, field := range fields {
-+		if field.serialized {
-+			paths = append(paths, field.apiPath)
-+		}
-+	}
-+	if len(paths) == 0 {
-+		diags.AddError(
-+			"Unable to build update mask",
-+			"The update payload has no maskable fields. No request was sent.",
-+		)
-+		return nil, diags
-+	}
-+	mask := strings.Join(paths, ",")
-+	return &mask, diags
-+}
+index 0000000000000000000000000000000000000000..30218f9435f3a0f469a89e66fc36a11eba719ebe
+GIT binary patch
+literal 7937
+zcmeHMTW{Mo6n?gU1?z{xE?lM01u`H=n!z2G1WDVMq7Z0_wz<fpN>a(PHvfI+kdmky
+z<seJnR-lDT9)9P3p_tR;mTnozmAvCAQ`0Hm=TaFmpH61lC@!{oHih3?Zg#~wO62}1
+zks>V;Bb5~F$S|eoMymbW3gT^Rp9`Q6G&|Di?a^MQEYnANM-@wFZPXprJDy0DHzBiP
+z%f;J`qI-5P)$LKr>GnD2%tOvVkHvI~zetg%)UZFPzCGtGO9?0n3XvbvNv+NWu*7vR
+zz;r@$enriWxIfjZW{T5{|HD#TUrU)yAE(o!qb9smr#mXPOp|rNvs4pG_P~~Gl-!dI
+zGS}oD^xnaFV31hilyE`Jjv>~k%DyDes326N1dIp%Vwwq45|WQMmlq_b51FKCL_S;f
+z$jQ}86UF{wpc)kj#`d{+umUWRYsTPwk`*Z^2^2)`xiO%Pl?$OuVH4cDW9nXU14m3W
+z-4r4jRCBHkSa#`zwN{TV*C@fV()R1Oj`bI0{>GVfNzlL18T=!pHayV_^vNAnc0>2J
+zrxVNW#DJgHg#jzSKL)3P1d(5xFQyZ;onJvJT<H>li!H*Q-m>}EZ<SE*mLy|h?!2{t
+z7@9!5lep9f!4$f<QV=9|Vtt`m0j99>T>epu=H>WmA){8zeS^~|TX`6Ny0dK+LPz<A
+zys8-f{7GJw=iz4!8h!X)(9Ai?a<N99OdxFy7X<?W9^o$_Iq@1{j;c*^Yo=pD^PGuv
+zZvR`_A}SLFERGnE4G4qAvs4Rmd`#Y<ODE`P9i61<2c@KfVl$b{J`1{rkTlZeN*P}^
+zTxUy5@o5K<4;B#+q%Kt;CL|FO69EI6LCCu3H9Kk`hq$gw8^JKvbi=X-QtL#}m6ps!
+zWkfC{<jnViX+!R*21;Qf%N~_d%oIux!7~@D+9_#M+J>Gjn9)bcOO=;oww%Gq^5AQv
+ztd4?tY#!l1hD+hn7OT>ni@Y%8jVqMVc}cLs)r08*7I(+N*dVAicgenyc~aff<?Gzm
+zp*awPr0BFKk@pfA{raPffcIpUat*$Ez(P8MEU3A?cj7^s*Zbs^74;Fl+(ckHQ9MW6
+z3?umc077NjPf+y-Au7`%K>#B!)*073mY&Kz6v$ON2z1q<It!q2eFpu~3}UR@Uf`r=
+z3HYUR5Od3VJG!yk3-TLz*R`W8%vu&Ay<i5r=t-8zdr&Eibs0D?h^`Zvv-DbKY?bP;
+zculGr=W&586TL(#SNSYBubbycSNSiQG8E=zyKZt^lHpKq)omZ}v2YRp<V-02O<un~
+zkQqIOKK{Y(4SuclUgq`rdHPoDb@^2;im|b`I95BMJnOMMFH2f4@47te?2BRag!GF!
+z=AYNK-XF`(9{cfZ?aIJ)oR&%J8IL4#kKIsWcbU}b?OD`IV=f%209_VU9f*Z11Tk$?
+z0?)Q0J5VlM=DEs^vFinSLiy;5=88zHpo)Npv5a_m#tKYWh?_$Nhb9Tr`kLKwcJGT$
+zr}dsRh*tl%UwhlB8+f2>c+V+o+?9Yy8tzxn#=HH&x-W7*Xp*(ckjG2eh8CIm0v>}1
+z>19Q9=Jx{#P(<>Kp(tl?OBe)!Led}!;LyUzYo=v(Hw<#(_X7xpW>+%f$-^bwtQ6e6
+z2Zj0Er3#>-Jijx+6litL@CH8!hhnwK0(ds(Le)I7xz#J(-cRgrylI{?WjIXZsY{|$
+zDK?<58IFMuqelW#qSiNtDsxKrIpy2oF%gw+Q3cR+0z+PrvD6X=<Kw1B7Qll7Qz)7|
+zth6rJiH-kZr}XJUh@i=7CN(>#Z;R>>+8Il@4h`98J&RUR1<(?i6?=hB=G%~(b-g`p
+z5C`z!QU}44P|Vd4)QcWj08c}BP`JIZ5inPXZrYRqJbU3ptJ!2YsPPK#r!{#4voQh>
+zccf>G!N0C+4UWg-7stUPzjmSy-YvUhN9tP`c+eNH_WDqxsc)tYS5AI(@m&LqdAkF8
+zJ}=WCyIjjQ8RKNrQR{jAv&+DD(HK9Zws`oxU<DoNuw71A;bZvLSvFd4Iox<o1MV__
+zHXP@+56Ae4vuwnk&r7uFE>Ek}w(QoRUD>WZQzU4&>EZg)BO47y+td4Zx97C_u12om
+z$4S-kV^_-H&gOf*SMS%32VL2$wc(qnGI8R^1TPKlx5k5@ty@$FOkIu=v18oJl9!n^
+zda9O_M9gvI04J26&Kk=0XN_TX`*foUTO%hpnuLwqnn{Maf-727Pvx2V38tZIg;q^2
+z<2);>ah~=*2sw+j6~Y^59vkI$=<&Q?W*X}Hw>c9Hac%C8j5!BprY_e~*?NE);#_Zz
+zu)VfM8=J1WoXaXw3Q$j6u`OBPO>ggd@8zbk@sH*9l|lEv3?BSEKlYmCo>t%?;lK;j
+o;RmP}dA)i0#~WwU>ZOvvn=d@x*cTrA^y7^BoHv-sbDv=T1tsOrqyPW_
+
+literal 0
+HcmV?d00001
+
+# End of patch

--- a/patches/04-function-update-mask.patch
+++ b/patches/04-function-update-mask.patch
@@ -1,0 +1,17 @@
+diff --git a/internal/provider/function_resource_sdk.go b/internal/provider/function_resource_sdk.go
+index ca09e5d0..2cc9ff38 100644
+--- a/internal/provider/function_resource_sdk.go
++++ b/internal/provider/function_resource_sdk.go
+@@ -285,8 +285,11 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
+ 		return nil, diags
+ 	}
+ 
++	updateMask := "displayName,description,functionType,publishedCommitId,isDraft,secret," +
++		"outboundNetworkAllowlist,scopedRoleIds,provisionedConcurrency"
+ 	out := shared.FunctionsServiceUpdateFunctionRequest{
+-		Function: function,
++		Function:   function,
++		UpdateMask: &updateMask,
+ 	}
+ 
+ 	return &out, diags

--- a/patches/04-function-update-mask.patch
+++ b/patches/04-function-update-mask.patch
@@ -1,71 +1,212 @@
 diff --git a/internal/provider/function_resource.go b/internal/provider/function_resource.go
-index 9b58fb9d8840f66a641e7ee02f5b89daf2b056c6..46997bbf1f764b6b8934e8db167a30549cb6399b 100644
-GIT binary patch
-delta 230
-zcmcapwz+bHo4!zSNn%N=LP=#oYO$VwQdVkm$>a?RW>Uc*VLkWM5{=}N3LOPCurf_O
-zJw46I2NaDbH>gQ$F41>pj4Ulk0V?!OEY8+ZK(Jjh6Vr<otZWt1O7oISGV}97;mX|d
-zi<~nO^U_m`HNa--C=}!*=IJODr52W^7MJL`L3K=aP?8o#GZAXNz5*vqHNsp4TO|7@
-N|1nqGe9fSZ3jqG{R7L;*
-
-delta 24
-gcmdm7d8cfHoBrf&3YC-X41P?Wqa?ps*QkvP0F&nmkpKVy
-
+index 9b58fb9d..46997bbf 100644
+--- a/internal/provider/function_resource.go
++++ b/internal/provider/function_resource.go
+@@ -309,8 +309,14 @@ func (r *FunctionResource) Read(ctx context.Context, req resource.ReadRequest, r
+ 
+ func (r *FunctionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+ 	var data *FunctionResourceModel
++	var state types.Object
+ 	var plan types.Object
+ 
++	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++
+ 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+ 	if resp.Diagnostics.HasError() {
+ 		return
+@@ -327,6 +333,12 @@ func (r *FunctionResource) Update(ctx context.Context, req resource.UpdateReques
+ 	if resp.Diagnostics.HasError() {
+ 		return
+ 	}
++	updateMask, updateMaskDiags := functionUpdateMaskForChanges(state, plan, request.Function)
++	resp.Diagnostics.Append(updateMaskDiags...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++	request.UpdateMask = updateMask
+ 	res, err := r.client.Functions.UpdateFunction(ctx, request)
+ 	if err != nil {
+ 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
 diff --git a/internal/provider/function_resource_sdk.go b/internal/provider/function_resource_sdk.go
-index 2cc9ff38db4ba655c3f89e8a910c0a5143d3bf2c..a221d8e6a1d4adab206a63ca0fdd2db42e8d393a 100644
-GIT binary patch
-delta 131
-zcmaFqbJJ%-sA`CgLTN!tVo9oRVsW-hW@37=f|ad8T4`Q#NoIatC|pVdCZx&5nF3O#
-z=U7mXnwO%1rdv->Pm^o19IxbL6IId4>y+guFW?oJ%p=G-Sx!xb3!!*&pP&o?PqQr|
-
-delta 166
-zcmccV^U`NSsA{l+m92tON@j6EPGY5BVs5HVN@{U(QD#9&W`3SdT4`P~h!Ij*kg8Kq
-znv|1SoROO1oS&PUS>l<ZlUeLil$chcQ=FPylv<*rq@c~k$*Gh-Ie}GNO{X|HzaTXw
-zC_g9FGo@IkpeVmAvlwU;NPAv#X;D#XUUH?<<h9BQlNay`Oy&{foXoGL!mU<Xkdj!E
-N>YG@cJ-JU%1_1vgJ3#;d
-
+index 2cc9ff38..a221d8e6 100644
+--- a/internal/provider/function_resource_sdk.go
++++ b/internal/provider/function_resource_sdk.go
+@@ -285,11 +285,14 @@ func (r *FunctionResourceModel) ToSharedFunctionsServiceUpdateFunctionRequest(ct
+ 		return nil, diags
+ 	}
+ 
+-	updateMask := "displayName,description,functionType,publishedCommitId,isDraft,secret," +
+-		"outboundNetworkAllowlist,scopedRoleIds,provisionedConcurrency"
++	updateMask, updateMaskDiags := functionUpdateMask(function)
++	diags.Append(updateMaskDiags...)
++	if diags.HasError() {
++		return nil, diags
++	}
+ 	out := shared.FunctionsServiceUpdateFunctionRequest{
+ 		Function:   function,
+-		UpdateMask: &updateMask,
++		UpdateMask: updateMask,
+ 	}
+ 
+ 	return &out, diags
 diff --git a/internal/provider/update_mask.go b/internal/provider/update_mask.go
 new file mode 100644
-index 0000000000000000000000000000000000000000..30218f9435f3a0f469a89e66fc36a11eba719ebe
-GIT binary patch
-literal 7937
-zcmeHMTW{Mo6n?gU1?z{xE?lM01u`H=n!z2G1WDVMq7Z0_wz<fpN>a(PHvfI+kdmky
-z<seJnR-lDT9)9P3p_tR;mTnozmAvCAQ`0Hm=TaFmpH61lC@!{oHih3?Zg#~wO62}1
-zks>V;Bb5~F$S|eoMymbW3gT^Rp9`Q6G&|Di?a^MQEYnANM-@wFZPXprJDy0DHzBiP
-z%f;J`qI-5P)$LKr>GnD2%tOvVkHvI~zetg%)UZFPzCGtGO9?0n3XvbvNv+NWu*7vR
-zz;r@$enriWxIfjZW{T5{|HD#TUrU)yAE(o!qb9smr#mXPOp|rNvs4pG_P~~Gl-!dI
-zGS}oD^xnaFV31hilyE`Jjv>~k%DyDes326N1dIp%Vwwq45|WQMmlq_b51FKCL_S;f
-z$jQ}86UF{wpc)kj#`d{+umUWRYsTPwk`*Z^2^2)`xiO%Pl?$OuVH4cDW9nXU14m3W
-z-4r4jRCBHkSa#`zwN{TV*C@fV()R1Oj`bI0{>GVfNzlL18T=!pHayV_^vNAnc0>2J
-zrxVNW#DJgHg#jzSKL)3P1d(5xFQyZ;onJvJT<H>li!H*Q-m>}EZ<SE*mLy|h?!2{t
-z7@9!5lep9f!4$f<QV=9|Vtt`m0j99>T>epu=H>WmA){8zeS^~|TX`6Ny0dK+LPz<A
-zys8-f{7GJw=iz4!8h!X)(9Ai?a<N99OdxFy7X<?W9^o$_Iq@1{j;c*^Yo=pD^PGuv
-zZvR`_A}SLFERGnE4G4qAvs4Rmd`#Y<ODE`P9i61<2c@KfVl$b{J`1{rkTlZeN*P}^
-zTxUy5@o5K<4;B#+q%Kt;CL|FO69EI6LCCu3H9Kk`hq$gw8^JKvbi=X-QtL#}m6ps!
-zWkfC{<jnViX+!R*21;Qf%N~_d%oIux!7~@D+9_#M+J>Gjn9)bcOO=;oww%Gq^5AQv
-ztd4?tY#!l1hD+hn7OT>ni@Y%8jVqMVc}cLs)r08*7I(+N*dVAicgenyc~aff<?Gzm
-zp*awPr0BFKk@pfA{raPffcIpUat*$Ez(P8MEU3A?cj7^s*Zbs^74;Fl+(ckHQ9MW6
-z3?umc077NjPf+y-Au7`%K>#B!)*073mY&Kz6v$ON2z1q<It!q2eFpu~3}UR@Uf`r=
-z3HYUR5Od3VJG!yk3-TLz*R`W8%vu&Ay<i5r=t-8zdr&Eibs0D?h^`Zvv-DbKY?bP;
-zculGr=W&586TL(#SNSYBubbycSNSiQG8E=zyKZt^lHpKq)omZ}v2YRp<V-02O<un~
-zkQqIOKK{Y(4SuclUgq`rdHPoDb@^2;im|b`I95BMJnOMMFH2f4@47te?2BRag!GF!
-z=AYNK-XF`(9{cfZ?aIJ)oR&%J8IL4#kKIsWcbU}b?OD`IV=f%209_VU9f*Z11Tk$?
-z0?)Q0J5VlM=DEs^vFinSLiy;5=88zHpo)Npv5a_m#tKYWh?_$Nhb9Tr`kLKwcJGT$
-zr}dsRh*tl%UwhlB8+f2>c+V+o+?9Yy8tzxn#=HH&x-W7*Xp*(ckjG2eh8CIm0v>}1
-z>19Q9=Jx{#P(<>Kp(tl?OBe)!Led}!;LyUzYo=v(Hw<#(_X7xpW>+%f$-^bwtQ6e6
-z2Zj0Er3#>-Jijx+6litL@CH8!hhnwK0(ds(Le)I7xz#J(-cRgrylI{?WjIXZsY{|$
-zDK?<58IFMuqelW#qSiNtDsxKrIpy2oF%gw+Q3cR+0z+PrvD6X=<Kw1B7Qll7Qz)7|
-zth6rJiH-kZr}XJUh@i=7CN(>#Z;R>>+8Il@4h`98J&RUR1<(?i6?=hB=G%~(b-g`p
-z5C`z!QU}44P|Vd4)QcWj08c}BP`JIZ5inPXZrYRqJbU3ptJ!2YsPPK#r!{#4voQh>
-zccf>G!N0C+4UWg-7stUPzjmSy-YvUhN9tP`c+eNH_WDqxsc)tYS5AI(@m&LqdAkF8
-zJ}=WCyIjjQ8RKNrQR{jAv&+DD(HK9Zws`oxU<DoNuw71A;bZvLSvFd4Iox<o1MV__
-zHXP@+56Ae4vuwnk&r7uFE>Ek}w(QoRUD>WZQzU4&>EZg)BO47y+td4Zx97C_u12om
-z$4S-kV^_-H&gOf*SMS%32VL2$wc(qnGI8R^1TPKlx5k5@ty@$FOkIu=v18oJl9!n^
-zda9O_M9gvI04J26&Kk=0XN_TX`*foUTO%hpnuLwqnn{Maf-727Pvx2V38tZIg;q^2
-z<2);>ah~=*2sw+j6~Y^59vkI$=<&Q?W*X}Hw>c9Hac%C8j5!BprY_e~*?NE);#_Zz
-zu)VfM8=J1WoXaXw3Q$j6u`OBPO>ggd@8zbk@sH*9l|lEv3?BSEKlYmCo>t%?;lK;j
-o;RmP}dA)i0#~WwU>ZOvvn=d@x*cTrA^y7^BoHv-sbDv=T1tsOrqyPW_
-
-literal 0
-HcmV?d00001
-
-# End of patch
+index 00000000..30218f94
+--- /dev/null
++++ b/internal/provider/update_mask.go
+@@ -0,0 +1,152 @@
++package provider
++
++import (
++	"strings"
++
++	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
++	"github.com/hashicorp/terraform-plugin-framework/diag"
++	"github.com/hashicorp/terraform-plugin-framework/types"
++)
++
++type updateMaskField struct {
++	terraformName string
++	apiPath       string
++	serialized    bool
++}
++
++// updateMaskForChanges builds a mask from fields which both changed in the
++// Terraform plan and are present in the JSON payload. Update APIs reject an
++// empty mask, while including an omitted field in a mask can overwrite it.
++func updateMaskForChanges(state, plan types.Object, fields []updateMaskField) (*string, diag.Diagnostics) {
++	var diags diag.Diagnostics
++	stateAttributes := state.Attributes()
++	planAttributes := plan.Attributes()
++	paths := make([]string, 0, len(fields))
++
++	for _, field := range fields {
++		stateValue, stateOK := stateAttributes[field.terraformName]
++		planValue, planOK := planAttributes[field.terraformName]
++		if !stateOK || !planOK || planValue.Equal(stateValue) {
++			continue
++		}
++		if field.serialized {
++			paths = append(paths, field.apiPath)
++		}
++	}
++
++	if len(paths) == 0 {
++		diags.AddError(
++			"Unable to build update mask",
++			"The planned changes do not include a field that this provider can safely serialize for this update. No request was sent.",
++		)
++		return nil, diags
++	}
++
++	mask := strings.Join(paths, ",")
++	return &mask, diags
++}
++
++func functionUpdateMask(input *shared.FunctionInput) (*string, diag.Diagnostics) {
++	if input == nil {
++		return updateMaskForSerializedFields(nil)
++	}
++
++	return updateMaskForSerializedFields([]updateMaskField{
++		{apiPath: "displayName", serialized: input.DisplayName != nil},
++		{apiPath: "description", serialized: input.Description != nil},
++		{apiPath: "functionType", serialized: input.FunctionType != nil},
++		{apiPath: "publishedCommitId", serialized: input.PublishedCommitID != nil},
++		{apiPath: "isDraft", serialized: input.IsDraft != nil},
++		{apiPath: "secret", serialized: len(input.Secret) > 0},
++		{apiPath: "outboundNetworkAllowlist", serialized: len(input.OutboundNetworkAllowlist) > 0},
++		{apiPath: "scopedRoleIds", serialized: len(input.ScopedRoleIds) > 0},
++	})
++}
++
++func functionUpdateMaskForChanges(state, plan types.Object, input *shared.FunctionInput) (*string, diag.Diagnostics) {
++	return updateMaskForChanges(state, plan, []updateMaskField{
++		{terraformName: "display_name", apiPath: "displayName", serialized: input != nil && input.DisplayName != nil},
++		{terraformName: "description", apiPath: "description", serialized: input != nil && input.Description != nil},
++		{terraformName: "function_type", apiPath: "functionType", serialized: input != nil && input.FunctionType != nil},
++		{terraformName: "published_commit_id", apiPath: "publishedCommitId", serialized: input != nil && input.PublishedCommitID != nil},
++		{terraformName: "is_draft", apiPath: "isDraft", serialized: input != nil && input.IsDraft != nil},
++		{terraformName: "secret", apiPath: "secret", serialized: input != nil && len(input.Secret) > 0},
++		{terraformName: "outbound_network_allowlist", apiPath: "outboundNetworkAllowlist", serialized: input != nil && len(input.OutboundNetworkAllowlist) > 0},
++		{terraformName: "scoped_role_ids", apiPath: "scopedRoleIds", serialized: input != nil && len(input.ScopedRoleIds) > 0},
++	})
++}
++
++func accessReviewUpdateMask(input *shared.AccessReviewInput) (*string, diag.Diagnostics) {
++	if input == nil {
++		return updateMaskForSerializedFields(nil)
++	}
++
++	return updateMaskForSerializedFields([]updateMaskField{
++		{apiPath: "displayName", serialized: input.DisplayName != nil},
++		{apiPath: "description", serialized: input.Description != nil},
++		{apiPath: "reviewInstructions", serialized: input.ReviewInstructions != nil},
++		{apiPath: "defaultView", serialized: input.DefaultView != nil},
++		{apiPath: "completionDate", serialized: input.CompletionDate != nil},
++		{apiPath: "autoResolve", serialized: input.AutoResolve != nil},
++		{apiPath: "usePolicyOverride", serialized: input.UsePolicyOverride != nil},
++		{apiPath: "autoGenerateReport", serialized: input.AutoGenerateReport != nil},
++		{apiPath: "scopeType", serialized: input.ScopeType != nil},
++		{apiPath: "exemptCertifiedAccessConflicts", serialized: input.ExemptCertifiedAccessConflicts != nil},
++		{apiPath: "autoStartCampaign", serialized: input.AutoStartCampaign != nil},
++		{apiPath: "scheduledStartDate", serialized: input.ScheduledStartDate != nil},
++		{apiPath: "accuracyIssueAction", serialized: input.AccuracyIssueAction != nil},
++		{apiPath: "autoCloseCampaign", serialized: input.AutoCloseCampaign != nil},
++		{apiPath: "autoCloseDecision", serialized: input.AutoCloseDecision != nil},
++		{apiPath: "columnConfig", serialized: input.AccessReviewColumnConfig != nil},
++		{apiPath: "notificationConfig", serialized: input.NotificationConfig != nil},
++		{apiPath: "signatureConfig", serialized: input.ReviewSignatureConfig != nil},
++		{apiPath: "inclusionScope", serialized: input.AccessReviewInclusionScope != nil},
++	})
++}
++
++func accessReviewUpdateMaskForChanges(state, plan types.Object, input *shared.AccessReviewInput) (*string, diag.Diagnostics) {
++	if input == nil {
++		return updateMaskForChanges(state, plan, nil)
++	}
++
++	return updateMaskForChanges(state, plan, []updateMaskField{
++		{terraformName: "display_name", apiPath: "displayName", serialized: input.DisplayName != nil},
++		{terraformName: "description", apiPath: "description", serialized: input.Description != nil},
++		{terraformName: "review_instructions", apiPath: "reviewInstructions", serialized: input.ReviewInstructions != nil},
++		{terraformName: "default_view", apiPath: "defaultView", serialized: input.DefaultView != nil},
++		{terraformName: "completion_date", apiPath: "completionDate", serialized: input.CompletionDate != nil},
++		{terraformName: "auto_resolve", apiPath: "autoResolve", serialized: input.AutoResolve != nil},
++		{terraformName: "use_policy_override", apiPath: "usePolicyOverride", serialized: input.UsePolicyOverride != nil},
++		{terraformName: "auto_generate_report", apiPath: "autoGenerateReport", serialized: input.AutoGenerateReport != nil},
++		{terraformName: "scope_type", apiPath: "scopeType", serialized: input.ScopeType != nil},
++		{terraformName: "exempt_certified_access_conflicts", apiPath: "exemptCertifiedAccessConflicts", serialized: input.ExemptCertifiedAccessConflicts != nil},
++		{terraformName: "auto_start_campaign", apiPath: "autoStartCampaign", serialized: input.AutoStartCampaign != nil},
++		{terraformName: "scheduled_start_date", apiPath: "scheduledStartDate", serialized: input.ScheduledStartDate != nil},
++		{terraformName: "accuracy_issue_action", apiPath: "accuracyIssueAction", serialized: input.AccuracyIssueAction != nil},
++		{terraformName: "auto_close_campaign", apiPath: "autoCloseCampaign", serialized: input.AutoCloseCampaign != nil},
++		{terraformName: "auto_close_decision", apiPath: "autoCloseDecision", serialized: input.AutoCloseDecision != nil},
++		{terraformName: "access_review_column_config", apiPath: "columnConfig", serialized: input.AccessReviewColumnConfig != nil},
++		{terraformName: "notification_config", apiPath: "notificationConfig", serialized: input.NotificationConfig != nil},
++		{terraformName: "review_signature_config", apiPath: "signatureConfig", serialized: input.ReviewSignatureConfig != nil},
++		{terraformName: "access_review_inclusion_scope", apiPath: "inclusionScope", serialized: input.AccessReviewInclusionScope != nil},
++	})
++}
++
++func updateMaskForSerializedFields(fields []updateMaskField) (*string, diag.Diagnostics) {
++	var diags diag.Diagnostics
++	paths := make([]string, 0, len(fields))
++	for _, field := range fields {
++		if field.serialized {
++			paths = append(paths, field.apiPath)
++		}
++	}
++	if len(paths) == 0 {
++		diags.AddError(
++			"Unable to build update mask",
++			"The update payload has no maskable fields. No request was sent.",
++		)
++		return nil, diags
++	}
++	mask := strings.Join(paths, ",")
++	return &mask, diags
++}

--- a/patches/05-access-review-update-mask.patch
+++ b/patches/05-access-review-update-mask.patch
@@ -1,50 +1,35 @@
 diff --git a/internal/provider/access_review_resource.go b/internal/provider/access_review_resource.go
---- a/internal/provider/access_review_resource.go
-+++ b/internal/provider/access_review_resource.go
-@@ -961,8 +961,14 @@ func (r *AccessReviewResource) Read(ctx context.Context, req resource.ReadReques
- 
- func (r *AccessReviewResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
- 	var data *AccessReviewResourceModel
-+	var state types.Object
- 	var plan types.Object
- 
-+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-+	if resp.Diagnostics.HasError() {
-+		return
-+	}
-+
- 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
- 	if resp.Diagnostics.HasError() {
- 		return
-@@ -979,6 +985,12 @@ func (r *AccessReviewResource) Update(ctx context.Context, req resource.UpdateRe
- 	if resp.Diagnostics.HasError() {
- 		return
- 	}
-+	updateMask, updateMaskDiags := accessReviewUpdateMaskForChanges(state, plan, request.AccessReviewServiceUpdateRequest.AccessReview)
-+	resp.Diagnostics.Append(updateMaskDiags...)
-+	if resp.Diagnostics.HasError() {
-+		return
-+	}
-+	request.AccessReviewServiceUpdateRequest.UpdateMask = updateMask
- 	res, err := r.client.AccessReview.Update(ctx, *request)
- 	if err != nil {
- 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
+index 89102abe6cf25957e766093a5ea0365750937815..ee432cb69631e6ba9a47f8f54d428ab19f5c9ccd 100644
+GIT binary patch
+delta 305
+zcmcb-n`!GorVYBxtocb<smYt~Fj=WiR!ET(_6KoGs<}8p04!HBIWWb1vzW#*-^l_M
+zT$5|#MSuz$CjTh4oBSa~Z?kh*nY2)GNn%N=LP=#oYOx-~gvtHQW|JRu39y2tCLf&P
+zxB2PBaK_Nmf)t=q-^Ai<9R&p2B{MO-Si#CxAu%~QwYWGawJbBWJQS|fEx*V)BQY;M
+zwO9jeoQ^_4PGX*pLQ!gAX=-ta-sFQF!jsQW;^otGMAEN0d18l@Fq$QLdU~3Z8z<;<
+Wa-wUN&_h_LV2k9q%~q3VasdDvl5^1j
+
+delta 62
+zcmV-E0KxyY!2;8}0<bLuvx5WaB$FR<FS7$FcTJNpY7LV+U<#8@WFM0fcSN&ycY_;~
+U)`WSp@{<YylUSW1vp|-03Ju~I_5c6?
+
 diff --git a/internal/provider/access_review_resource_sdk.go b/internal/provider/access_review_resource_sdk.go
---- a/internal/provider/access_review_resource_sdk.go
-+++ b/internal/provider/access_review_resource_sdk.go
-@@ -1872,8 +1872,14 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
- 		return nil, diags
- 	}
- 
-+	updateMask, updateMaskDiags := accessReviewUpdateMask(accessReview)
-+	diags.Append(updateMaskDiags...)
-+	if diags.HasError() {
-+		return nil, diags
-+	}
- 	out := shared.AccessReviewServiceUpdateRequest{
--		AccessReview: accessReview,
-+		AccessReview: accessReview,
-+		UpdateMask:   updateMask,
- 	}
- 
- 	return &out, diags
+index 4f2398cd98b989a9e74c2ed474899547fda08a73..2df77c7c2371f17fd6bac691e9f226328986c7bf 100644
+GIT binary patch
+delta 140
+zcmZ2@oAuN+)`l&NhFPhl1u2OoslJKD**Xdcwo7JWda;6)twLgQa%ypLP-<CbYI!JJ
+zsRpvJCKqQ4NV%S4K|yL>iUyh~dU|@A)3O-#r<<lRDotKc$}#yt1M76JTt<WG)wzsn
+E0HX0TG5`Po
+
+delta 772
+zcmYL{J&qGG6o8c?5?RCzKza%i0x`)hp<9U}N>G%7u-YKn=*50B<HWH?{z;f>_5?I3
+zR-%GCa0(7UL&G6B0JbxM_WgYR-h2M>v-|B=_wIY=)uy?;1j}?qtNjR2aj3KutX>HY
+zXb3n-u_l9#WDWF*NzaL2gDVNv$hH(33~h)xd(jIdR5kdDhjL(OOf6IaBto@;3S9|8
+zwdvIk?H06R4J8=EU4^1hP~wRsDR*%5b}^kVW?)?)X5pm*4VPps=o}6uC2(}vqx1yG
+zoJSc%S&6D3K1@z?6|JL5sN6wtAvkC+Ijjv~vjy6dsX<5BAQu!8?Fi3lSPWs~txF&-
+zY$dT?DcsSE;0_4JD;3FS{UI!gU_KiUMz60%kZURRVc;tWz06xHv<gxu{JXe;>*fvg
+zTks-qGftKnQMpi=8QKdv%$0S<vly`<ouilTV~A%=?<z?#K8@=^@ANHME%%i5;pIiI
+z*Y}og(mCIU5sl!dq8X`l(OastdE~Nm{ttCU867)co-~QHbZFe9y~>$qSxMYW;wgK2
+zl`(IS)pKh-jgw{SpGa-#Uw?E<kts0|w-Dr|->HdKxhT%~)4WqMW9N)mdq-_vX(w{Q
+yFwWYBZ1^nbyg8SMc;!f5#?Rcp|6F#S9>4kr$KQ9|`#+n`)x&51*M6*;$A1A<C>P!U
+
+# End of patch

--- a/patches/05-access-review-update-mask.patch
+++ b/patches/05-access-review-update-mask.patch
@@ -1,35 +1,95 @@
 diff --git a/internal/provider/access_review_resource.go b/internal/provider/access_review_resource.go
-index 89102abe6cf25957e766093a5ea0365750937815..ee432cb69631e6ba9a47f8f54d428ab19f5c9ccd 100644
-GIT binary patch
-delta 305
-zcmcb-n`!GorVYBxtocb<smYt~Fj=WiR!ET(_6KoGs<}8p04!HBIWWb1vzW#*-^l_M
-zT$5|#MSuz$CjTh4oBSa~Z?kh*nY2)GNn%N=LP=#oYOx-~gvtHQW|JRu39y2tCLf&P
-zxB2PBaK_Nmf)t=q-^Ai<9R&p2B{MO-Si#CxAu%~QwYWGawJbBWJQS|fEx*V)BQY;M
-zwO9jeoQ^_4PGX*pLQ!gAX=-ta-sFQF!jsQW;^otGMAEN0d18l@Fq$QLdU~3Z8z<;<
-Wa-wUN&_h_LV2k9q%~q3VasdDvl5^1j
-
-delta 62
-zcmV-E0KxyY!2;8}0<bLuvx5WaB$FR<FS7$FcTJNpY7LV+U<#8@WFM0fcSN&ycY_;~
-U)`WSp@{<YylUSW1vp|-03Ju~I_5c6?
-
+index 89102abe..ee432cb6 100644
+--- a/internal/provider/access_review_resource.go
++++ b/internal/provider/access_review_resource.go
+@@ -13,6 +13,7 @@ import (
+ 	"github.com/hashicorp/terraform-plugin-framework/resource"
+ 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+ 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
++	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+ 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+ 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+ 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+@@ -198,6 +199,9 @@ func (r *AccessReviewResource) Schema(ctx context.Context, req resource.SchemaRe
+ 			"access_review_scope_v2": schema.SingleNestedAttribute{
+ 				Computed: true,
+ 				Optional: true,
++				PlanModifiers: []planmodifier.Object{
++					objectplanmodifier.RequiresReplaceIfConfigured(),
++				},
+ 				Attributes: map[string]schema.Attribute{
+ 					"account_criteria_scope": schema.SingleNestedAttribute{
+ 						Computed: true,
+@@ -742,9 +746,12 @@ func (r *AccessReviewResource) Schema(ctx context.Context, req resource.SchemaRe
+ 				Description: `The IDs of the users who own and manage this campaign. At least one owner is required. Requires replacement if changed.`,
+ 			},
+ 			"policy_id": schema.StringAttribute{
+-				Computed:    true,
+-				Optional:    true,
+-				Description: `The ID of the review policy that governs task assignment and resolution.`,
++				Computed: true,
++				Optional: true,
++				PlanModifiers: []planmodifier.String{
++					stringplanmodifier.RequiresReplaceIfConfigured(),
++				},
++				Description: `The ID of the review policy that governs task assignment and resolution. Requires replacement if changed.`,
+ 			},
+ 			"policy_path": schema.StringAttribute{
+ 				Computed:    true,
+@@ -961,8 +968,14 @@ func (r *AccessReviewResource) Read(ctx context.Context, req resource.ReadReques
+ 
+ func (r *AccessReviewResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+ 	var data *AccessReviewResourceModel
++	var state types.Object
+ 	var plan types.Object
+ 
++	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++
+ 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+ 	if resp.Diagnostics.HasError() {
+ 		return
+@@ -979,6 +992,12 @@ func (r *AccessReviewResource) Update(ctx context.Context, req resource.UpdateRe
+ 	if resp.Diagnostics.HasError() {
+ 		return
+ 	}
++	updateMask, updateMaskDiags := accessReviewUpdateMaskForChanges(state, plan, request.AccessReviewServiceUpdateRequest.AccessReview)
++	resp.Diagnostics.Append(updateMaskDiags...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++	request.AccessReviewServiceUpdateRequest.UpdateMask = updateMask
+ 	res, err := r.client.AccessReview.Update(ctx, *request)
+ 	if err != nil {
+ 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
 diff --git a/internal/provider/access_review_resource_sdk.go b/internal/provider/access_review_resource_sdk.go
-index 4f2398cd98b989a9e74c2ed474899547fda08a73..2df77c7c2371f17fd6bac691e9f226328986c7bf 100644
-GIT binary patch
-delta 140
-zcmZ2@oAuN+)`l&NhFPhl1u2OoslJKD**Xdcwo7JWda;6)twLgQa%ypLP-<CbYI!JJ
-zsRpvJCKqQ4NV%S4K|yL>iUyh~dU|@A)3O-#r<<lRDotKc$}#yt1M76JTt<WG)wzsn
-E0HX0TG5`Po
-
-delta 772
-zcmYL{J&qGG6o8c?5?RCzKza%i0x`)hp<9U}N>G%7u-YKn=*50B<HWH?{z;f>_5?I3
-zR-%GCa0(7UL&G6B0JbxM_WgYR-h2M>v-|B=_wIY=)uy?;1j}?qtNjR2aj3KutX>HY
-zXb3n-u_l9#WDWF*NzaL2gDVNv$hH(33~h)xd(jIdR5kdDhjL(OOf6IaBto@;3S9|8
-zwdvIk?H06R4J8=EU4^1hP~wRsDR*%5b}^kVW?)?)X5pm*4VPps=o}6uC2(}vqx1yG
-zoJSc%S&6D3K1@z?6|JL5sN6wtAvkC+Ijjv~vjy6dsX<5BAQu!8?Fi3lSPWs~txF&-
-zY$dT?DcsSE;0_4JD;3FS{UI!gU_KiUMz60%kZURRVc;tWz06xHv<gxu{JXe;>*fvg
-zTks-qGftKnQMpi=8QKdv%$0S<vly`<ouilTV~A%=?<z?#K8@=^@ANHME%%i5;pIiI
-z*Y}og(mCIU5sl!dq8X`l(OastdE~Nm{ttCU867)co-~QHbZFe9y~>$qSxMYW;wgK2
-zl`(IS)pKh-jgw{SpGa-#Uw?E<kts0|w-Dr|->HdKxhT%~)4WqMW9N)mdq-_vX(w{Q
-yFwWYBZ1^nbyg8SMc;!f5#?Rcp|6F#S9>4kr$KQ9|`#+n`)x&51*M6*;$A1A<C>P!U
-
-# End of patch
+index 4f2398cd..2df77c7c 100644
+--- a/internal/provider/access_review_resource_sdk.go
++++ b/internal/provider/access_review_resource_sdk.go
+@@ -1872,18 +1872,14 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
+ 		return nil, diags
+ 	}
+ 
+-	// scope_v2 and policy_id are deliberately excluded: the backend rejects
+-	// any update carrying either path in update_mask once the campaign has
+-	// left PENDING state, regardless of whether the value actually changed.
+-	// Including them here would break every other-field update (e.g. just
+-	// display_name) on a running campaign. See IGA-2302 follow-up discussion.
+-	updateMask := "displayName,description,reviewInstructions,defaultView,completionDate,autoResolve," +
+-		"usePolicyOverride,autoGenerateReport,scopeType,exemptCertifiedAccessConflicts,autoStartCampaign," +
+-		"scheduledStartDate,accuracyIssueAction,autoCloseCampaign,autoCloseDecision,columnConfig," +
+-		"reviewerAttributeConfig,notificationConfig,signatureConfig,inclusionScope"
++	updateMask, updateMaskDiags := accessReviewUpdateMask(accessReview)
++	diags.Append(updateMaskDiags...)
++	if diags.HasError() {
++		return nil, diags
++	}
+ 	out := shared.AccessReviewServiceUpdateRequest{
+ 		AccessReview: accessReview,
+-		UpdateMask:   &updateMask,
++		UpdateMask:   updateMask,
+ 	}
+ 
+ 	return &out, diags

--- a/patches/05-access-review-update-mask.patch
+++ b/patches/05-access-review-update-mask.patch
@@ -1,23 +1,50 @@
+diff --git a/internal/provider/access_review_resource.go b/internal/provider/access_review_resource.go
+--- a/internal/provider/access_review_resource.go
++++ b/internal/provider/access_review_resource.go
+@@ -961,8 +961,14 @@ func (r *AccessReviewResource) Read(ctx context.Context, req resource.ReadReques
+ 
+ func (r *AccessReviewResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+ 	var data *AccessReviewResourceModel
++	var state types.Object
+ 	var plan types.Object
+ 
++	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++
+ 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+ 	if resp.Diagnostics.HasError() {
+ 		return
+@@ -979,6 +985,12 @@ func (r *AccessReviewResource) Update(ctx context.Context, req resource.UpdateRe
+ 	if resp.Diagnostics.HasError() {
+ 		return
+ 	}
++	updateMask, updateMaskDiags := accessReviewUpdateMaskForChanges(state, plan, request.AccessReviewServiceUpdateRequest.AccessReview)
++	resp.Diagnostics.Append(updateMaskDiags...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++	request.AccessReviewServiceUpdateRequest.UpdateMask = updateMask
+ 	res, err := r.client.AccessReview.Update(ctx, *request)
+ 	if err != nil {
+ 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
 diff --git a/internal/provider/access_review_resource_sdk.go b/internal/provider/access_review_resource_sdk.go
-index 83cf6273..4f2398cd 100644
 --- a/internal/provider/access_review_resource_sdk.go
 +++ b/internal/provider/access_review_resource_sdk.go
-@@ -1872,8 +1872,18 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
+@@ -1872,8 +1872,14 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
  		return nil, diags
  	}
  
-+	// scope_v2 and policy_id are deliberately excluded: the backend rejects
-+	// any update carrying either path in update_mask once the campaign has
-+	// left PENDING state, regardless of whether the value actually changed.
-+	// Including them here would break every other-field update (e.g. just
-+	// display_name) on a running campaign. See IGA-2302 follow-up discussion.
-+	updateMask := "displayName,description,reviewInstructions,defaultView,completionDate,autoResolve," +
-+		"usePolicyOverride,autoGenerateReport,scopeType,exemptCertifiedAccessConflicts,autoStartCampaign," +
-+		"scheduledStartDate,accuracyIssueAction,autoCloseCampaign,autoCloseDecision,columnConfig," +
-+		"reviewerAttributeConfig,notificationConfig,signatureConfig,inclusionScope"
++	updateMask, updateMaskDiags := accessReviewUpdateMask(accessReview)
++	diags.Append(updateMaskDiags...)
++	if diags.HasError() {
++		return nil, diags
++	}
  	out := shared.AccessReviewServiceUpdateRequest{
- 		AccessReview: accessReview,
-+		UpdateMask:   &updateMask,
+-		AccessReview: accessReview,
++		AccessReview: accessReview,
++		UpdateMask:   updateMask,
  	}
  
  	return &out, diags

--- a/patches/05-access-review-update-mask.patch
+++ b/patches/05-access-review-update-mask.patch
@@ -1,0 +1,23 @@
+diff --git a/internal/provider/access_review_resource_sdk.go b/internal/provider/access_review_resource_sdk.go
+index 83cf6273..4f2398cd 100644
+--- a/internal/provider/access_review_resource_sdk.go
++++ b/internal/provider/access_review_resource_sdk.go
+@@ -1872,8 +1872,18 @@ func (r *AccessReviewResourceModel) ToSharedAccessReviewServiceUpdateRequest(ctx
+ 		return nil, diags
+ 	}
+ 
++	// scope_v2 and policy_id are deliberately excluded: the backend rejects
++	// any update carrying either path in update_mask once the campaign has
++	// left PENDING state, regardless of whether the value actually changed.
++	// Including them here would break every other-field update (e.g. just
++	// display_name) on a running campaign. See IGA-2302 follow-up discussion.
++	updateMask := "displayName,description,reviewInstructions,defaultView,completionDate,autoResolve," +
++		"usePolicyOverride,autoGenerateReport,scopeType,exemptCertifiedAccessConflicts,autoStartCampaign," +
++		"scheduledStartDate,accuracyIssueAction,autoCloseCampaign,autoCloseDecision,columnConfig," +
++		"reviewerAttributeConfig,notificationConfig,signatureConfig,inclusionScope"
+ 	out := shared.AccessReviewServiceUpdateRequest{
+ 		AccessReview: accessReview,
++		UpdateMask:   &updateMask,
+ 	}
+ 
+ 	return &out, diags


### PR DESCRIPTION
Codex: Over the original two commits in #237, I added four things.

  1. Safe masks instead of static full masks

  The originals set one fixed mask for every update. That could include fields
  absent from the request JSON and reset them.

  The branch now:

  - builds a mask only from fields present in the payload;
  - narrows it to fields that changed between Terraform state and plan;
  - stops with a diagnostic if no safe mask remains.

  This excludes provisionedConcurrency and reviewerAttributeConfig, which the
  provider cannot serialize.

  2. Access-review lifecycle protection

  C1 rejects policy_id and scope_v2 update-mask paths once a campaign leaves
  PENDING. They are now replacement-only Terraform attributes instead of changes
  that reach an unsupported update call.

  This means changing either recreates the campaign. policy_id documentation now
  says so.

  3. Regression coverage

  Added tests for:

  - one changed serialized field producing a precise mask;
  - omitted changed fields being rejected before any API call;
  - unsupported paths staying excluded;
  - policy_id and access_review_scope_v2 retaining replacement behavior;
  - regeneration output containing change-aware mask handling.

  4. Regeneration persistence

  Updated patches 04 and 05 so the changes survive regeneration. They remain
  readable unified diffs, apply and reverse cleanly, and pass git diff --check.

  The main tradeoff is intentional: the provider currently rejects clearing a
  field when omitempty would omit it from JSON, rather than risk sending a mask
  that clears an unintended backend value.