### PR TITLE
fix: update masks on app_resource/vault, writable deprovisioner_policy (IGA-3382), ProvisionPolicy oneof collision (IGA-3483), and patches that survive regen

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -4,6 +4,8 @@ overlay.yaml
 .gitignore
 .idea
 /internal/provider/provider.go
+/internal/provider/update_mask.go
+/internal/provider/provision_policy_oneof.go
 /internal/sdk/token_source.go
 /internal/sdk/login.go
 /internal/sdk/extra_sdk_options.go

--- a/docs/resources/custom_app_entitlement.md
+++ b/docs/resources/custom_app_entitlement.md
@@ -164,6 +164,17 @@ resource "conductorone_custom_app_entitlement" "my_custom_app_entitlement" {
 - `app_resource_type_id` (String) The ID of the resource type that this entitlement belongs to. Requires replacement if changed.
 - `certify_policy_id` (String) The ID of the policy to use for certification tasks.
 - `compliance_framework_value_ids` (List of String) The IDs of compliance frameworks to associate with this entitlement (e.g., SOX, HIPAA).
+- `deprovisioner_policy` (Attributes) ProvisionPolicy is a oneOf that indicates how a provision step should be processed.
+
+This message contains a oneof named typ. Only a single field of the following list may be set at a time:
+  - connector
+  - manual
+  - delegated
+  - webhook
+  - multiStep
+  - externalTicket
+  - unconfigured
+  - action (see [below for nested schema](#nestedatt--deprovisioner_policy))
 - `description` (String) The description of the new entitlement.
 - `duration_grant` (String)
 - `duration_unset` (Attributes) (see [below for nested schema](#nestedatt--duration_unset))
@@ -193,17 +204,6 @@ This message contains a oneof named typ. Only a single field of the following li
 - `created_at` (String)
 - `default_values_applied` (Boolean) Flag to indicate if app-level access request defaults have been applied to the entitlement
 - `delete` (Boolean) The delete field.
-- `deprovisioner_policy` (Attributes) ProvisionPolicy is a oneOf that indicates how a provision step should be processed.
-
-This message contains a oneof named typ. Only a single field of the following list may be set at a time:
-  - connector
-  - manual
-  - delegated
-  - webhook
-  - multiStep
-  - externalTicket
-  - unconfigured
-  - action (see [below for nested schema](#nestedatt--deprovisioner_policy))
 - `edit` (Boolean) The edit field.
 - `expanded` (Attributes List) List of serialized related objects. (see [below for nested schema](#nestedatt--expanded))
 - `external_id` (String) The upstream product's native external ID for this entitlement (e.g. an Okta group ID).
@@ -218,6 +218,213 @@ This message contains a oneof named typ. Only a single field of the following li
 - `source_connector_ids` (Map of String) Map to tell us which connector the entitlement came from.
 - `system_builtin` (Boolean) This field indicates if this is a system builtin entitlement.
 - `updated_at` (String)
+
+<a id="nestedatt--deprovisioner_policy"></a>
+### Nested Schema for `deprovisioner_policy`
+
+Optional:
+
+- `action_provision` (Attributes) This provision step indicates that account lifecycle action should be called to provision this entitlement. (see [below for nested schema](#nestedatt--deprovisioner_policy--action_provision))
+- `connector_provision` (Attributes) Indicates that a connector should perform the provisioning. This object has no fields.
+
+This message contains a oneof named provision_type. Only a single field of the following list may be set at a time:
+  - defaultBehavior
+  - account
+  - deleteAccount (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision))
+- `delegated_provision` (Attributes) This provision step indicates that we should delegate provisioning to the configuration of another app entitlement. This app entitlement does not have to be one from the same app, but MUST be configured as a proxy binding leading into this entitlement. (see [below for nested schema](#nestedatt--deprovisioner_policy--delegated_provision))
+- `external_ticket_provision` (Attributes) This provision step indicates that we should check an external ticket to provision this entitlement (see [below for nested schema](#nestedatt--deprovisioner_policy--external_ticket_provision))
+- `manual_provision` (Attributes) Manual provisioning indicates that a human must intervene for the provisioning of this step. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision))
+- `multi_step` (String) MultiStep indicates that this provision step has multiple steps to process. Parsed as JSON.
+- `unconfigured_provision` (Attributes) The UnconfiguredProvision message. (see [below for nested schema](#nestedatt--deprovisioner_policy--unconfigured_provision))
+- `webhook_provision` (Attributes) This provision step indicates that a webhook should be called to provision this entitlement. (see [below for nested schema](#nestedatt--deprovisioner_policy--webhook_provision))
+
+<a id="nestedatt--deprovisioner_policy--action_provision"></a>
+### Nested Schema for `deprovisioner_policy.action_provision`
+
+Optional:
+
+- `action_name` (String) The actionName field.
+- `app_id` (String) The appId field.
+- `connector_id` (String) The connectorId field.
+- `display_name` (String) The displayName field.
+
+
+<a id="nestedatt--deprovisioner_policy--connector_provision"></a>
+### Nested Schema for `deprovisioner_policy.connector_provision`
+
+Optional:
+
+- `account_provision` (Attributes) The AccountProvision message.
+
+This message contains a oneof named storage_type. Only a single field of the following list may be set at a time:
+  - saveToVault
+  - doNotSave (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--account_provision))
+- `default_behavior` (Attributes) The DefaultBehavior message. (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--default_behavior))
+- `delete_account` (Attributes) The DeleteAccount message. (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--delete_account))
+
+<a id="nestedatt--deprovisioner_policy--connector_provision--account_provision"></a>
+### Nested Schema for `deprovisioner_policy.connector_provision.account_provision`
+
+Optional:
+
+- `config` (String) Parsed as JSON.
+- `connector_id` (String) The connectorId field.
+- `do_not_save` (Attributes) The DoNotSave message. (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--account_provision--do_not_save))
+- `save_to_vault` (Attributes) The SaveToVault message. (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--account_provision--save_to_vault))
+- `schema_id` (String) The schemaId field.
+
+<a id="nestedatt--deprovisioner_policy--connector_provision--account_provision--do_not_save"></a>
+### Nested Schema for `deprovisioner_policy.connector_provision.account_provision.do_not_save`
+
+
+<a id="nestedatt--deprovisioner_policy--connector_provision--account_provision--save_to_vault"></a>
+### Nested Schema for `deprovisioner_policy.connector_provision.account_provision.save_to_vault`
+
+Optional:
+
+- `vault_ids` (List of String) The vaultIds field.
+
+
+
+<a id="nestedatt--deprovisioner_policy--connector_provision--default_behavior"></a>
+### Nested Schema for `deprovisioner_policy.connector_provision.default_behavior`
+
+Optional:
+
+- `connector_id` (String) this checks if the entitlement is enabled by provisioning in a specific connector
+ this can happen automatically and doesn't need any extra info
+
+
+<a id="nestedatt--deprovisioner_policy--connector_provision--delete_account"></a>
+### Nested Schema for `deprovisioner_policy.connector_provision.delete_account`
+
+Optional:
+
+- `connector_id` (String) The connectorId field.
+
+
+
+<a id="nestedatt--deprovisioner_policy--delegated_provision"></a>
+### Nested Schema for `deprovisioner_policy.delegated_provision`
+
+Optional:
+
+- `app_id` (String) The AppID of the entitlement to delegate provisioning to.
+- `entitlement_id` (String) The ID of the entitlement we are delegating provisioning to.
+
+
+<a id="nestedatt--deprovisioner_policy--external_ticket_provision"></a>
+### Nested Schema for `deprovisioner_policy.external_ticket_provision`
+
+Optional:
+
+- `app_id` (String) The appId field.
+- `connector_id` (String) The connectorId field.
+- `external_ticket_provisioner_config_id` (String) The externalTicketProvisionerConfigId field.
+- `instructions` (String) This field indicates a text body of instructions for the provisioner to indicate.
+
+
+<a id="nestedatt--deprovisioner_policy--manual_provision"></a>
+### Nested Schema for `deprovisioner_policy.manual_provision`
+
+Optional:
+
+- `instructions` (String) This field indicates a text body of instructions for the provisioner to indicate.
+- `provisioner_assignment` (Attributes) ProvisionerAssignment defines how a provisioner is dynamically assigned.
+
+This message contains a oneof named typ. Only a single field of the following list may be set at a time:
+  - users
+  - appOwners
+  - group
+  - manager
+  - expression
+  - entitlementOwners (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment))
+- `user_ids` (List of String) An array of users that are required to provision during this step.
+ Deprecated: Use assignee field instead for dynamic provisioner assignment.
+
+<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment"></a>
+### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment`
+
+Optional:
+
+- `app_owner_provisioner` (Attributes) AppOwnerProvisioner resolves to app owners. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--app_owner_provisioner))
+- `entitlement_owner_provisioner` (Attributes) EntitlementOwnerProvisioner resolves to entitlement owners. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--entitlement_owner_provisioner))
+- `expression_provisioner` (Attributes) ExpressionProvisioner evaluates CEL expressions to determine provisioners. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--expression_provisioner))
+- `group_provisioner` (Attributes) GroupProvisioner resolves to members of a specific group. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--group_provisioner))
+- `manager_provisioner` (Attributes) ManagerProvisioner resolves to the user's manager. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--manager_provisioner))
+- `user_provisioner` (Attributes) UserProvisioner assigns specific users as provisioners. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--user_provisioner))
+
+<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--app_owner_provisioner"></a>
+### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.app_owner_provisioner`
+
+Optional:
+
+- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
+- `fallback_user_ids` (List of String) Fallback user IDs if no app owners are found.
+
+
+<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--entitlement_owner_provisioner"></a>
+### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.entitlement_owner_provisioner`
+
+Optional:
+
+- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
+- `fallback_user_ids` (List of String) Fallback user IDs if no entitlement owners are found.
+
+
+<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--expression_provisioner"></a>
+### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.expression_provisioner`
+
+Optional:
+
+- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
+- `expressions` (List of String) The CEL expressions to evaluate.
+- `fallback_user_ids` (List of String) Fallback user IDs if expression evaluation yields no users.
+
+
+<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--group_provisioner"></a>
+### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.group_provisioner`
+
+Optional:
+
+- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
+- `app_group_id` (String) The app group ID (entitlement ID).
+- `app_id` (String) The app ID containing the group.
+- `fallback_user_ids` (List of String) Fallback user IDs if no group members are found.
+
+
+<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--manager_provisioner"></a>
+### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.manager_provisioner`
+
+Optional:
+
+- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
+- `fallback_user_ids` (List of String) Fallback user IDs if no manager is found.
+
+
+<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--user_provisioner"></a>
+### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.user_provisioner`
+
+Optional:
+
+- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
+- `user_ids` (List of String) The user IDs to assign as provisioners.
+
+
+
+
+<a id="nestedatt--deprovisioner_policy--unconfigured_provision"></a>
+### Nested Schema for `deprovisioner_policy.unconfigured_provision`
+
+
+<a id="nestedatt--deprovisioner_policy--webhook_provision"></a>
+### Nested Schema for `deprovisioner_policy.webhook_provision`
+
+Optional:
+
+- `webhook_id` (String) The ID of the webhook to call for provisioning.
+
+
 
 <a id="nestedatt--duration_unset"></a>
 ### Nested Schema for `duration_unset`
@@ -425,213 +632,6 @@ Optional:
 ### Nested Schema for `provision_policy.webhook_provision`
 
 Optional:
-
-- `webhook_id` (String) The ID of the webhook to call for provisioning.
-
-
-
-<a id="nestedatt--deprovisioner_policy"></a>
-### Nested Schema for `deprovisioner_policy`
-
-Read-Only:
-
-- `action_provision` (Attributes) This provision step indicates that account lifecycle action should be called to provision this entitlement. (see [below for nested schema](#nestedatt--deprovisioner_policy--action_provision))
-- `connector_provision` (Attributes) Indicates that a connector should perform the provisioning. This object has no fields.
-
-This message contains a oneof named provision_type. Only a single field of the following list may be set at a time:
-  - defaultBehavior
-  - account
-  - deleteAccount (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision))
-- `delegated_provision` (Attributes) This provision step indicates that we should delegate provisioning to the configuration of another app entitlement. This app entitlement does not have to be one from the same app, but MUST be configured as a proxy binding leading into this entitlement. (see [below for nested schema](#nestedatt--deprovisioner_policy--delegated_provision))
-- `external_ticket_provision` (Attributes) This provision step indicates that we should check an external ticket to provision this entitlement (see [below for nested schema](#nestedatt--deprovisioner_policy--external_ticket_provision))
-- `manual_provision` (Attributes) Manual provisioning indicates that a human must intervene for the provisioning of this step. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision))
-- `multi_step` (String) MultiStep indicates that this provision step has multiple steps to process. Parsed as JSON.
-- `unconfigured_provision` (Attributes) The UnconfiguredProvision message. (see [below for nested schema](#nestedatt--deprovisioner_policy--unconfigured_provision))
-- `webhook_provision` (Attributes) This provision step indicates that a webhook should be called to provision this entitlement. (see [below for nested schema](#nestedatt--deprovisioner_policy--webhook_provision))
-
-<a id="nestedatt--deprovisioner_policy--action_provision"></a>
-### Nested Schema for `deprovisioner_policy.action_provision`
-
-Read-Only:
-
-- `action_name` (String) The actionName field.
-- `app_id` (String) The appId field.
-- `connector_id` (String) The connectorId field.
-- `display_name` (String) The displayName field.
-
-
-<a id="nestedatt--deprovisioner_policy--connector_provision"></a>
-### Nested Schema for `deprovisioner_policy.connector_provision`
-
-Read-Only:
-
-- `account_provision` (Attributes) The AccountProvision message.
-
-This message contains a oneof named storage_type. Only a single field of the following list may be set at a time:
-  - saveToVault
-  - doNotSave (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--account_provision))
-- `default_behavior` (Attributes) The DefaultBehavior message. (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--default_behavior))
-- `delete_account` (Attributes) The DeleteAccount message. (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--delete_account))
-
-<a id="nestedatt--deprovisioner_policy--connector_provision--account_provision"></a>
-### Nested Schema for `deprovisioner_policy.connector_provision.account_provision`
-
-Read-Only:
-
-- `config` (String) Parsed as JSON.
-- `connector_id` (String) The connectorId field.
-- `do_not_save` (Attributes) The DoNotSave message. (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--account_provision--do_not_save))
-- `save_to_vault` (Attributes) The SaveToVault message. (see [below for nested schema](#nestedatt--deprovisioner_policy--connector_provision--account_provision--save_to_vault))
-- `schema_id` (String) The schemaId field.
-
-<a id="nestedatt--deprovisioner_policy--connector_provision--account_provision--do_not_save"></a>
-### Nested Schema for `deprovisioner_policy.connector_provision.account_provision.do_not_save`
-
-
-<a id="nestedatt--deprovisioner_policy--connector_provision--account_provision--save_to_vault"></a>
-### Nested Schema for `deprovisioner_policy.connector_provision.account_provision.save_to_vault`
-
-Read-Only:
-
-- `vault_ids` (List of String) The vaultIds field.
-
-
-
-<a id="nestedatt--deprovisioner_policy--connector_provision--default_behavior"></a>
-### Nested Schema for `deprovisioner_policy.connector_provision.default_behavior`
-
-Read-Only:
-
-- `connector_id` (String) this checks if the entitlement is enabled by provisioning in a specific connector
- this can happen automatically and doesn't need any extra info
-
-
-<a id="nestedatt--deprovisioner_policy--connector_provision--delete_account"></a>
-### Nested Schema for `deprovisioner_policy.connector_provision.delete_account`
-
-Read-Only:
-
-- `connector_id` (String) The connectorId field.
-
-
-
-<a id="nestedatt--deprovisioner_policy--delegated_provision"></a>
-### Nested Schema for `deprovisioner_policy.delegated_provision`
-
-Read-Only:
-
-- `app_id` (String) The AppID of the entitlement to delegate provisioning to.
-- `entitlement_id` (String) The ID of the entitlement we are delegating provisioning to.
-
-
-<a id="nestedatt--deprovisioner_policy--external_ticket_provision"></a>
-### Nested Schema for `deprovisioner_policy.external_ticket_provision`
-
-Read-Only:
-
-- `app_id` (String) The appId field.
-- `connector_id` (String) The connectorId field.
-- `external_ticket_provisioner_config_id` (String) The externalTicketProvisionerConfigId field.
-- `instructions` (String) This field indicates a text body of instructions for the provisioner to indicate.
-
-
-<a id="nestedatt--deprovisioner_policy--manual_provision"></a>
-### Nested Schema for `deprovisioner_policy.manual_provision`
-
-Read-Only:
-
-- `instructions` (String) This field indicates a text body of instructions for the provisioner to indicate.
-- `provisioner_assignment` (Attributes) ProvisionerAssignment defines how a provisioner is dynamically assigned.
-
-This message contains a oneof named typ. Only a single field of the following list may be set at a time:
-  - users
-  - appOwners
-  - group
-  - manager
-  - expression
-  - entitlementOwners (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment))
-- `user_ids` (List of String) An array of users that are required to provision during this step.
- Deprecated: Use assignee field instead for dynamic provisioner assignment.
-
-<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment"></a>
-### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment`
-
-Read-Only:
-
-- `app_owner_provisioner` (Attributes) AppOwnerProvisioner resolves to app owners. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--app_owner_provisioner))
-- `entitlement_owner_provisioner` (Attributes) EntitlementOwnerProvisioner resolves to entitlement owners. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--entitlement_owner_provisioner))
-- `expression_provisioner` (Attributes) ExpressionProvisioner evaluates CEL expressions to determine provisioners. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--expression_provisioner))
-- `group_provisioner` (Attributes) GroupProvisioner resolves to members of a specific group. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--group_provisioner))
-- `manager_provisioner` (Attributes) ManagerProvisioner resolves to the user's manager. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--manager_provisioner))
-- `user_provisioner` (Attributes) UserProvisioner assigns specific users as provisioners. (see [below for nested schema](#nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--user_provisioner))
-
-<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--app_owner_provisioner"></a>
-### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.app_owner_provisioner`
-
-Read-Only:
-
-- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
-- `fallback_user_ids` (List of String) Fallback user IDs if no app owners are found.
-
-
-<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--entitlement_owner_provisioner"></a>
-### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.entitlement_owner_provisioner`
-
-Read-Only:
-
-- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
-- `fallback_user_ids` (List of String) Fallback user IDs if no entitlement owners are found.
-
-
-<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--expression_provisioner"></a>
-### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.expression_provisioner`
-
-Read-Only:
-
-- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
-- `expressions` (List of String) The CEL expressions to evaluate.
-- `fallback_user_ids` (List of String) Fallback user IDs if expression evaluation yields no users.
-
-
-<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--group_provisioner"></a>
-### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.group_provisioner`
-
-Read-Only:
-
-- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
-- `app_group_id` (String) The app group ID (entitlement ID).
-- `app_id` (String) The app ID containing the group.
-- `fallback_user_ids` (List of String) Fallback user IDs if no group members are found.
-
-
-<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--manager_provisioner"></a>
-### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.manager_provisioner`
-
-Read-Only:
-
-- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
-- `fallback_user_ids` (List of String) Fallback user IDs if no manager is found.
-
-
-<a id="nestedatt--deprovisioner_policy--manual_provision--provisioner_assignment--user_provisioner"></a>
-### Nested Schema for `deprovisioner_policy.manual_provision.provisioner_assignment.user_provisioner`
-
-Read-Only:
-
-- `allow_reassignment` (Boolean) Whether the provisioner can reassign the task.
-- `user_ids` (List of String) The user IDs to assign as provisioners.
-
-
-
-
-<a id="nestedatt--deprovisioner_policy--unconfigured_provision"></a>
-### Nested Schema for `deprovisioner_policy.unconfigured_provision`
-
-
-<a id="nestedatt--deprovisioner_policy--webhook_provision"></a>
-### Nested Schema for `deprovisioner_policy.webhook_provision`
-
-Read-Only:
 
 - `webhook_id` (String) The ID of the webhook to call for provisioning.
 

--- a/internal/provider/app_entitlement_resource.go
+++ b/internal/provider/app_entitlement_resource.go
@@ -144,6 +144,17 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 							},
 						},
 						Description: `This provision step indicates that account lifecycle action should be called to provision this entitlement.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"connector_provision": schema.SingleNestedAttribute{
 						Computed: true,
@@ -168,6 +179,11 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 										Computed:    true,
 										Optional:    true,
 										Description: `The DoNotSave message.`,
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("save_to_vault"),
+											}...),
+										},
 									},
 									"save_to_vault": schema.SingleNestedAttribute{
 										Computed: true,
@@ -181,6 +197,11 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 											},
 										},
 										Description: `The SaveToVault message.`,
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("do_not_save"),
+											}...),
+										},
 									},
 									"schema_id": schema.StringAttribute{
 										Computed:    true,
@@ -193,6 +214,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 									`This message contains a oneof named storage_type. Only a single field of the following list may be set at a time:` + "\n" +
 									`  - saveToVault` + "\n" +
 									`  - doNotSave`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("default_behavior"),
+										path.MatchRelative().AtParent().AtName("delete_account"),
+									}...),
+								},
 							},
 							"default_behavior": schema.SingleNestedAttribute{
 								Computed: true,
@@ -206,6 +233,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 									},
 								},
 								Description: `The DefaultBehavior message.`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("account_provision"),
+										path.MatchRelative().AtParent().AtName("delete_account"),
+									}...),
+								},
 							},
 							"delete_account": schema.SingleNestedAttribute{
 								Computed: true,
@@ -218,6 +251,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 									},
 								},
 								Description: `The DeleteAccount message.`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("account_provision"),
+										path.MatchRelative().AtParent().AtName("default_behavior"),
+									}...),
+								},
 							},
 						},
 						MarkdownDescription: `Indicates that a connector should perform the provisioning. This object has no fields.` + "\n" +
@@ -228,10 +267,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 							`  - deleteAccount`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -254,10 +295,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `This provision step indicates that we should delegate provisioning to the configuration of another app entitlement. This app entitlement does not have to be one from the same app, but MUST be configured as a proxy binding leading into this entitlement.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -290,10 +333,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `This provision step indicates that we should check an external ticket to provision this entitlement`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -457,10 +502,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `Manual provisioning indicates that a human must intervene for the provisioning of this step.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -472,10 +519,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `MultiStep indicates that this provision step has multiple steps to process. Parsed as JSON.`,
 						Validators: []validator.String{
 							stringvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -484,6 +533,17 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Computed:    true,
 						Optional:    true,
 						Description: `The UnconfiguredProvision message.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"webhook_provision": schema.SingleNestedAttribute{
 						Computed: true,
@@ -498,11 +558,13 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `This provision step indicates that a webhook should be called to provision this entitlement.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 							}...),
 						},
 					},
@@ -615,6 +677,17 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 							},
 						},
 						Description: `This provision step indicates that account lifecycle action should be called to provision this entitlement.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"connector_provision": schema.SingleNestedAttribute{
 						Computed: true,
@@ -639,6 +712,11 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 										Computed:    true,
 										Optional:    true,
 										Description: `The DoNotSave message.`,
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("save_to_vault"),
+											}...),
+										},
 									},
 									"save_to_vault": schema.SingleNestedAttribute{
 										Computed: true,
@@ -652,6 +730,11 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 											},
 										},
 										Description: `The SaveToVault message.`,
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("do_not_save"),
+											}...),
+										},
 									},
 									"schema_id": schema.StringAttribute{
 										Computed:    true,
@@ -664,6 +747,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 									`This message contains a oneof named storage_type. Only a single field of the following list may be set at a time:` + "\n" +
 									`  - saveToVault` + "\n" +
 									`  - doNotSave`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("default_behavior"),
+										path.MatchRelative().AtParent().AtName("delete_account"),
+									}...),
+								},
 							},
 							"default_behavior": schema.SingleNestedAttribute{
 								Computed: true,
@@ -677,6 +766,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 									},
 								},
 								Description: `The DefaultBehavior message.`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("account_provision"),
+										path.MatchRelative().AtParent().AtName("delete_account"),
+									}...),
+								},
 							},
 							"delete_account": schema.SingleNestedAttribute{
 								Computed: true,
@@ -689,6 +784,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 									},
 								},
 								Description: `The DeleteAccount message.`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("account_provision"),
+										path.MatchRelative().AtParent().AtName("default_behavior"),
+									}...),
+								},
 							},
 						},
 						MarkdownDescription: `Indicates that a connector should perform the provisioning. This object has no fields.` + "\n" +
@@ -699,10 +800,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 							`  - deleteAccount`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -725,10 +828,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `This provision step indicates that we should delegate provisioning to the configuration of another app entitlement. This app entitlement does not have to be one from the same app, but MUST be configured as a proxy binding leading into this entitlement.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -761,10 +866,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `This provision step indicates that we should check an external ticket to provision this entitlement`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -928,10 +1035,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `Manual provisioning indicates that a human must intervene for the provisioning of this step.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -943,10 +1052,12 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `MultiStep indicates that this provision step has multiple steps to process. Parsed as JSON.`,
 						Validators: []validator.String{
 							stringvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -955,6 +1066,17 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Computed:    true,
 						Optional:    true,
 						Description: `The UnconfiguredProvision message.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"webhook_provision": schema.SingleNestedAttribute{
 						Computed: true,
@@ -969,11 +1091,13 @@ func (r *AppEntitlementResource) Schema(ctx context.Context, req resource.Schema
 						Description: `This provision step indicates that a webhook should be called to provision this entitlement.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 							}...),
 						},
 					},
@@ -1182,6 +1306,11 @@ func (r *AppEntitlementResource) Update(ctx context.Context, req resource.Update
 	}
 
 	cleanupDurationFields(ctx, req, resp, data)
+
+	resp.Diagnostics.Append(pruneAppEntitlementPolicyOneofs(ctx, req.Config, data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	var updateAppEntitlementRequest *shared.UpdateAppEntitlementRequest
 	appEntitlement := data.ToUpdateSDKType()

--- a/internal/provider/app_resource_resource.go
+++ b/internal/provider/app_resource_resource.go
@@ -373,7 +373,13 @@ func (r *AppResourceResource) Read(ctx context.Context, req resource.ReadRequest
 
 func (r *AppResourceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data *AppResourceResourceModel
+	var state types.Object
 	var plan types.Object
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -391,6 +397,12 @@ func (r *AppResourceResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	updateMask, updateMaskDiags := appResourceUpdateMaskForChanges(state, plan, request.AppResourceServiceUpdateRequest.AppResource)
+	resp.Diagnostics.Append(updateMaskDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	request.AppResourceServiceUpdateRequest.UpdateMask = updateMask
 	res, err := r.client.AppResource.Update(ctx, *request)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())

--- a/internal/provider/custom_app_entitlement_resource.go
+++ b/internal/provider/custom_app_entitlement_resource.go
@@ -153,61 +153,96 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 			},
 			"deprovisioner_policy": schema.SingleNestedAttribute{
 				Computed: true,
+				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"action_provision": schema.SingleNestedAttribute{
+						Optional: true,
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"action_name": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The actionName field.`,
 							},
 							"app_id": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The appId field.`,
 							},
 							"connector_id": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The connectorId field.`,
 							},
 							"display_name": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The displayName field.`,
 							},
 						},
 						Description: `This provision step indicates that account lifecycle action should be called to provision this entitlement.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"connector_provision": schema.SingleNestedAttribute{
+						Optional: true,
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"account_provision": schema.SingleNestedAttribute{
 								Computed: true,
+								Optional: true,
 								Attributes: map[string]schema.Attribute{
 									"config": schema.StringAttribute{
 										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
+										Optional:    true,
 										Description: `Parsed as JSON.`,
 									},
 									"connector_id": schema.StringAttribute{
 										Computed:    true,
+										Optional:    true,
 										Description: `The connectorId field.`,
 									},
 									"do_not_save": schema.SingleNestedAttribute{
 										Computed:    true,
+										Optional:    true,
 										Description: `The DoNotSave message.`,
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("save_to_vault"),
+											}...),
+										},
 									},
 									"save_to_vault": schema.SingleNestedAttribute{
 										Computed: true,
+										Optional: true,
 										Attributes: map[string]schema.Attribute{
 											"vault_ids": schema.ListAttribute{
 												Computed:    true,
+												Optional:    true,
 												ElementType: types.StringType,
 												Description: `The vaultIds field.`,
 											},
 										},
 										Description: `The SaveToVault message.`,
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("do_not_save"),
+											}...),
+										},
 									},
 									"schema_id": schema.StringAttribute{
 										Computed:    true,
+										Optional:    true,
 										Description: `The schemaId field.`,
 									},
 								},
@@ -216,27 +251,49 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									`This message contains a oneof named storage_type. Only a single field of the following list may be set at a time:` + "\n" +
 									`  - saveToVault` + "\n" +
 									`  - doNotSave`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("default_behavior"),
+										path.MatchRelative().AtParent().AtName("delete_account"),
+									}...),
+								},
 							},
 							"default_behavior": schema.SingleNestedAttribute{
 								Computed: true,
+								Optional: true,
 								Attributes: map[string]schema.Attribute{
 									"connector_id": schema.StringAttribute{
 										Computed: true,
+										Optional: true,
 										MarkdownDescription: `this checks if the entitlement is enabled by provisioning in a specific connector` + "\n" +
 											` this can happen automatically and doesn't need any extra info`,
 									},
 								},
 								Description: `The DefaultBehavior message.`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("account_provision"),
+										path.MatchRelative().AtParent().AtName("delete_account"),
+									}...),
+								},
 							},
 							"delete_account": schema.SingleNestedAttribute{
 								Computed: true,
+								Optional: true,
 								Attributes: map[string]schema.Attribute{
 									"connector_id": schema.StringAttribute{
 										Computed:    true,
+										Optional:    true,
 										Description: `The connectorId field.`,
 									},
 								},
 								Description: `The DeleteAccount message.`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("account_provision"),
+										path.MatchRelative().AtParent().AtName("default_behavior"),
+									}...),
+								},
 							},
 						},
 						MarkdownDescription: `Indicates that a connector should perform the provisioning. This object has no fields.` + "\n" +
@@ -245,62 +302,109 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 							`  - defaultBehavior` + "\n" +
 							`  - account` + "\n" +
 							`  - deleteAccount`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"delegated_provision": schema.SingleNestedAttribute{
+						Optional: true,
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"app_id": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The AppID of the entitlement to delegate provisioning to.`,
 							},
 							"entitlement_id": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The ID of the entitlement we are delegating provisioning to.`,
 							},
 						},
 						Description: `This provision step indicates that we should delegate provisioning to the configuration of another app entitlement. This app entitlement does not have to be one from the same app, but MUST be configured as a proxy binding leading into this entitlement.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"external_ticket_provision": schema.SingleNestedAttribute{
+						Optional: true,
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"app_id": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The appId field.`,
 							},
 							"connector_id": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The connectorId field.`,
 							},
 							"external_ticket_provisioner_config_id": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The externalTicketProvisionerConfigId field.`,
 							},
 							"instructions": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `This field indicates a text body of instructions for the provisioner to indicate.`,
 							},
 						},
 						Description: `This provision step indicates that we should check an external ticket to provision this entitlement`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"manual_provision": schema.SingleNestedAttribute{
+						Optional: true,
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"instructions": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `This field indicates a text body of instructions for the provisioner to indicate.`,
 							},
 							"provisioner_assignment": schema.SingleNestedAttribute{
 								Computed: true,
+								Optional: true,
 								Attributes: map[string]schema.Attribute{
 									"app_owner_provisioner": schema.SingleNestedAttribute{
 										Computed: true,
+										Optional: true,
 										Attributes: map[string]schema.Attribute{
 											"allow_reassignment": schema.BoolAttribute{
 												Computed:    true,
+												Optional:    true,
 												Description: `Whether the provisioner can reassign the task.`,
 											},
 											"fallback_user_ids": schema.ListAttribute{
 												Computed:    true,
+												Optional:    true,
 												ElementType: types.StringType,
 												Description: `Fallback user IDs if no app owners are found.`,
 											},
@@ -309,13 +413,16 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									},
 									"entitlement_owner_provisioner": schema.SingleNestedAttribute{
 										Computed: true,
+										Optional: true,
 										Attributes: map[string]schema.Attribute{
 											"allow_reassignment": schema.BoolAttribute{
 												Computed:    true,
+												Optional:    true,
 												Description: `Whether the provisioner can reassign the task.`,
 											},
 											"fallback_user_ids": schema.ListAttribute{
 												Computed:    true,
+												Optional:    true,
 												ElementType: types.StringType,
 												Description: `Fallback user IDs if no entitlement owners are found.`,
 											},
@@ -324,18 +431,22 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									},
 									"expression_provisioner": schema.SingleNestedAttribute{
 										Computed: true,
+										Optional: true,
 										Attributes: map[string]schema.Attribute{
 											"allow_reassignment": schema.BoolAttribute{
 												Computed:    true,
+												Optional:    true,
 												Description: `Whether the provisioner can reassign the task.`,
 											},
 											"expressions": schema.ListAttribute{
 												Computed:    true,
+												Optional:    true,
 												ElementType: types.StringType,
 												Description: `The CEL expressions to evaluate.`,
 											},
 											"fallback_user_ids": schema.ListAttribute{
 												Computed:    true,
+												Optional:    true,
 												ElementType: types.StringType,
 												Description: `Fallback user IDs if expression evaluation yields no users.`,
 											},
@@ -344,21 +455,26 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									},
 									"group_provisioner": schema.SingleNestedAttribute{
 										Computed: true,
+										Optional: true,
 										Attributes: map[string]schema.Attribute{
 											"allow_reassignment": schema.BoolAttribute{
 												Computed:    true,
+												Optional:    true,
 												Description: `Whether the provisioner can reassign the task.`,
 											},
 											"app_group_id": schema.StringAttribute{
 												Computed:    true,
+												Optional:    true,
 												Description: `The app group ID (entitlement ID).`,
 											},
 											"app_id": schema.StringAttribute{
 												Computed:    true,
+												Optional:    true,
 												Description: `The app ID containing the group.`,
 											},
 											"fallback_user_ids": schema.ListAttribute{
 												Computed:    true,
+												Optional:    true,
 												ElementType: types.StringType,
 												Description: `Fallback user IDs if no group members are found.`,
 											},
@@ -367,13 +483,16 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									},
 									"manager_provisioner": schema.SingleNestedAttribute{
 										Computed: true,
+										Optional: true,
 										Attributes: map[string]schema.Attribute{
 											"allow_reassignment": schema.BoolAttribute{
 												Computed:    true,
+												Optional:    true,
 												Description: `Whether the provisioner can reassign the task.`,
 											},
 											"fallback_user_ids": schema.ListAttribute{
 												Computed:    true,
+												Optional:    true,
 												ElementType: types.StringType,
 												Description: `Fallback user IDs if no manager is found.`,
 											},
@@ -382,13 +501,16 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									},
 									"user_provisioner": schema.SingleNestedAttribute{
 										Computed: true,
+										Optional: true,
 										Attributes: map[string]schema.Attribute{
 											"allow_reassignment": schema.BoolAttribute{
 												Computed:    true,
+												Optional:    true,
 												Description: `Whether the provisioner can reassign the task.`,
 											},
 											"user_ids": schema.ListAttribute{
 												Computed:    true,
+												Optional:    true,
 												ElementType: types.StringType,
 												Description: `The user IDs to assign as provisioners.`,
 											},
@@ -408,31 +530,80 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 							},
 							"user_ids": schema.ListAttribute{
 								Computed:    true,
+								Optional:    true,
 								ElementType: types.StringType,
 								MarkdownDescription: `An array of users that are required to provision during this step.` + "\n" +
 									` Deprecated: Use assignee field instead for dynamic provisioner assignment.`,
 							},
 						},
 						Description: `Manual provisioning indicates that a human must intervene for the provisioning of this step.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"multi_step": schema.StringAttribute{
 						CustomType:  jsontypes.NormalizedType{},
 						Computed:    true,
+						Optional:    true,
 						Description: `MultiStep indicates that this provision step has multiple steps to process. Parsed as JSON.`,
+						Validators: []validator.String{
+							stringvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"unconfigured_provision": schema.SingleNestedAttribute{
 						Computed:    true,
+						Optional:    true,
 						Description: `The UnconfiguredProvision message.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"webhook_provision": schema.SingleNestedAttribute{
+						Optional: true,
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"webhook_id": schema.StringAttribute{
 								Computed:    true,
+								Optional:    true,
 								Description: `The ID of the webhook to call for provisioning.`,
 							},
 						},
 						Description: `This provision step indicates that a webhook should be called to provision this entitlement.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+							}...),
+						},
 					},
 				},
 				MarkdownDescription: `ProvisionPolicy is a oneOf that indicates how a provision step should be processed.` + "\n" +
@@ -572,6 +743,17 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 							},
 						},
 						Description: `This provision step indicates that account lifecycle action should be called to provision this entitlement.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"connector_provision": schema.SingleNestedAttribute{
 						Optional: true,
@@ -595,6 +777,11 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 										Computed:    true,
 										Optional:    true,
 										Description: `The DoNotSave message.`,
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("save_to_vault"),
+											}...),
+										},
 									},
 									"save_to_vault": schema.SingleNestedAttribute{
 										Computed: true,
@@ -608,6 +795,11 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 											},
 										},
 										Description: `The SaveToVault message.`,
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("do_not_save"),
+											}...),
+										},
 									},
 									"schema_id": schema.StringAttribute{
 										Computed:    true,
@@ -620,6 +812,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									`This message contains a oneof named storage_type. Only a single field of the following list may be set at a time:` + "\n" +
 									`  - saveToVault` + "\n" +
 									`  - doNotSave`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("default_behavior"),
+										path.MatchRelative().AtParent().AtName("delete_account"),
+									}...),
+								},
 							},
 							"default_behavior": schema.SingleNestedAttribute{
 								Computed: true,
@@ -633,6 +831,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									},
 								},
 								Description: `The DefaultBehavior message.`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("account_provision"),
+										path.MatchRelative().AtParent().AtName("delete_account"),
+									}...),
+								},
 							},
 							"delete_account": schema.SingleNestedAttribute{
 								Computed: true,
@@ -645,6 +849,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 									},
 								},
 								Description: `The DeleteAccount message.`,
+								Validators: []validator.Object{
+									objectvalidator.ConflictsWith(path.Expressions{
+										path.MatchRelative().AtParent().AtName("account_provision"),
+										path.MatchRelative().AtParent().AtName("default_behavior"),
+									}...),
+								},
 							},
 						},
 						MarkdownDescription: `Indicates that a connector should perform the provisioning. This object has no fields.` + "\n" +
@@ -655,10 +865,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 							`  - deleteAccount`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -680,10 +892,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 						Description: `This provision step indicates that we should delegate provisioning to the configuration of another app entitlement. This app entitlement does not have to be one from the same app, but MUST be configured as a proxy binding leading into this entitlement.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -715,10 +929,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 						Description: `This provision step indicates that we should check an external ticket to provision this entitlement`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -881,10 +1097,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 						Description: `Manual provisioning indicates that a human must intervene for the provisioning of this step.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -896,10 +1114,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 						Description: `MultiStep indicates that this provision step has multiple steps to process. Parsed as JSON.`,
 						Validators: []validator.String{
 							stringvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 								path.MatchRelative().AtParent().AtName("webhook_provision"),
 							}...),
 						},
@@ -908,6 +1128,17 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 						Computed:    true,
 						Optional:    true,
 						Description: `The UnconfiguredProvision message.`,
+						Validators: []validator.Object{
+							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
+								path.MatchRelative().AtParent().AtName("connector_provision"),
+								path.MatchRelative().AtParent().AtName("delegated_provision"),
+								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+								path.MatchRelative().AtParent().AtName("manual_provision"),
+								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("webhook_provision"),
+							}...),
+						},
 					},
 					"webhook_provision": schema.SingleNestedAttribute{
 						Optional: true,
@@ -921,11 +1152,13 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
 						Description: `This provision step indicates that a webhook should be called to provision this entitlement.`,
 						Validators: []validator.Object{
 							objectvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("action_provision"),
 								path.MatchRelative().AtParent().AtName("connector_provision"),
 								path.MatchRelative().AtParent().AtName("delegated_provision"),
 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
 								path.MatchRelative().AtParent().AtName("manual_provision"),
 								path.MatchRelative().AtParent().AtName("multi_step"),
+								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
 							}...),
 						},
 					},
@@ -1139,6 +1372,11 @@ func (r *CustomAppEntitlementResource) Update(ctx context.Context, req resource.
 	}
 
 	merge(ctx, req, resp, &data)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(pruneCustomAppEntitlementPolicyOneofs(ctx, req.Config, data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/provision_policy_oneof.go
+++ b/internal/provider/provision_policy_oneof.go
@@ -1,0 +1,259 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
+	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
+)
+
+// provisionBranch identifies one arm of the ProvisionPolicy oneof by its
+// Terraform attribute name.
+type provisionBranch string
+
+const (
+	provisionBranchNone           provisionBranch = ""
+	provisionBranchAction         provisionBranch = "action_provision"
+	provisionBranchConnector      provisionBranch = "connector_provision"
+	provisionBranchDelegated      provisionBranch = "delegated_provision"
+	provisionBranchExternalTicket provisionBranch = "external_ticket_provision"
+	provisionBranchManual         provisionBranch = "manual_provision"
+	provisionBranchMultiStep      provisionBranch = "multi_step"
+	provisionBranchUnconfigured   provisionBranch = "unconfigured_provision"
+	provisionBranchWebhook        provisionBranch = "webhook_provision"
+)
+
+// The two entry points below narrow both policy oneofs on data to the single arm
+// the practitioner configured.
+//
+// The API models these as a protobuf oneof and rejects a body carrying two arms
+// with `oneof c1.api.policy.v1.ProvisionPolicy.typ is already set`. The generated
+// SDK instead models every arm as an independent optional field, and merge() loads
+// prior state before overlaying the plan — so the arm being replaced survives in
+// the merged model alongside its replacement and both get serialized.
+//
+// Configuration is the only input where an arm the practitioner did not write is
+// reliably null: in the plan, an unset arm of a Computed+Optional object holds the
+// prior state value. ConflictsWith cannot substitute for this, because it
+// validates configuration and the surviving arm comes from state.
+//
+// The arms have to stay Computed. Dropping Computed also stops the stale arm, but
+// then a config that omits the policy block entirely cannot carry the stored value
+// forward and Terraform marks the whole object unknown on every plan — a permanent
+// diff, verified against a live tenant.
+//
+// An empty config selection leaves data untouched: nothing was chosen, so whichever
+// single arm the remote already had is the correct thing to send.
+
+func pruneAppEntitlementPolicyOneofs(ctx context.Context, config tfsdk.Config, data *AppEntitlementResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if data == nil {
+		return diags
+	}
+
+	var configured *AppEntitlementResourceModel
+	diags.Append(config.Get(ctx, &configured)...)
+	if diags.HasError() || configured == nil {
+		return diags
+	}
+
+	provision, provisionDiags := selectedProvisionPolicyBranch("provision_policy", configured.ProvisionPolicy)
+	diags.Append(provisionDiags...)
+	deprovisioner, deprovisionerDiags := selectedDeprovisionerPolicyBranch("deprovisioner_policy", configured.DeprovisionerPolicy)
+	diags.Append(deprovisionerDiags...)
+	if diags.HasError() {
+		return diags
+	}
+
+	keepOnlyProvisionPolicyBranch(data.ProvisionPolicy, provision)
+	keepOnlyDeprovisionerPolicyBranch(data.DeprovisionerPolicy, deprovisioner)
+
+	return diags
+}
+
+func pruneCustomAppEntitlementPolicyOneofs(ctx context.Context, config tfsdk.Config, data *CustomAppEntitlementResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if data == nil {
+		return diags
+	}
+
+	var configured *CustomAppEntitlementResourceModel
+	diags.Append(config.Get(ctx, &configured)...)
+	if diags.HasError() || configured == nil {
+		return diags
+	}
+
+	provision, provisionDiags := selectedProvisionPolicyBranch("provision_policy", configured.ProvisionPolicy)
+	diags.Append(provisionDiags...)
+	deprovisioner, deprovisionerDiags := selectedDeprovisionerPolicyBranch("deprovisioner_policy", configured.DeprovisionerPolicy)
+	diags.Append(deprovisionerDiags...)
+	if diags.HasError() {
+		return diags
+	}
+
+	keepOnlyProvisionPolicyBranch(data.ProvisionPolicy, provision)
+	keepOnlyDeprovisionerPolicyBranch(data.DeprovisionerPolicy, deprovisioner)
+
+	return diags
+}
+
+// The four functions below are duplicated per type rather than unified:
+// tfTypes.ProvisionPolicy and tfTypes.DeprovisionerPolicy are distinct structs
+// with identical arms, and Go generics cannot range over struct fields.
+// TestPolicyOneofTypesStayInSync fails if the two shapes diverge, which is the
+// signal to update all four.
+
+func selectedProvisionPolicyBranch(attribute string, p *tfTypes.ProvisionPolicy) (provisionBranch, diag.Diagnostics) {
+	if p == nil {
+		return provisionBranchNone, nil
+	}
+	var configured []provisionBranch
+	if p.ActionProvision != nil {
+		configured = append(configured, provisionBranchAction)
+	}
+	if p.ConnectorProvision != nil {
+		configured = append(configured, provisionBranchConnector)
+	}
+	if p.DelegatedProvision != nil {
+		configured = append(configured, provisionBranchDelegated)
+	}
+	if p.ExternalTicketProvision != nil {
+		configured = append(configured, provisionBranchExternalTicket)
+	}
+	if p.ManualProvision != nil {
+		configured = append(configured, provisionBranchManual)
+	}
+	if !p.MultiStep.IsNull() && !p.MultiStep.IsUnknown() {
+		configured = append(configured, provisionBranchMultiStep)
+	}
+	if p.UnconfiguredProvision != nil {
+		configured = append(configured, provisionBranchUnconfigured)
+	}
+	if p.WebhookProvision != nil {
+		configured = append(configured, provisionBranchWebhook)
+	}
+	return onlyConfiguredBranch(attribute, configured)
+}
+
+// onlyConfiguredBranch rejects a configuration carrying more than one arm.
+// Choosing one of them applies a policy the practitioner did not write, and the
+// arm that loses is dropped without a plan ever showing it.
+func onlyConfiguredBranch(attribute string, configured []provisionBranch) (provisionBranch, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	switch len(configured) {
+	case 0:
+		return provisionBranchNone, diags
+	case 1:
+		return configured[0], diags
+	}
+
+	names := make([]string, 0, len(configured))
+	for _, branch := range configured {
+		names = append(names, string(branch))
+	}
+	diags.AddError(
+		fmt.Sprintf("Conflicting %s configuration", attribute),
+		fmt.Sprintf(
+			"Only one provisioning arm may be configured, but the configuration sets %s. The API models this as a oneof and rejects a body carrying more than one arm.",
+			strings.Join(names, ", "),
+		),
+	)
+	return provisionBranchNone, diags
+}
+
+func keepOnlyProvisionPolicyBranch(p *tfTypes.ProvisionPolicy, keep provisionBranch) {
+	if p == nil || keep == provisionBranchNone {
+		return
+	}
+	if keep != provisionBranchAction {
+		p.ActionProvision = nil
+	}
+	if keep != provisionBranchConnector {
+		p.ConnectorProvision = nil
+	}
+	if keep != provisionBranchDelegated {
+		p.DelegatedProvision = nil
+	}
+	if keep != provisionBranchExternalTicket {
+		p.ExternalTicketProvision = nil
+	}
+	if keep != provisionBranchManual {
+		p.ManualProvision = nil
+	}
+	if keep != provisionBranchMultiStep {
+		p.MultiStep = jsontypes.NewNormalizedNull()
+	}
+	if keep != provisionBranchUnconfigured {
+		p.UnconfiguredProvision = nil
+	}
+	if keep != provisionBranchWebhook {
+		p.WebhookProvision = nil
+	}
+}
+
+func selectedDeprovisionerPolicyBranch(attribute string, p *tfTypes.DeprovisionerPolicy) (provisionBranch, diag.Diagnostics) {
+	if p == nil {
+		return provisionBranchNone, nil
+	}
+	var configured []provisionBranch
+	if p.ActionProvision != nil {
+		configured = append(configured, provisionBranchAction)
+	}
+	if p.ConnectorProvision != nil {
+		configured = append(configured, provisionBranchConnector)
+	}
+	if p.DelegatedProvision != nil {
+		configured = append(configured, provisionBranchDelegated)
+	}
+	if p.ExternalTicketProvision != nil {
+		configured = append(configured, provisionBranchExternalTicket)
+	}
+	if p.ManualProvision != nil {
+		configured = append(configured, provisionBranchManual)
+	}
+	if !p.MultiStep.IsNull() && !p.MultiStep.IsUnknown() {
+		configured = append(configured, provisionBranchMultiStep)
+	}
+	if p.UnconfiguredProvision != nil {
+		configured = append(configured, provisionBranchUnconfigured)
+	}
+	if p.WebhookProvision != nil {
+		configured = append(configured, provisionBranchWebhook)
+	}
+	return onlyConfiguredBranch(attribute, configured)
+}
+
+func keepOnlyDeprovisionerPolicyBranch(p *tfTypes.DeprovisionerPolicy, keep provisionBranch) {
+	if p == nil || keep == provisionBranchNone {
+		return
+	}
+	if keep != provisionBranchAction {
+		p.ActionProvision = nil
+	}
+	if keep != provisionBranchConnector {
+		p.ConnectorProvision = nil
+	}
+	if keep != provisionBranchDelegated {
+		p.DelegatedProvision = nil
+	}
+	if keep != provisionBranchExternalTicket {
+		p.ExternalTicketProvision = nil
+	}
+	if keep != provisionBranchManual {
+		p.ManualProvision = nil
+	}
+	if keep != provisionBranchMultiStep {
+		p.MultiStep = jsontypes.NewNormalizedNull()
+	}
+	if keep != provisionBranchUnconfigured {
+		p.UnconfiguredProvision = nil
+	}
+	if keep != provisionBranchWebhook {
+		p.WebhookProvision = nil
+	}
+}

--- a/internal/provider/provision_policy_oneof_test.go
+++ b/internal/provider/provision_policy_oneof_test.go
@@ -1,0 +1,196 @@
+package provider
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+	tfTypes "github.com/conductorone/terraform-provider-conductorone/internal/provider/types"
+)
+
+// TestPolicyOneofTypesStayInSync guards the deliberate duplication in
+// provision_policy_oneof.go. The prune helpers are written twice because
+// ProvisionPolicy and DeprovisionerPolicy are distinct structs with identical
+// arms; if the spec ever adds or renames an arm on one, this fails and the four
+// functions need the same edit.
+func TestPolicyOneofTypesStayInSync(t *testing.T) {
+	provision := reflect.TypeOf(tfTypes.ProvisionPolicy{})
+	deprovisioner := reflect.TypeOf(tfTypes.DeprovisionerPolicy{})
+
+	if got, want := deprovisioner.NumField(), provision.NumField(); got != want {
+		t.Fatalf("DeprovisionerPolicy has %d fields, ProvisionPolicy has %d", got, want)
+	}
+	for i := 0; i < provision.NumField(); i++ {
+		p, d := provision.Field(i), deprovisioner.Field(i)
+		if p.Name != d.Name {
+			t.Errorf("field %d: ProvisionPolicy has %q, DeprovisionerPolicy has %q", i, p.Name, d.Name)
+		}
+		if p.Tag.Get("tfsdk") != d.Tag.Get("tfsdk") {
+			t.Errorf("field %s: tfsdk tag %q vs %q", p.Name, p.Tag.Get("tfsdk"), d.Tag.Get("tfsdk"))
+		}
+	}
+}
+
+func TestKeepOnlyProvisionPolicyBranchDropsTheStaleArm(t *testing.T) {
+	// The IGA-3483 shape: state contributed unconfigured, config selected manual,
+	// and merge() left both on the model.
+	merged := &tfTypes.ProvisionPolicy{
+		ManualProvision:       &tfTypes.ManualProvision{},
+		UnconfiguredProvision: &tfTypes.UnconfiguredProvision{},
+	}
+	configured := &tfTypes.ProvisionPolicy{ManualProvision: &tfTypes.ManualProvision{}}
+
+	branch, diags := selectedProvisionPolicyBranch("provision_policy", configured)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	keepOnlyProvisionPolicyBranch(merged, branch)
+
+	if merged.ManualProvision == nil {
+		t.Error("configured arm was dropped")
+	}
+	if merged.UnconfiguredProvision != nil {
+		t.Error("stale arm survived; the request would carry two oneof arms and the API returns 400")
+	}
+}
+
+func TestKeepOnlyDeprovisionerPolicyBranchDropsTheStaleArm(t *testing.T) {
+	merged := &tfTypes.DeprovisionerPolicy{
+		ConnectorProvision:    &tfTypes.ConnectorProvision{},
+		UnconfiguredProvision: &tfTypes.UnconfiguredProvision{},
+	}
+	configured := &tfTypes.DeprovisionerPolicy{ConnectorProvision: &tfTypes.ConnectorProvision{}}
+
+	branch, diags := selectedDeprovisionerPolicyBranch("deprovisioner_policy", configured)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	keepOnlyDeprovisionerPolicyBranch(merged, branch)
+
+	if merged.ConnectorProvision == nil {
+		t.Error("configured arm was dropped")
+	}
+	if merged.UnconfiguredProvision != nil {
+		t.Error("stale arm survived")
+	}
+}
+
+func TestEmptyConfigSelectionLeavesTheStoredArmAlone(t *testing.T) {
+	// Config omits the policy block, so there is nothing to choose: whatever
+	// single arm the remote already had is what should be sent back.
+	merged := &tfTypes.ProvisionPolicy{UnconfiguredProvision: &tfTypes.UnconfiguredProvision{}}
+
+	branch, diags := selectedProvisionPolicyBranch("provision_policy", nil)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	keepOnlyProvisionPolicyBranch(merged, branch)
+
+	if merged.UnconfiguredProvision == nil {
+		t.Error("stored arm was cleared even though the practitioner configured nothing")
+	}
+}
+
+func TestConfiguringTwoArmsIsAnErrorRatherThanASilentChoice(t *testing.T) {
+	// The API models the policy as a oneof, so a body carrying two arms is
+	// rejected. Keeping the first arm in source order would instead apply one
+	// half of the configuration and drop the other without a plan showing it.
+	configured := &tfTypes.DeprovisionerPolicy{
+		ActionProvision: &tfTypes.ActionProvision{},
+		ManualProvision: &tfTypes.ManualProvision{},
+	}
+
+	branch, diags := selectedDeprovisionerPolicyBranch("deprovisioner_policy", configured)
+
+	if !diags.HasError() {
+		t.Fatal("expected an error for a configuration setting two arms")
+	}
+	if branch != provisionBranchNone {
+		t.Errorf("branch = %q, want none: an ambiguous configuration must not select an arm", branch)
+	}
+	detail := diags.Errors()[0].Detail()
+	for _, arm := range []string{"action_provision", "manual_provision"} {
+		if !strings.Contains(detail, arm) {
+			t.Errorf("error detail %q does not name %q", detail, arm)
+		}
+	}
+}
+
+func TestProvisionPolicyReportsEveryConfiguredArm(t *testing.T) {
+	configured := &tfTypes.ProvisionPolicy{
+		ConnectorProvision:    &tfTypes.ConnectorProvision{},
+		UnconfiguredProvision: &tfTypes.UnconfiguredProvision{},
+		WebhookProvision:      &tfTypes.WebhookProvision{},
+	}
+
+	_, diags := selectedProvisionPolicyBranch("provision_policy", configured)
+
+	if !diags.HasError() {
+		t.Fatal("expected an error for a configuration setting three arms")
+	}
+	detail := diags.Errors()[0].Detail()
+	for _, arm := range []string{"connector_provision", "unconfigured_provision", "webhook_provision"} {
+		if !strings.Contains(detail, arm) {
+			t.Errorf("error detail %q does not name %q", detail, arm)
+		}
+	}
+}
+
+// TestPolicyArmsConflictWithEveryOtherArm covers the schema half of the same
+// defect: without a complete ConflictsWith set, Terraform accepts a
+// configuration carrying two arms and Create serializes both.
+func TestPolicyArmsConflictWithEveryOtherArm(t *testing.T) {
+	ctx := context.Background()
+	appEntitlement := &resource.SchemaResponse{}
+	(&AppEntitlementResource{}).Schema(ctx, resource.SchemaRequest{}, appEntitlement)
+	customAppEntitlement := &resource.SchemaResponse{}
+	(&CustomAppEntitlementResource{}).Schema(ctx, resource.SchemaRequest{}, customAppEntitlement)
+
+	resources := map[string]schema.Schema{
+		"conductorone_app_entitlement":        appEntitlement.Schema,
+		"conductorone_custom_app_entitlement": customAppEntitlement.Schema,
+	}
+	for resourceName, resourceSchema := range resources {
+		for _, policyName := range []string{"provision_policy", "deprovisioner_policy"} {
+			policy, ok := resourceSchema.Attributes[policyName].(schema.SingleNestedAttribute)
+			if !ok {
+				t.Fatalf("%s.%s is %T, want schema.SingleNestedAttribute", resourceName, policyName, resourceSchema.Attributes[policyName])
+			}
+			for name, attribute := range policy.Attributes {
+				described := describeValidators(t, attribute)
+				for sibling := range policy.Attributes {
+					if sibling == name {
+						continue
+					}
+					if !strings.Contains(described, sibling) {
+						t.Errorf("%s.%s.%s does not conflict with %s: a configuration setting both is accepted",
+							resourceName, policyName, name, sibling)
+					}
+				}
+			}
+		}
+	}
+}
+
+func describeValidators(t *testing.T, attribute schema.Attribute) string {
+	t.Helper()
+	ctx := context.Background()
+	var described []string
+	switch typed := attribute.(type) {
+	case schema.SingleNestedAttribute:
+		for _, v := range typed.Validators {
+			described = append(described, v.Description(ctx))
+		}
+	case schema.StringAttribute:
+		for _, v := range typed.Validators {
+			described = append(described, v.Description(ctx))
+		}
+	default:
+		t.Fatalf("unhandled attribute type %T", attribute)
+	}
+	return strings.Join(described, "\n")
+}

--- a/internal/provider/speakeasy_regen_test.go
+++ b/internal/provider/speakeasy_regen_test.go
@@ -200,3 +200,81 @@ func TestAppEntitlementSDKMirrorsManualProvisionSchema(t *testing.T) {
 		}
 	}
 }
+
+// TestUpdateRequestsSetUpdateMask verifies that every listed resource's
+// ToShared*ServiceUpdateRequest function actually populates UpdateMask on the
+// outgoing shared request, and that the resources whose masks are built in the
+// resource layer keep narrowing them to changed, serialized fields.
+//
+// Regression: Speakeasy does not auto-generate update_mask population for
+// these operations — nothing in the OAS distinguishes them from any other
+// update. access_review_template hit this first and was hand-patched
+// (patches/03, PR #231 / IGA-2302) with no tripwire test added at the time.
+// Its backend RPC hard-rejects a request with a nil/empty update_mask
+// (InvalidArgument: "update_mask is required"), so without this every
+// terraform apply that updates an existing template fails outright.
+//
+// app_resource and vault are the same missing-mask bug with a quieter failure:
+// their RPCs accept a nil mask and treat it as full replace over every writable
+// field, including the ones the payload left empty. app_resource loses
+// custom_description on any update, and vault stops mirroring display_name and
+// description onto its app resource and owner entitlement while clearing that
+// entitlement's policy bindings. Both apply cleanly and report success.
+//
+// function and access_review deliberately have no case here. PR #238 added
+// them, PR #241 reverted it pending upstream apigw rework, and this tripwire
+// must not assert on call sites that no longer exist.
+func TestUpdateRequestsSetUpdateMask(t *testing.T) {
+	cases := []struct {
+		file     string
+		funcName string
+	}{
+		{"access_review_template_resource_sdk.go", "ToSharedAccessReviewTemplateServiceUpdateRequest"},
+	}
+
+	funcBody := regexp.MustCompile(`(?s)func \(r \*\w+\) (\w+)\(ctx context\.Context\).*?\n}\n`)
+
+	for _, c := range cases {
+		data, err := os.ReadFile(c.file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", c.file, err)
+		}
+		content := string(data)
+
+		matches := funcBody.FindAllStringSubmatch(content, -1)
+		var body string
+		found := false
+		for _, m := range matches {
+			if m[1] == c.funcName {
+				body = m[0]
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("%s: could not find function %s", c.file, c.funcName)
+		}
+
+		if !strings.Contains(body, "UpdateMask:") {
+			t.Errorf("%s: %s does not set UpdateMask on the outgoing request. "+
+				"The backend requires a non-empty update_mask and will reject every "+
+				"Update() call with InvalidArgument otherwise. Re-apply "+
+				"patches/03-access-review-template-update-mask.patch.", c.file, c.funcName)
+		}
+	}
+
+	changeAwareMasks := map[string]string{
+		"app_resource_resource.go": "appResourceUpdateMaskForChanges(state, plan, request.AppResourceServiceUpdateRequest.AppResource)",
+		"vault_resource.go":        "vaultUpdateMask(request.VaultServiceUpdateRequest.Vault)",
+	}
+	for file, marker := range changeAwareMasks {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		if !strings.Contains(string(data), marker) {
+			t.Errorf("%s does not narrow the update mask to changed, serialized fields "+
+				"(expected call site %q); re-apply patches/06-app-resource-and-vault-update-mask.patch", file, marker)
+		}
+	}
+}

--- a/internal/provider/update_mask.go
+++ b/internal/provider/update_mask.go
@@ -1,0 +1,107 @@
+package provider
+
+import (
+	"strings"
+
+	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type updateMaskField struct {
+	terraformName string
+	apiPath       string
+	serialized    bool
+}
+
+// updateMaskForChanges builds a mask from fields which both changed in the
+// Terraform plan and are present in the JSON payload. Update APIs reject an
+// empty mask, while including an omitted field in a mask can overwrite it.
+func updateMaskForChanges(state, plan types.Object, fields []updateMaskField) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	stateAttributes := state.Attributes()
+	planAttributes := plan.Attributes()
+	paths := make([]string, 0, len(fields))
+
+	for _, field := range fields {
+		stateValue, stateOK := stateAttributes[field.terraformName]
+		planValue, planOK := planAttributes[field.terraformName]
+		if !stateOK || !planOK || planValue.Equal(stateValue) {
+			continue
+		}
+		if field.serialized {
+			paths = append(paths, field.apiPath)
+		}
+	}
+
+	if len(paths) == 0 {
+		diags.AddError(
+			"Unable to build update mask",
+			"The planned changes do not include a field that this provider can safely serialize for this update. No request was sent.",
+		)
+		return nil, diags
+	}
+
+	mask := strings.Join(paths, ",")
+	return &mask, diags
+}
+
+func appResourceUpdateMaskForChanges(state, plan types.Object, input *shared.AppResourceInput) (*string, diag.Diagnostics) {
+	if input == nil {
+		return updateMaskForChanges(state, plan, nil)
+	}
+
+	return updateMaskForChanges(state, plan, []updateMaskField{
+		{terraformName: "display_name", apiPath: "displayName", serialized: input.DisplayName != nil},
+		{terraformName: "description", apiPath: "description", serialized: input.Description != nil},
+		{terraformName: "annotations", apiPath: "annotations", serialized: plannedValueIsSet(plan, "annotations")},
+	})
+}
+
+// plannedValueIsSet reports whether the practitioner configured a concrete
+// value for the attribute. Collections need this instead of a length check on
+// the payload: an emptied map is a real update, and omitempty drops it from the
+// JSON body, so the mask is the only thing that still carries the intent to
+// clear it.
+func plannedValueIsSet(plan types.Object, terraformName string) bool {
+	value, ok := plan.Attributes()[terraformName]
+	return ok && !value.IsNull() && !value.IsUnknown()
+}
+
+// vaultUpdateMask is deliberately static rather than change-aware. The vault
+// update RPC patches only display_name and description, and it mirrors both onto
+// the vault's C1 app resource and owner entitlement through a mask filtered to
+// those two paths — a mask that omits them clears unrelated owner-entitlement
+// policy bindings. credential_expiration_duration is computed-only in the
+// schema, and the vault-type oneof plans as a permanent diff because Read never
+// populates it, so a plan/state comparison would routinely produce a mask
+// without display_name or description.
+func vaultUpdateMask(input *shared.VaultInput) (*string, diag.Diagnostics) {
+	if input == nil {
+		return updateMaskForSerializedFields(nil)
+	}
+
+	return updateMaskForSerializedFields([]updateMaskField{
+		{apiPath: "displayName", serialized: input.DisplayName != nil},
+		{apiPath: "description", serialized: input.Description != nil},
+	})
+}
+
+func updateMaskForSerializedFields(fields []updateMaskField) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	paths := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field.serialized {
+			paths = append(paths, field.apiPath)
+		}
+	}
+	if len(paths) == 0 {
+		diags.AddError(
+			"Unable to build update mask",
+			"The update payload has no maskable fields. No request was sent.",
+		)
+		return nil, diags
+	}
+	mask := strings.Join(paths, ",")
+	return &mask, diags
+}

--- a/internal/provider/update_mask_test.go
+++ b/internal/provider/update_mask_test.go
@@ -1,0 +1,206 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestUpdateMaskRejectsChangedFieldMissingFromPayload(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{"description": types.StringValue("before")},
+		map[string]attr.Value{"description": types.StringNull()},
+	)
+
+	mask, diags := appResourceUpdateMaskForChanges(state, plan, &shared.AppResourceInput{})
+	if mask != nil {
+		t.Errorf("mask = %q, want nil", *mask)
+	}
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics when a changed field is omitted from the payload")
+	}
+}
+
+func TestPayloadMasksContainOnlySerializedBackendPaths(t *testing.T) {
+	mask, diags := vaultUpdateMask(&shared.VaultInput{
+		DisplayName: stringPointer("vault"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	// description is absent from the payload, so it must stay out of the mask
+	// even though vaultUpdateMask lists it.
+	if got, want := *mask, "displayName"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}
+
+func TestAppResourceUpdateMaskPreservesFieldsTheSchemaDoesNotModel(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{
+			"display_name": types.StringValue("before"),
+			"description":  types.StringValue("unchanged"),
+			"annotations":  types.MapNull(types.StringType),
+		},
+		map[string]attr.Value{
+			"display_name": types.StringValue("after"),
+			"description":  types.StringValue("unchanged"),
+			"annotations":  types.MapNull(types.StringType),
+		},
+	)
+
+	mask, diags := appResourceUpdateMaskForChanges(state, plan, &shared.AppResourceInput{
+		DisplayName: stringPointer("after"),
+		Description: stringPointer("unchanged"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	// customDescription and accessConfigId must stay out of the mask. The
+	// backend assigns custom_description unconditionally from the merged
+	// payload, so a mask that omits it keeps the stored value while a nil mask
+	// clears it; access_config_id is computed-only in the schema.
+	if got, want := *mask, "displayName"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}
+
+func TestVaultUpdateMaskAlwaysCarriesTheMirroredPaths(t *testing.T) {
+	mask, diags := vaultUpdateMask(&shared.VaultInput{
+		DisplayName: stringPointer("vault"),
+		Description: stringPointer("secrets for the deploy pipeline"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	// The vault update RPC copies display_name and description onto the vault's
+	// app resource and owner entitlement through a mask filtered to exactly
+	// these two paths. Dropping either one from the request mask leaves that
+	// filtered mask empty, which full-replaces the owner entitlement from a
+	// two-field stub and clears its policy bindings.
+	if got, want := *mask, "displayName,description"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}
+
+func TestUpdateMaskTreatsUnknownPlannedValueAsAChange(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{
+			"display_name": types.StringValue("unchanged"),
+			"description":  types.StringValue("stored"),
+		},
+		map[string]attr.Value{
+			"display_name": types.StringValue("unchanged"),
+			"description":  types.StringUnknown(),
+		},
+	)
+
+	mask, diags := updateMaskForChanges(state, plan, []updateMaskField{
+		{terraformName: "display_name", apiPath: "displayName", serialized: true},
+		{terraformName: "description", apiPath: "description", serialized: true},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	// An unknown planned value is not equal to the stored value, so it lands in
+	// the mask. Terraform marks computed attributes unknown on every plan even
+	// when the practitioner changed nothing, so callers must not list
+	// computed-only attributes: doing so produces a mask on every apply and can
+	// crowd out the paths that actually needed to be there.
+	if got, want := *mask, "description"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}
+
+func updateMaskObjects(state, plan map[string]attr.Value) (types.Object, types.Object) {
+	attributeTypes := make(map[string]attr.Type, len(state))
+	for name, value := range state {
+		attributeTypes[name] = value.Type(context.Background())
+	}
+	return types.ObjectValueMust(attributeTypes, state), types.ObjectValueMust(attributeTypes, plan)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func TestAppResourceUpdateMaskClearsAnnotations(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{
+			"display_name": types.StringValue("unchanged"),
+			"annotations":  types.MapValueMust(types.StringType, map[string]attr.Value{"managed_by": types.StringValue("terraform")}),
+		},
+		map[string]attr.Value{
+			"display_name": types.StringValue("unchanged"),
+			"annotations":  types.MapValueMust(types.StringType, map[string]attr.Value{}),
+		},
+	)
+
+	mask, diags := appResourceUpdateMaskForChanges(state, plan, &shared.AppResourceInput{
+		DisplayName: stringPointer("unchanged"),
+		Annotations: map[string]string{},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	// Emptying the map is the practitioner clearing it. omitempty drops the
+	// field from the JSON body, so the mask is the only thing carrying that
+	// intent; without the path the stored annotations survive the update and
+	// the next refresh drifts them back into state.
+	if got, want := *mask, "annotations"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}
+
+func TestAppResourceUpdateMaskClearsAnnotationsAlongsideAnotherChange(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{
+			"display_name": types.StringValue("before"),
+			"annotations":  types.MapValueMust(types.StringType, map[string]attr.Value{"managed_by": types.StringValue("terraform")}),
+		},
+		map[string]attr.Value{
+			"display_name": types.StringValue("after"),
+			"annotations":  types.MapValueMust(types.StringType, map[string]attr.Value{}),
+		},
+	)
+
+	mask, diags := appResourceUpdateMaskForChanges(state, plan, &shared.AppResourceInput{
+		DisplayName: stringPointer("after"),
+		Annotations: map[string]string{},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got, want := *mask, "displayName,annotations"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}
+
+func TestAppResourceUpdateMaskLeavesUnknownAnnotationsAlone(t *testing.T) {
+	state, plan := updateMaskObjects(
+		map[string]attr.Value{
+			"display_name": types.StringValue("before"),
+			"annotations":  types.MapNull(types.StringType),
+		},
+		map[string]attr.Value{
+			"display_name": types.StringValue("after"),
+			"annotations":  types.MapUnknown(types.StringType),
+		},
+	)
+
+	mask, diags := appResourceUpdateMaskForChanges(state, plan, &shared.AppResourceInput{
+		DisplayName: stringPointer("after"),
+		Annotations: map[string]string{},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	// An unconfigured Computed attribute plans as unknown. Masking it would
+	// clear whatever the remote holds, which the practitioner never asked for.
+	if got, want := *mask, "displayName"; got != want {
+		t.Errorf("mask = %q, want %q", got, want)
+	}
+}

--- a/internal/provider/vault_resource.go
+++ b/internal/provider/vault_resource.go
@@ -271,6 +271,12 @@ func (r *VaultResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	updateMask, updateMaskDiags := vaultUpdateMask(request.VaultServiceUpdateRequest.Vault)
+	resp.Diagnostics.Append(updateMaskDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	request.VaultServiceUpdateRequest.UpdateMask = updateMask
 	res, err := r.client.Vault.Update(ctx, *request)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())

--- a/patches/06-app-resource-and-vault-update-mask.patch
+++ b/patches/06-app-resource-and-vault-update-mask.patch
@@ -1,0 +1,49 @@
+diff --git a/internal/provider/app_resource_resource.go b/internal/provider/app_resource_resource.go
+index 13fc311f..1cfbebbe 100644
+--- a/internal/provider/app_resource_resource.go
++++ b/internal/provider/app_resource_resource.go
+@@ -373,8 +373,14 @@ func (r *AppResourceResource) Read(ctx context.Context, req resource.ReadRequest
+ 
+ func (r *AppResourceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+ 	var data *AppResourceResourceModel
++	var state types.Object
+ 	var plan types.Object
+ 
++	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++
+ 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+ 	if resp.Diagnostics.HasError() {
+ 		return
+@@ -391,6 +397,12 @@ func (r *AppResourceResource) Update(ctx context.Context, req resource.UpdateReq
+ 	if resp.Diagnostics.HasError() {
+ 		return
+ 	}
++	updateMask, updateMaskDiags := appResourceUpdateMaskForChanges(state, plan, request.AppResourceServiceUpdateRequest.AppResource)
++	resp.Diagnostics.Append(updateMaskDiags...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++	request.AppResourceServiceUpdateRequest.UpdateMask = updateMask
+ 	res, err := r.client.AppResource.Update(ctx, *request)
+ 	if err != nil {
+ 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
+diff --git a/internal/provider/vault_resource.go b/internal/provider/vault_resource.go
+index c8c0a9af..3bbb2f09 100644
+--- a/internal/provider/vault_resource.go
++++ b/internal/provider/vault_resource.go
+@@ -271,6 +271,12 @@ func (r *VaultResource) Update(ctx context.Context, req resource.UpdateRequest,
+ 	if resp.Diagnostics.HasError() {
+ 		return
+ 	}
++	updateMask, updateMaskDiags := vaultUpdateMask(request.VaultServiceUpdateRequest.Vault)
++	resp.Diagnostics.Append(updateMaskDiags...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++	request.VaultServiceUpdateRequest.UpdateMask = updateMask
+ 	res, err := r.client.Vault.Update(ctx, *request)
+ 	if err != nil {
+ 		resp.Diagnostics.AddError("failure to invoke API", err.Error())

--- a/patches/07-custom-app-entitlement-deprovisioner-writable.patch
+++ b/patches/07-custom-app-entitlement-deprovisioner-writable.patch
@@ -1,0 +1,633 @@
+diff --git a/internal/provider/custom_app_entitlement_resource.go b/internal/provider/custom_app_entitlement_resource.go
+index 3a951206..433a8090 100644
+--- a/internal/provider/custom_app_entitlement_resource.go
++++ b/internal/provider/custom_app_entitlement_resource.go
+@@ -153,61 +153,96 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 			},
+ 			"deprovisioner_policy": schema.SingleNestedAttribute{
+ 				Computed: true,
++				Optional: true,
+ 				Attributes: map[string]schema.Attribute{
+ 					"action_provision": schema.SingleNestedAttribute{
++						Optional: true,
+ 						Computed: true,
+ 						Attributes: map[string]schema.Attribute{
+ 							"action_name": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The actionName field.`,
+ 							},
+ 							"app_id": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The appId field.`,
+ 							},
+ 							"connector_id": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The connectorId field.`,
+ 							},
+ 							"display_name": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The displayName field.`,
+ 							},
+ 						},
+ 						Description: `This provision step indicates that account lifecycle action should be called to provision this entitlement.`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"connector_provision": schema.SingleNestedAttribute{
++						Optional: true,
+ 						Computed: true,
+ 						Attributes: map[string]schema.Attribute{
+ 							"account_provision": schema.SingleNestedAttribute{
+ 								Computed: true,
++								Optional: true,
+ 								Attributes: map[string]schema.Attribute{
+ 									"config": schema.StringAttribute{
+ 										CustomType:  jsontypes.NormalizedType{},
+ 										Computed:    true,
++										Optional:    true,
+ 										Description: `Parsed as JSON.`,
+ 									},
+ 									"connector_id": schema.StringAttribute{
+ 										Computed:    true,
++										Optional:    true,
+ 										Description: `The connectorId field.`,
+ 									},
+ 									"do_not_save": schema.SingleNestedAttribute{
+ 										Computed:    true,
++										Optional:    true,
+ 										Description: `The DoNotSave message.`,
++										Validators: []validator.Object{
++											objectvalidator.ConflictsWith(path.Expressions{
++												path.MatchRelative().AtParent().AtName("save_to_vault"),
++											}...),
++										},
+ 									},
+ 									"save_to_vault": schema.SingleNestedAttribute{
+ 										Computed: true,
++										Optional: true,
+ 										Attributes: map[string]schema.Attribute{
+ 											"vault_ids": schema.ListAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												ElementType: types.StringType,
+ 												Description: `The vaultIds field.`,
+ 											},
+ 										},
+ 										Description: `The SaveToVault message.`,
++										Validators: []validator.Object{
++											objectvalidator.ConflictsWith(path.Expressions{
++												path.MatchRelative().AtParent().AtName("do_not_save"),
++											}...),
++										},
+ 									},
+ 									"schema_id": schema.StringAttribute{
+ 										Computed:    true,
++										Optional:    true,
+ 										Description: `The schemaId field.`,
+ 									},
+ 								},
+@@ -216,27 +251,49 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									`This message contains a oneof named storage_type. Only a single field of the following list may be set at a time:` + "\n" +
+ 									`  - saveToVault` + "\n" +
+ 									`  - doNotSave`,
++								Validators: []validator.Object{
++									objectvalidator.ConflictsWith(path.Expressions{
++										path.MatchRelative().AtParent().AtName("default_behavior"),
++										path.MatchRelative().AtParent().AtName("delete_account"),
++									}...),
++								},
+ 							},
+ 							"default_behavior": schema.SingleNestedAttribute{
+ 								Computed: true,
++								Optional: true,
+ 								Attributes: map[string]schema.Attribute{
+ 									"connector_id": schema.StringAttribute{
+ 										Computed: true,
++										Optional: true,
+ 										MarkdownDescription: `this checks if the entitlement is enabled by provisioning in a specific connector` + "\n" +
+ 											` this can happen automatically and doesn't need any extra info`,
+ 									},
+ 								},
+ 								Description: `The DefaultBehavior message.`,
++								Validators: []validator.Object{
++									objectvalidator.ConflictsWith(path.Expressions{
++										path.MatchRelative().AtParent().AtName("account_provision"),
++										path.MatchRelative().AtParent().AtName("delete_account"),
++									}...),
++								},
+ 							},
+ 							"delete_account": schema.SingleNestedAttribute{
+ 								Computed: true,
++								Optional: true,
+ 								Attributes: map[string]schema.Attribute{
+ 									"connector_id": schema.StringAttribute{
+ 										Computed:    true,
++										Optional:    true,
+ 										Description: `The connectorId field.`,
+ 									},
+ 								},
+ 								Description: `The DeleteAccount message.`,
++								Validators: []validator.Object{
++									objectvalidator.ConflictsWith(path.Expressions{
++										path.MatchRelative().AtParent().AtName("account_provision"),
++										path.MatchRelative().AtParent().AtName("default_behavior"),
++									}...),
++								},
+ 							},
+ 						},
+ 						MarkdownDescription: `Indicates that a connector should perform the provisioning. This object has no fields.` + "\n" +
+@@ -245,62 +302,109 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 							`  - defaultBehavior` + "\n" +
+ 							`  - account` + "\n" +
+ 							`  - deleteAccount`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"delegated_provision": schema.SingleNestedAttribute{
++						Optional: true,
+ 						Computed: true,
+ 						Attributes: map[string]schema.Attribute{
+ 							"app_id": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The AppID of the entitlement to delegate provisioning to.`,
+ 							},
+ 							"entitlement_id": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The ID of the entitlement we are delegating provisioning to.`,
+ 							},
+ 						},
+ 						Description: `This provision step indicates that we should delegate provisioning to the configuration of another app entitlement. This app entitlement does not have to be one from the same app, but MUST be configured as a proxy binding leading into this entitlement.`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"external_ticket_provision": schema.SingleNestedAttribute{
++						Optional: true,
+ 						Computed: true,
+ 						Attributes: map[string]schema.Attribute{
+ 							"app_id": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The appId field.`,
+ 							},
+ 							"connector_id": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The connectorId field.`,
+ 							},
+ 							"external_ticket_provisioner_config_id": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The externalTicketProvisionerConfigId field.`,
+ 							},
+ 							"instructions": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `This field indicates a text body of instructions for the provisioner to indicate.`,
+ 							},
+ 						},
+ 						Description: `This provision step indicates that we should check an external ticket to provision this entitlement`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"manual_provision": schema.SingleNestedAttribute{
++						Optional: true,
+ 						Computed: true,
+ 						Attributes: map[string]schema.Attribute{
+ 							"instructions": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `This field indicates a text body of instructions for the provisioner to indicate.`,
+ 							},
+ 							"provisioner_assignment": schema.SingleNestedAttribute{
+ 								Computed: true,
++								Optional: true,
+ 								Attributes: map[string]schema.Attribute{
+ 									"app_owner_provisioner": schema.SingleNestedAttribute{
+ 										Computed: true,
++										Optional: true,
+ 										Attributes: map[string]schema.Attribute{
+ 											"allow_reassignment": schema.BoolAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												Description: `Whether the provisioner can reassign the task.`,
+ 											},
+ 											"fallback_user_ids": schema.ListAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												ElementType: types.StringType,
+ 												Description: `Fallback user IDs if no app owners are found.`,
+ 											},
+@@ -309,13 +413,16 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									},
+ 									"entitlement_owner_provisioner": schema.SingleNestedAttribute{
+ 										Computed: true,
++										Optional: true,
+ 										Attributes: map[string]schema.Attribute{
+ 											"allow_reassignment": schema.BoolAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												Description: `Whether the provisioner can reassign the task.`,
+ 											},
+ 											"fallback_user_ids": schema.ListAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												ElementType: types.StringType,
+ 												Description: `Fallback user IDs if no entitlement owners are found.`,
+ 											},
+@@ -324,18 +431,22 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									},
+ 									"expression_provisioner": schema.SingleNestedAttribute{
+ 										Computed: true,
++										Optional: true,
+ 										Attributes: map[string]schema.Attribute{
+ 											"allow_reassignment": schema.BoolAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												Description: `Whether the provisioner can reassign the task.`,
+ 											},
+ 											"expressions": schema.ListAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												ElementType: types.StringType,
+ 												Description: `The CEL expressions to evaluate.`,
+ 											},
+ 											"fallback_user_ids": schema.ListAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												ElementType: types.StringType,
+ 												Description: `Fallback user IDs if expression evaluation yields no users.`,
+ 											},
+@@ -344,21 +455,26 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									},
+ 									"group_provisioner": schema.SingleNestedAttribute{
+ 										Computed: true,
++										Optional: true,
+ 										Attributes: map[string]schema.Attribute{
+ 											"allow_reassignment": schema.BoolAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												Description: `Whether the provisioner can reassign the task.`,
+ 											},
+ 											"app_group_id": schema.StringAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												Description: `The app group ID (entitlement ID).`,
+ 											},
+ 											"app_id": schema.StringAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												Description: `The app ID containing the group.`,
+ 											},
+ 											"fallback_user_ids": schema.ListAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												ElementType: types.StringType,
+ 												Description: `Fallback user IDs if no group members are found.`,
+ 											},
+@@ -367,13 +483,16 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									},
+ 									"manager_provisioner": schema.SingleNestedAttribute{
+ 										Computed: true,
++										Optional: true,
+ 										Attributes: map[string]schema.Attribute{
+ 											"allow_reassignment": schema.BoolAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												Description: `Whether the provisioner can reassign the task.`,
+ 											},
+ 											"fallback_user_ids": schema.ListAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												ElementType: types.StringType,
+ 												Description: `Fallback user IDs if no manager is found.`,
+ 											},
+@@ -382,13 +501,16 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									},
+ 									"user_provisioner": schema.SingleNestedAttribute{
+ 										Computed: true,
++										Optional: true,
+ 										Attributes: map[string]schema.Attribute{
+ 											"allow_reassignment": schema.BoolAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												Description: `Whether the provisioner can reassign the task.`,
+ 											},
+ 											"user_ids": schema.ListAttribute{
+ 												Computed:    true,
++												Optional:    true,
+ 												ElementType: types.StringType,
+ 												Description: `The user IDs to assign as provisioners.`,
+ 											},
+@@ -408,31 +530,80 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 							},
+ 							"user_ids": schema.ListAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								ElementType: types.StringType,
+ 								MarkdownDescription: `An array of users that are required to provision during this step.` + "\n" +
+ 									` Deprecated: Use assignee field instead for dynamic provisioner assignment.`,
+ 							},
+ 						},
+ 						Description: `Manual provisioning indicates that a human must intervene for the provisioning of this step.`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"multi_step": schema.StringAttribute{
+ 						CustomType:  jsontypes.NormalizedType{},
+ 						Computed:    true,
++						Optional:    true,
+ 						Description: `MultiStep indicates that this provision step has multiple steps to process. Parsed as JSON.`,
++						Validators: []validator.String{
++							stringvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"unconfigured_provision": schema.SingleNestedAttribute{
+ 						Computed:    true,
++						Optional:    true,
+ 						Description: `The UnconfiguredProvision message.`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"webhook_provision": schema.SingleNestedAttribute{
++						Optional: true,
+ 						Computed: true,
+ 						Attributes: map[string]schema.Attribute{
+ 							"webhook_id": schema.StringAttribute{
+ 								Computed:    true,
++								Optional:    true,
+ 								Description: `The ID of the webhook to call for provisioning.`,
+ 							},
+ 						},
+ 						Description: `This provision step indicates that a webhook should be called to provision this entitlement.`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
++							}...),
++						},
+ 					},
+ 				},
+ 				MarkdownDescription: `ProvisionPolicy is a oneOf that indicates how a provision step should be processed.` + "\n" +
+@@ -572,6 +743,17 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 							},
+ 						},
+ 						Description: `This provision step indicates that account lifecycle action should be called to provision this entitlement.`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"connector_provision": schema.SingleNestedAttribute{
+ 						Optional: true,
+@@ -595,6 +777,11 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 										Computed:    true,
+ 										Optional:    true,
+ 										Description: `The DoNotSave message.`,
++										Validators: []validator.Object{
++											objectvalidator.ConflictsWith(path.Expressions{
++												path.MatchRelative().AtParent().AtName("save_to_vault"),
++											}...),
++										},
+ 									},
+ 									"save_to_vault": schema.SingleNestedAttribute{
+ 										Computed: true,
+@@ -608,6 +795,11 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 											},
+ 										},
+ 										Description: `The SaveToVault message.`,
++										Validators: []validator.Object{
++											objectvalidator.ConflictsWith(path.Expressions{
++												path.MatchRelative().AtParent().AtName("do_not_save"),
++											}...),
++										},
+ 									},
+ 									"schema_id": schema.StringAttribute{
+ 										Computed:    true,
+@@ -620,6 +812,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									`This message contains a oneof named storage_type. Only a single field of the following list may be set at a time:` + "\n" +
+ 									`  - saveToVault` + "\n" +
+ 									`  - doNotSave`,
++								Validators: []validator.Object{
++									objectvalidator.ConflictsWith(path.Expressions{
++										path.MatchRelative().AtParent().AtName("default_behavior"),
++										path.MatchRelative().AtParent().AtName("delete_account"),
++									}...),
++								},
+ 							},
+ 							"default_behavior": schema.SingleNestedAttribute{
+ 								Computed: true,
+@@ -633,6 +831,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									},
+ 								},
+ 								Description: `The DefaultBehavior message.`,
++								Validators: []validator.Object{
++									objectvalidator.ConflictsWith(path.Expressions{
++										path.MatchRelative().AtParent().AtName("account_provision"),
++										path.MatchRelative().AtParent().AtName("delete_account"),
++									}...),
++								},
+ 							},
+ 							"delete_account": schema.SingleNestedAttribute{
+ 								Computed: true,
+@@ -645,6 +849,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 									},
+ 								},
+ 								Description: `The DeleteAccount message.`,
++								Validators: []validator.Object{
++									objectvalidator.ConflictsWith(path.Expressions{
++										path.MatchRelative().AtParent().AtName("account_provision"),
++										path.MatchRelative().AtParent().AtName("default_behavior"),
++									}...),
++								},
+ 							},
+ 						},
+ 						MarkdownDescription: `Indicates that a connector should perform the provisioning. This object has no fields.` + "\n" +
+@@ -655,10 +865,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 							`  - deleteAccount`,
+ 						Validators: []validator.Object{
+ 							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
+ 								path.MatchRelative().AtParent().AtName("delegated_provision"),
+ 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+ 								path.MatchRelative().AtParent().AtName("manual_provision"),
+ 								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+ 								path.MatchRelative().AtParent().AtName("webhook_provision"),
+ 							}...),
+ 						},
+@@ -680,10 +892,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 						Description: `This provision step indicates that we should delegate provisioning to the configuration of another app entitlement. This app entitlement does not have to be one from the same app, but MUST be configured as a proxy binding leading into this entitlement.`,
+ 						Validators: []validator.Object{
+ 							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
+ 								path.MatchRelative().AtParent().AtName("connector_provision"),
+ 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+ 								path.MatchRelative().AtParent().AtName("manual_provision"),
+ 								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+ 								path.MatchRelative().AtParent().AtName("webhook_provision"),
+ 							}...),
+ 						},
+@@ -715,10 +929,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 						Description: `This provision step indicates that we should check an external ticket to provision this entitlement`,
+ 						Validators: []validator.Object{
+ 							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
+ 								path.MatchRelative().AtParent().AtName("connector_provision"),
+ 								path.MatchRelative().AtParent().AtName("delegated_provision"),
+ 								path.MatchRelative().AtParent().AtName("manual_provision"),
+ 								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+ 								path.MatchRelative().AtParent().AtName("webhook_provision"),
+ 							}...),
+ 						},
+@@ -881,10 +1097,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 						Description: `Manual provisioning indicates that a human must intervene for the provisioning of this step.`,
+ 						Validators: []validator.Object{
+ 							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
+ 								path.MatchRelative().AtParent().AtName("connector_provision"),
+ 								path.MatchRelative().AtParent().AtName("delegated_provision"),
+ 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+ 								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+ 								path.MatchRelative().AtParent().AtName("webhook_provision"),
+ 							}...),
+ 						},
+@@ -896,10 +1114,12 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 						Description: `MultiStep indicates that this provision step has multiple steps to process. Parsed as JSON.`,
+ 						Validators: []validator.String{
+ 							stringvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
+ 								path.MatchRelative().AtParent().AtName("connector_provision"),
+ 								path.MatchRelative().AtParent().AtName("delegated_provision"),
+ 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+ 								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+ 								path.MatchRelative().AtParent().AtName("webhook_provision"),
+ 							}...),
+ 						},
+@@ -908,6 +1128,17 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 						Computed:    true,
+ 						Optional:    true,
+ 						Description: `The UnconfiguredProvision message.`,
++						Validators: []validator.Object{
++							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
++								path.MatchRelative().AtParent().AtName("connector_provision"),
++								path.MatchRelative().AtParent().AtName("delegated_provision"),
++								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
++								path.MatchRelative().AtParent().AtName("manual_provision"),
++								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("webhook_provision"),
++							}...),
++						},
+ 					},
+ 					"webhook_provision": schema.SingleNestedAttribute{
+ 						Optional: true,
+@@ -921,11 +1152,13 @@ func (r *CustomAppEntitlementResource) Schema(ctx context.Context, req resource.
+ 						Description: `This provision step indicates that a webhook should be called to provision this entitlement.`,
+ 						Validators: []validator.Object{
+ 							objectvalidator.ConflictsWith(path.Expressions{
++								path.MatchRelative().AtParent().AtName("action_provision"),
+ 								path.MatchRelative().AtParent().AtName("connector_provision"),
+ 								path.MatchRelative().AtParent().AtName("delegated_provision"),
+ 								path.MatchRelative().AtParent().AtName("external_ticket_provision"),
+ 								path.MatchRelative().AtParent().AtName("manual_provision"),
+ 								path.MatchRelative().AtParent().AtName("multi_step"),
++								path.MatchRelative().AtParent().AtName("unconfigured_provision"),
+ 							}...),
+ 						},
+ 					},
+@@ -1143,6 +1376,11 @@ func (r *CustomAppEntitlementResource) Update(ctx context.Context, req resource.
+ 		return
+ 	}
+ 
++	resp.Diagnostics.Append(pruneCustomAppEntitlementPolicyOneofs(ctx, req.Config, data)...)
++	if resp.Diagnostics.HasError() {
++		return
++	}
++
+ 	request, requestDiags := data.ToOperationsC1APIAppV1AppEntitlementsUpdateRequest(ctx)
+ 	resp.Diagnostics.Append(requestDiags...)
+ 

--- a/patches/README.md
+++ b/patches/README.md
@@ -8,6 +8,19 @@ Unified-diff patches applied by `make gen` after Speakeasy generates the SDK + p
 2. `git diff <files...> > patches/NN-<short-description>.patch` (or use `git format-patch` from a commit so the message header is preserved).
 3. Confirm a clean re-run: `make gen` should succeed end-to-end.
 
+**Cut the diff against the regen baseline, not against your branch.** `git diff` on a
+branch that already carries an earlier attempt produces hunks whose pre-image is your own
+intermediate commit — text Speakeasy never emits. Those patches apply and reverse cleanly
+within the branch and fail on the next real regen, which nothing in CI exercises: CI runs
+`make generate` (tfplugindocs), never `make gen`. Patches 04 and 05 shipped this way and
+had to be re-cut.
+
+**A hand-written file in a generated directory belongs in `.genignore`, not in a patch.**
+Do not write a patch that re-creates it. `.genignore` already preserves `provider.go`,
+`token_source.go` and `extra_sdk_options.go` that way; `update_mask.go` joins them. A
+new-file hunk is a bet that regen deletes the file, and it fails with "already exists" the
+moment that bet is wrong.
+
 ## Removing a patch
 
 When upstream Speakeasy resolves the regression and we bump the pinned CLI past the fix:


### PR DESCRIPTION
Squire (Opus 5):

Rebased onto current `main` (post-#241) and re-scoped. Covers **IGA-3483** (ProvisionPolicy oneof collision) and **IGA-3382** (writable `deprovisioner_policy`), plus update masks on `app_resource` and `vault`.

## What changed in this rebase

`main` moved to `caec5b7d`, the revert of #238. This branch was cut directly on top of #238, so the entire conflict surface was 5 files and `main`'s change to every one of them was "undo #238".

Resolved on the merits rather than taking either side wholesale:

- **Kept** the shared mask machinery in `update_mask.go` (`updateMaskForChanges`, `updateMaskForSerializedFields`, `plannedValueIsSet`) and this PR's own `appResourceUpdateMaskForChanges` / `vaultUpdateMask`. These are the only helpers with live call sites.
- **Dropped** `functionUpdateMask*` and `accessReviewUpdateMask*`. #241 removed their call sites; carrying them forward would be dead code and a partial re-land of reverted work.
- **Dropped** `patches/04` and `patches/05`. They stay deleted.
- `TestUpdateRequestsSetUpdateMask` now asserts only on `access_review_template` (patch 03, still live) plus the `app_resource` / `vault` call sites. It deliberately does not assert on `function` or `access_review`.

Patch numbering keeps the 04/05 gap on purpose so it does not collide with the `04-app-entitlement-empty-search-results.patch` proposed in #244.

## Generated vs hand-maintained — why some of this is a patch and some is not

Per-file, from `.genignore` and `.speakeasy/gen.lock` (`generatedFiles:` begins at line 14204):

| File | Verdict | Evidence | Carried as |
|---|---|---|---|
| `app_resource_resource.go` | generated | `gen.lock:14417` | `patches/06` |
| `vault_resource.go` | generated | `gen.lock:14852` | `patches/06` |
| `custom_app_entitlement_resource.go` | generated | `gen.lock:14456` | `patches/07` |
| `app_entitlement_resource.go` | hand-maintained | in `.genignore`, absent from `gen.lock` | direct edit |
| `update_mask.go` | hand-maintained | added to `.genignore` | direct edit |
| `provision_policy_oneof.go` | hand-maintained | added to `.genignore` | direct edit |
| `*_test.go` | hand-maintained | `.genignore` glob | direct edit |

A hand-written file in a generated directory belongs in `.genignore`, not in a patch — a new-file hunk is a bet that regen deletes the file, and it fails with "already exists" the moment that bet is wrong. The three generated files genuinely need patches 06/07 or the fixes are wiped on the next `make gen`.

Note: `files.gen` is stale and disagrees with `gen.lock` on every resource file. Use `gen.lock`.

## Verification

Run and passing:

- `go build ./...`, full `go test ./...` — green.
- `golangci-lint run ./internal/provider/...` — 0 issues.
- `make generate` (tfplugindocs) — regenerates to exactly the committed docs, no drift.
- `make verify-pagination`, `make check` — clean (only the pre-existing TODO-marker warnings in vendored SDK files).
- All five patches reverse-apply cleanly against the tree, so each patch matches the change it claims to carry.

**Provider schema comparison, released `1.4.0` vs this branch**, for the four touched resources (`terraform providers schema -json` on both, flattened per attribute):

```
added: 0   removed: 0   changed: 55
all 55: computed-only -> computed + optional
sample: conductorone_custom_app_entitlement.deprovisioner_policy
```

Every schema change is `deprovisioner_policy.*` becoming writable, which is exactly the IGA-3382 intent. No attribute added, removed, or made required. `app_resource`, `vault` and `app_entitlement` have zero schema delta — the update-mask work is request-layer only, and the oneof `ConflictsWith` validators do not alter schema shape. Computed-only to computed+optional is the safe direction for an existing statefile: the attributes stay Computed, so state carries forward and a config that does not set them plans clean.

### Not verified

- **No live-tenant run.** `CONDUCTORONE_CLIENT_ID` / `_CLIENT_SECRET` / `_SERVER_URL` are not available in the environment this was prepared in, so `make testacc` and any real `terraform plan` / `apply` did not run.
- **The apply-based statefile upgrade test was therefore not performed.** The schema comparison above is static evidence and does not exercise the read/write conversion path — `merge()`, the oneof prune, or the mask actually sent on the wire. A perpetual diff can also originate in Read failing to populate a field, which schema comparison cannot detect.
- `make gen` was not run end-to-end: `speakeasy` is not installed and the Makefile pins `speakeasyVersion: 1.762.0` behind a hard version-equality gate. Whether patches 06/07 apply against a fresh regen baseline is therefore unproven here.

### One open question for review

#241's stated reason was "we need to do some re-work upstream in apigw first." That is a backend gap, and #238 touched `function` and `access_review` while this PR touches `app_resource`, `vault` and `custom_app_entitlement` — disjoint resources. But the OpenAPI spec advertises `updateMask` for all of them equally, so spec presence does not prove apigw handles these three correctly. If the required apigw rework was about update-mask handling generally rather than access-review campaign lifecycle semantics specifically, this PR inherits the same blocker and should wait.
