### PR TITLE
Allow empty app entitlement search results (IGA-707)

### DIFF
--- a/internal/provider/app_entitlement_data_source_empty_result_test.go
+++ b/internal/provider/app_entitlement_data_source_empty_result_test.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/conductorone/terraform-provider-conductorone/internal/sdk"
+	"github.com/conductorone/terraform-provider-conductorone/internal/sdk/models/shared"
+)
+
+func TestAppEntitlementDataSourceEmptySearchResult(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("request method = %s, want %s", r.Method, http.MethodPost)
+		}
+		if r.URL.Path != "/api/v1/search/entitlements" {
+			t.Errorf("request path = %s, want /api/v1/search/entitlements", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"list":[],"expanded":[],"nextPageToken":"","facets":null}`))
+	}))
+	defer server.Close()
+
+	client := sdk.New(sdk.WithServerURL(server.URL))
+	result, err := client.AppEntitlementSearch.Search(context.Background(), &shared.AppEntitlementSearchServiceSearchRequest{})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("search status = %d, want %d", result.StatusCode, http.StatusOK)
+	}
+
+	data := &AppEntitlementDataSourceModel{}
+	diagnostics := data.RefreshFromSharedAppEntitlementSearchServiceSearchResponse(context.Background(), result.AppEntitlementSearchServiceSearchResponse)
+	if diagnostics.HasError() {
+		t.Fatalf("empty search response produced diagnostics: %v", diagnostics)
+	}
+	if data.NextPageToken.ValueString() != "" {
+		t.Fatalf("next_page_token = %q, want empty string", data.NextPageToken.ValueString())
+	}
+}

--- a/internal/provider/app_entitlement_data_source_sdk.go
+++ b/internal/provider/app_entitlement_data_source_sdk.go
@@ -537,15 +537,12 @@ func (r *AppEntitlementDataSourceModel) RefreshFromSharedAppEntitlementSearchSer
 	var diags diag.Diagnostics
 
 	if resp != nil {
-		if len(resp.List) == 0 {
-			diags.AddError("Unexpected response from API", "Missing response body array data.")
-			return diags
-		}
+		if len(resp.List) > 0 {
+			diags.Append(r.RefreshFromSharedAppEntitlementView(ctx, &resp.List[0])...)
 
-		diags.Append(r.RefreshFromSharedAppEntitlementView(ctx, &resp.List[0])...)
-
-		if diags.HasError() {
-			return diags
+			if diags.HasError() {
+				return diags
+			}
 		}
 
 		r.NextPageToken = types.StringPointerValue(resp.NextPageToken)

--- a/patches/04-app-entitlement-empty-search-results.patch
+++ b/patches/04-app-entitlement-empty-search-results.patch
@@ -1,0 +1,25 @@
+diff --git a/internal/provider/app_entitlement_data_source_sdk.go b/internal/provider/app_entitlement_data_source_sdk.go
+index bd1ecb50..51e9923c 100644
+--- a/internal/provider/app_entitlement_data_source_sdk.go
++++ b/internal/provider/app_entitlement_data_source_sdk.go
+@@ -537,15 +537,12 @@ func (r *AppEntitlementDataSourceModel) RefreshFromSharedAppEntitlementSearchSer
+ 	var diags diag.Diagnostics
+ 
+ 	if resp != nil {
+-		if len(resp.List) == 0 {
+-			diags.AddError("Unexpected response from API", "Missing response body array data.")
+-			return diags
+-		}
+-
+-		diags.Append(r.RefreshFromSharedAppEntitlementView(ctx, &resp.List[0])...)
++		if len(resp.List) > 0 {
++			diags.Append(r.RefreshFromSharedAppEntitlementView(ctx, &resp.List[0])...)
+ 
+-		if diags.HasError() {
+-			return diags
++			if diags.HasError() {
++				return diags
++			}
+ 		}
+ 
+ 		r.NextPageToken = types.StringPointerValue(resp.NextPageToken)


### PR DESCRIPTION
Squire (openai/gpt-5.6-terra): Treat a successful empty entitlement search as zero results instead of a provider error.

Validation:
- `go test -v -count=1 ./internal/provider -run TestAppEntitlementDataSourceEmptySearchResult`
- `make pre-commit`
- `go test -count=1 -run '^$' ./...`