### PR TITLE
fix: re-cut patches 01 and 02 so make gen completes on a fresh baseline

### DIFF
--- a/patches/01-actorobjectpermissions-boolnull.patch
+++ b/patches/01-actorobjectpermissions-boolnull.patch
@@ -1,119 +1,114 @@
-commit a089aa9e3afaa233d37b437b5bc1d8fc88e12901
+commit a089aa9e3afaa233d37b437b5bc1d8fc88e12901 (re-cut 2026-08-14)
 Author: Brandon High <759848+highb@users.noreply.github.com>
 Date:   Tue May 5 16:28:29 2026 -0700
 
-    Apply BoolNull else-branch patch on ActorObjectPermissions flatten
-    
-    Mirrors the patch from PR #210 (originally Robert's #184). Speakeasy
-    1.761.10 still emits "if X != nil { ... }" without an else for nullable
-    nested structs that get flattened into top-level Computed attributes,
-    leaving framework Bool fields at Unknown instead of Null.
+    Apply BoolNull else-branch patch on ObjectPermissions flatten
+
+    Speakeasy 1.762.0 still emits "if X != nil { ... }" without an else for
+    nullable nested structs that get flattened into top-level Computed
+    attributes, leaving framework Bool fields at Unknown instead of Null.
     terraform-plugin-framework rejects this with "invalid result object
-    after apply" — the failure shape on this regen's acceptance tests.
-    
+    after apply" -- the failure shape on this regen's acceptance tests.
+
     Patches the 6 files referenced by TestNullableNestedStructsHaveElseBranch
     plus the CreateManuallyManagedAppResourceResponse variant whose parent
-    type (AppResource, not AppResourceView) lacks ActorObjectPermissions
-    entirely.
-    
-    Also rewrites KNOWN_ISSUES.md per PR #210:
-    - The plan-only/Computed regression (the original "do not upgrade"
-      warning) was fixed upstream in speakeasy-api/speakeasy#1770 (merged
-      2025-12-17) and is no longer present in 1.761.10. Marked as fixed.
-    - Documents the still-present nullable-nested-struct flatten regression
-      that this commit hand-patches, with the patch shape and tripwire
-      pointer for future regens.
-    
+    type (AppResource, not AppResourceView) lacks the field entirely.
+
+    Re-cut against the current insulator spec: the API renamed the field
+    from actorObjectPermissions to objectPermissions since this patch was
+    last cut, so every hunk's context (resp.ActorObjectPermissions.*) no
+    longer matched a fresh `make gen` output and apply-patches aborted here
+    on every regen. Same fix, new field name (resp.ObjectPermissions.*);
+    no behavior change beyond following the rename.
+
     IGA-1704 Patch 2.
-    
-    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 diff --git a/internal/provider/access_review_data_source_sdk.go b/internal/provider/access_review_data_source_sdk.go
-index 7de5d95e..b44b5715 100644
+index 0000000..0000000 100644
 --- a/internal/provider/access_review_data_source_sdk.go
 +++ b/internal/provider/access_review_data_source_sdk.go
-@@ -547,6 +547,11 @@ func (r *AccessReviewDataSourceModel) RefreshFromSharedAccessReviewView(ctx cont
+@@ -587,6 +587,11 @@
  				}
  			}
- 			r.Read = types.BoolPointerValue(resp.ActorObjectPermissions.Read)
+ 			r.Read = types.BoolPointerValue(resp.ObjectPermissions.Read)
 +		} else {
 +			r.Delete = types.BoolNull()
 +			r.Edit = types.BoolNull()
 +			r.Extra = nil
 +			r.Read = types.BoolNull()
  		}
- 		r.CreatedByUserPath = types.StringPointerValue(resp.CreatedByUserPath)
  		r.PolicyPath = types.StringPointerValue(resp.PolicyPath)
+ 	}
 diff --git a/internal/provider/access_review_resource_sdk.go b/internal/provider/access_review_resource_sdk.go
-index 6e8902e3..8ce3851f 100644
+index 0000000..0000000 100644
 --- a/internal/provider/access_review_resource_sdk.go
 +++ b/internal/provider/access_review_resource_sdk.go
-@@ -586,6 +586,11 @@ func (r *AccessReviewResourceModel) RefreshFromSharedAccessReviewView(ctx contex
+@@ -626,6 +626,11 @@
  				}
  			}
- 			r.Read = types.BoolPointerValue(resp.ActorObjectPermissions.Read)
+ 			r.Read = types.BoolPointerValue(resp.ObjectPermissions.Read)
 +		} else {
 +			r.Delete = types.BoolNull()
 +			r.Edit = types.BoolNull()
 +			r.Extra = nil
 +			r.Read = types.BoolNull()
  		}
- 		r.CreatedByUserPath = types.StringPointerValue(resp.CreatedByUserPath)
  		r.PolicyPath = types.StringPointerValue(resp.PolicyPath)
+ 	}
 diff --git a/internal/provider/app_entitlement_data_source_sdk.go b/internal/provider/app_entitlement_data_source_sdk.go
-index 17b96074..604a77c4 100644
+index 0000000..0000000 100644
 --- a/internal/provider/app_entitlement_data_source_sdk.go
 +++ b/internal/provider/app_entitlement_data_source_sdk.go
-@@ -561,6 +561,11 @@ func (r *AppEntitlementDataSourceModel) RefreshFromSharedAppEntitlementView(ctx
+@@ -588,6 +588,11 @@
  			}
  		}
- 		r.Read = types.BoolPointerValue(resp.ActorObjectPermissions.Read)
+ 		r.Read = types.BoolPointerValue(resp.ObjectPermissions.Read)
 +	} else {
 +		r.Delete = types.BoolNull()
 +		r.Edit = types.BoolNull()
 +		r.Extra = nil
 +		r.Read = types.BoolNull()
  	}
- 	diags.Append(r.RefreshFromSharedAppEntitlement(ctx, resp.AppEntitlement)...)
  
+ 	return diags
 diff --git a/internal/provider/app_resource_data_source_sdk.go b/internal/provider/app_resource_data_source_sdk.go
-index b7626bc4..e64f2c9c 100644
+index 0000000..0000000 100644
 --- a/internal/provider/app_resource_data_source_sdk.go
 +++ b/internal/provider/app_resource_data_source_sdk.go
-@@ -82,6 +82,11 @@ func (r *AppResourceDataSourceModel) RefreshFromSharedAppResourceView(ctx contex
+@@ -113,6 +113,11 @@
  				}
  			}
- 			r.Read = types.BoolPointerValue(resp.ActorObjectPermissions.Read)
+ 			r.Read = types.BoolPointerValue(resp.ObjectPermissions.Read)
 +		} else {
 +			r.Delete = types.BoolNull()
 +			r.Edit = types.BoolNull()
 +			r.Extra = nil
 +			r.Read = types.BoolNull()
  		}
- 		diags.Append(r.RefreshFromSharedAppResource(ctx, resp.AppResource)...)
+ 	}
  
 diff --git a/internal/provider/app_resource_resource_sdk.go b/internal/provider/app_resource_resource_sdk.go
-index 87ea3866..94fcb864 100644
+index 0000000..0000000 100644
 --- a/internal/provider/app_resource_resource_sdk.go
 +++ b/internal/provider/app_resource_resource_sdk.go
-@@ -102,6 +102,11 @@ func (r *AppResourceResourceModel) RefreshFromSharedAppResourceView(ctx context.
+@@ -133,6 +133,11 @@
  				}
  			}
- 			r.Read = types.BoolPointerValue(resp.ActorObjectPermissions.Read)
+ 			r.Read = types.BoolPointerValue(resp.ObjectPermissions.Read)
 +		} else {
 +			r.Delete = types.BoolNull()
 +			r.Edit = types.BoolNull()
 +			r.Extra = nil
 +			r.Read = types.BoolNull()
  		}
- 		diags.Append(r.RefreshFromSharedAppResource(ctx, resp.AppResource)...)
+ 	}
  
-@@ -124,6 +129,12 @@ func (r *AppResourceResourceModel) RefreshFromSharedCreateManuallyManagedAppReso
+@@ -149,6 +154,12 @@
  			return diags
  		}
  
 +		// CreateManuallyManagedAppResourceResponse returns AppResource, not AppResourceView,
-+		// so ActorObjectPermissions fields are not available. Set them to null explicitly.
++		// so ObjectPermissions fields are not available. Set them to null explicitly.
 +		r.Delete = types.BoolNull()
 +		r.Edit = types.BoolNull()
 +		r.Extra = nil
@@ -122,18 +117,18 @@ index 87ea3866..94fcb864 100644
  
  	return diags
 diff --git a/internal/provider/custom_app_entitlement_resource_sdk.go b/internal/provider/custom_app_entitlement_resource_sdk.go
-index fd04a515..8a15e000 100644
+index 0000000..0000000 100644
 --- a/internal/provider/custom_app_entitlement_resource_sdk.go
 +++ b/internal/provider/custom_app_entitlement_resource_sdk.go
-@@ -504,6 +504,11 @@ func (r *CustomAppEntitlementResourceModel) RefreshFromSharedAppEntitlementView(
+@@ -528,6 +528,11 @@
  				}
  			}
- 			r.Read = types.BoolPointerValue(resp.ActorObjectPermissions.Read)
+ 			r.Read = types.BoolPointerValue(resp.ObjectPermissions.Read)
 +		} else {
 +			r.Delete = types.BoolNull()
 +			r.Edit = types.BoolNull()
 +			r.Extra = nil
 +			r.Read = types.BoolNull()
  		}
- 		diags.Append(r.RefreshFromSharedAppEntitlement(ctx, resp.AppEntitlement)...)
+ 	}
  

--- a/patches/02-deleted-at-on-nested-resources.patch
+++ b/patches/02-deleted-at-on-nested-resources.patch
@@ -1,5 +1,5 @@
 From: Brandon High <759848+highb@users.noreply.github.com>
-Date: Wed May 13 2026
+Date: Wed May 13 2026 (re-cut Thu Aug 14 2026)
 Subject: [PATCH] Re-add deleted_at to nested resource schemas (IGA-1774)
 
 Speakeasy's x-speakeasy-soft-delete-property handling has a known bug on
@@ -26,6 +26,14 @@ these entity-root types. Files:
   - connector_owner_entitlement_resource.go       (latent same-class bug, found by v1.4.0 smoke test)
   - connector_owner_user_resource.go              (latent same-class bug, found by v1.4.0 smoke test)
   - directory_resource.go                         (latent same-class bug)
+
+Re-cut against the current insulator spec: six of the seven hunks still
+applied with a line-offset only. directory_resource.go's did not --
+the nested "directory view" attribute map reordered/changed shape
+enough that the created_at/directory_account_filter_all context this
+hunk searched for no longer exists; the fix (insert deleted_at after
+created_at) is unchanged, just re-anchored against the new neighbor
+(merge_config).
 
 The patch will go away when upstream Speakeasy fixes
 x-speakeasy-soft-delete-property propagation to nested struct uses;
@@ -118,16 +126,16 @@ index 1af3af88..ff7b0646 100644
  						Computed:    true,
  						Description: `The department which the user belongs to in the organization.`,
 diff --git a/internal/provider/directory_resource.go b/internal/provider/directory_resource.go
-index da606749..5ba19b1f 100644
+index 0000000..0000000 100644
 --- a/internal/provider/directory_resource.go
 +++ b/internal/provider/directory_resource.go
-@@ -103,6 +103,9 @@ func (r *DirectoryResource) Schema(ctx context.Context, req resource.SchemaReque
+@@ -95,6 +95,9 @@
  							"created_at": schema.StringAttribute{
  								Computed: true,
  							},
 +							"deleted_at": schema.StringAttribute{
 +								Computed: true,
 +							},
- 							"directory_account_filter_all": schema.SingleNestedAttribute{
- 								Computed:    true,
- 								Description: `The DirectoryAccountFilterAll message.`,
+ 							"merge_config": schema.SingleNestedAttribute{
+ 								Computed: true,
+ 								Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
## What's broken

`make gen` cannot complete on `main` today. On a clean checkout with the pinned Speakeasy CLI (1.762.0) and a live regen against the current insulator spec, `apply-patches` aborts at the *first* patch:

```
Applying patches/01-actorobjectpermissions-boolnull.patch
error: patch failed: internal/provider/access_review_data_source_sdk.go:547
...
ERROR: failed to apply patches/01-actorobjectpermissions-boolnull.patch
make[1]: *** [Makefile:102: apply-patches] Error 1
make: *** [Makefile:40: gen] Error 2
```

This is independent of #239 and of patches 04/05 (those no longer exist on `main` — #241 deleted them along with #238 on 2026-08-11). Patch 01 fails because the API renamed `actorObjectPermissions` → `objectPermissions` on `AccessReviewView`, `AppEntitlementView`, `AppResourceView`, and `CustomAppEntitlement`'s view since the patch was cut — every hunk's context (`resp.ActorObjectPermissions.*`) no longer matches. The underlying Speakeasy flatten regression (missing `else` branch, framework `Bool` fields left `Unknown` instead of `Null`) is still present; the field just moved.

Patch 02 also fails on `directory_resource.go` specifically — the nested "directory view" attribute map reordered enough that the patch's anchor context (`created_at` / `directory_account_filter_all`) no longer exists. Same fix (insert `deleted_at` after `created_at`), re-anchored against the new neighbor (`merge_config`). The other six files patch 02 touches still applied with an offset only.

## What this PR does

Re-cuts `patches/01-actorobjectpermissions-boolnull.patch` and `patches/02-deleted-at-on-nested-resources.patch` against the current generator output. Same fixes, same shape, just re-anchored to match what Speakeasy 1.762.0 + the live insulator spec produce today. Patch 03 needed no changes (applies clean with an offset).

## Verified

Clean checkout of this branch, pinned `speakeasy 1.762.0`, real network regen (no cached artifacts):

```
$ make gen
...
SDK for terraform generated successfully ✓
make apply-patches
Applying patches/01-actorobjectpermissions-boolnull.patch
Applying patches/02-deleted-at-on-nested-resources.patch
Applying patches/03-access-review-template-update-mask.patch
make vendor
...
$ echo $?
0
```

## Found while verifying, not fixed here

`make gen` exiting 0 does not mean the resulting tree compiles — `make gen`'s own `check` step only builds `./tools/check`, not the full module. A real `go build ./...` on the freshly-generated + patched tree fails:

```
internal/provider/app_entitlement_resource.go:1084:3: unknown field AppEntitlement in struct literal of type shared.UpdateAppEntitlementRequest
internal/provider/app_entitlement_resource_sdk.go:118:24: r.ProvisionPolicy.ActionProvision undefined (...)
internal/provider/app_entitlement_resource_sdk.go:144:24: r.ProvisionPolicy.ConnectorProvision undefined (...)
```

`app_entitlement_resource.go` and `app_entitlement_resource_sdk.go` are both in `.genignore` (hand-maintained since #222), and they reference `ProvisionPolicy` oneof arm names (`ActionProvision`, `ConnectorProvision`, etc.) and an `AppEntitlement` field that the live spec has since renamed (`Action`, `Connector`, ...; `Entitlement`). ~486 stale references in `app_entitlement_resource_sdk.go` alone. The currently-committed tree builds fine (verified: exit 0) because it was checked in against an older regen where those names still matched — this only surfaces on a genuinely fresh regen. Not part of this PR's scope; flagging so it isn't mistaken for something this fix addresses.

## Not addressed here

#239 carries its own patch re-cut (04-07) plus three unrelated fixes (entitlement pair, update-mask sweep). That PR predates #241 (which reverted #238, deleting patches 04/05 and the update-mask infra they protected) and is currently `CONFLICTING` against `main` for that reason. This PR does not touch it or depend on it.