### PR TITLE
docs(patches): audit which post-regen patches can be retired upstream

### DIFF
--- a/patches/AUDIT-2026-08-14.md
+++ b/patches/AUDIT-2026-08-14.md
@@ -1,0 +1,178 @@
+# Patch audit — 2026-08-14
+
+Proposal, not a merge candidate. Audits every `patches/*.patch` to decide which can be
+retired by fixing generation upstream instead of re-cutting the patch on every regen.
+
+Generated with `speakeasy` 1.762.0 (the pin in `.speakeasy/workflow.yaml`), against the
+live spec from `insulator.conductor.one` on 2026-08-14, from `main` @ `3c640eed`.
+
+## Bottom line
+
+**No patch can be safely deleted today.** Patch `07` has a proven overlay replacement,
+but adopting it needs one API answer first (below).
+
+The larger finding is that the patch chain is not the whole regen tax — see
+"Regen breaks the build" below, which is the higher-priority cleanup.
+
+## Classification
+
+Each patch is classified by which layer actually owns the defect. The distinction matters
+because an overlay entry is a legitimate fix for one class and a workaround for another,
+and the two look identical in a diff. Overlay avoids the re-cutting tax but not the
+divergence tax, and `overlay.yaml` already carries 187 targets.
+
+- **SPEC-WRONG** — the OpenAPI description misdescribes a correctly-behaving API.
+  Overlay or a spec change is the right layer; the patch can die.
+- **SERVER-WRONG** — the API behaves incorrectly and the client compensates. Overlay only
+  stops *this* consumer tripping over it; the bug remains for the `cone` CLI, the UI, and
+  direct API callers.
+- **CLIENT-LOGIC-WRONG** — neither spec nor server is at fault; the generator emits
+  avoidable code.
+
+| Patch | Fixes / symptom if dropped | Class | Correct layer | Deletable |
+|---|---|---|---|---|
+| `01-actorobjectpermissions-boolnull` | Generator emits `if X != nil {…}` with no `else` for nullable nested structs flattened into Computed attrs; Bool fields stay Unknown; framework rejects apply with "invalid result object after apply" | CLIENT-LOGIC-WRONG | Speakeasy upstream | No |
+| `02-deleted-at-on-nested-resources` | `x-speakeasy-soft-delete-property` strips `deleted_at` from the nested schema but keeps it on the Go struct; "Struct defines fields not found in object: deleted_at" at plan/apply | CLIENT-LOGIC-WRONG | Speakeasy upstream | No |
+| `03-access-review-template-update-mask` | apigw returns `PermissionDenied` when the field mask names `signature_config`, even for a nil/unchanged value | SERVER-WRONG | apigw | No |
+| `04-app-entitlement-empty-search-results` | Singular data source errors "Missing response body array data" on a valid empty search result | SPEC-WRONG in origin | Speakeasy upstream — no lossless spec fix exists | No |
+| `06-app-resource-and-vault-update-mask` | `app_resource` / `vault` updates send no update mask | SERVER-WRONG | apigw + provider helper | No |
+| `07-custom-app-entitlement-deprovisioner-writable` | `deprovisioner_policy` generates `Computed`-only so it cannot be set; oneof arms miss `ConflictsWith` | SPEC-WRONG | overlay / spec | Not yet — one API answer blocks it |
+
+Patches `04`, `06`, `07` are not on `main`; they live on their originating PR branches.
+
+## Regen breaks the build before any patch is applied
+
+Committed `main` builds clean. A fresh regen against today's live spec does not:
+
+```
+internal/provider/app_entitlement_resource.go:1084:3: unknown field AppEntitlement
+    in struct literal of type shared.UpdateAppEntitlementRequest
+internal/provider/app_entitlement_resource_sdk.go:118:24: r.ProvisionPolicy.ActionProvision
+    undefined (type *types.ProvisionPolicy has no field or method ActionProvision)
+```
+
+Both files are listed in `.genignore`, so they are hand-maintained and never regenerated,
+while the types they consume are. The spec renamed `UpdateAppEntitlementRequest`'s body
+field to `entitlement` and reshaped `ProvisionPolicy`'s oneof arms; these two frozen files
+still reference the old shape.
+
+This is an unrecorded manual step that behaves exactly like a patch but is not in
+`patches/`, not in this README, and not covered by any tripwire test. It also means the
+invariant tests cannot run after a regen — the build fails first, so
+`patches/README.md`'s removal procedure ("delete the patch, re-run `make gen`, confirm the
+tripwire still passes") cannot currently be followed.
+
+## `04` — the plural-read hypothesis
+
+The idea was that an annotation could make the app-entitlement search data source generate
+as a collection read instead of a singular-entity read, so the bad guard is never emitted.
+
+**The lever exists.** The search operation is already mapped to *both* forms:
+
+```yaml
+# /api/v1/search/entitlements
+x-speakeasy-entity-operation:
+  terraform-datasource:
+    - App Entitlement#read      # singular -> emits list[0] + the guard
+    - App Entitlements#read     # plural   -> emits a correct collection read
+```
+
+Same response type, same regen, two readers: the plural one
+(`app_entitlements_data_source_sdk.go`) has no guard and no `list[0]`, just a range loop.
+The generator is fully capable of the correct form.
+
+**But the fix is not free.** Removing the singular mapping regenerates cleanly and the
+guard disappears — because `app_entitlement_data_source.go` and its `_sdk.go` no longer
+exist. It deletes the `conductorone_app_entitlement` data source outright. That is a
+breaking change for anyone using it, so it is a workaround with a capability cost, not a
+fix.
+
+Rebinding the singular data source to the real GET-by-id operation
+(`c1.api.app.v1.AppEntitlements.Get`, currently `terraform-datasource: null`) is also
+breaking: the data source's schema is a search-by-filters interface, and GET-by-id would
+replace those inputs with `app_id` + `id`.
+
+So patch `04` is the least-bad option today. The durable fix is upstream: Speakeasy should
+not emit a hard error for an empty list on a read whose operation is annotated
+`x-speakeasy-pagination` and returns a collection.
+
+## `07` — proven overlay replacement, blocked on one API answer
+
+`CreateAppEntitlementRequestInput` lists `provisionPolicy` but not `deprovisionerPolicy`.
+The update path takes the whole `AppEntitlement` body, which does carry it. Speakeasy
+drives Optional-ness off the create schema, so the siblings generate differently:
+`provision_policy` → `Optional: true`, `deprovisioner_policy` → `Computed: true` only.
+
+Proposed overlay entry:
+
+```yaml
+  - target: $["components"]["schemas"]["c1.api.app.v1.CreateAppEntitlementRequestInput"]["properties"]
+    update:
+      deprovisionerPolicy:
+        allOf:
+          - $ref: '#/components/schemas/c1.api.policy.v1.ProvisionPolicy'
+          - x-speakeasy-name-override: deprovisionerPolicy
+```
+
+Regenerating with it produces exactly the change class patch `07` hand-applies:
+
+```
+ "deprovisioner_policy": schema.SingleNestedAttribute{
+ 	Computed: true,
++	Optional: true,
+```
+
+`Optional:` occurrences go 75 → 132 and `ConflictsWith` 8 → 14 in
+`custom_app_entitlement_resource.go`, including the arms patch `07` adds by hand
+(`action_provision`, `device_placement_provision`, `unconfigured_provision`).
+
+This adds capability rather than removing any, so it is a genuine fix rather than a
+workaround. Three caveats:
+
+1. **Blocking: does `CreateAppEntitlement` actually accept `deprovisionerPolicy`?** The
+   overlay also wires the create path to send it, which patch `07` does not do. If the API
+   accepts it, the spec is simply under-describing the endpoint and this is correct. If the
+   API ignores it on create, this ships a silently dropped field — worse than the patch.
+2. The Go type changes from `tfTypes.DeprovisionerPolicy` to
+   `tfTypes.CreateAppEntitlementRequestDeprovisionerPolicy`. The `tfsdk:` tag is unchanged,
+   so state shape should be unaffected, but that is not proven.
+3. This is a superset of patch `07`, not an equivalent: the patch changes only the schema,
+   the overlay changes schema and request construction.
+
+Separately, patch `07` no longer applies to a fresh regen (`git apply --check` fails at
+`custom_app_entitlement_resource.go:153`).
+
+## `03` — do not "fix" this with an overlay
+
+Gating on field-mask presence rather than an actual write is an apigw defect:
+`validateSignatureConfigFeatureGate` returns `PermissionDenied` whenever the mask names
+`signature_config`, even when the value is nil and unchanged.
+
+The blunt overlay fix — `x-speakeasy-ignore` on `signatureConfig` — would stop the 403 by
+removing the ability to manage signature config in Terraform at all. That is a functional
+regression dressed as a fix and is not proposed.
+
+The deeper cause is the hardcoded mask listing every writable field, so every update names
+every gated field and any field-gated feature 403s for tenants lacking it. Computing the
+mask from what actually changed (as `appResourceUpdateMaskForChanges` does) retires the
+class for the provider with no lost functionality. The server bug still needs fixing for
+every other consumer.
+
+## `06` — not self-contained
+
+`appResourceUpdateMaskForChanges` and `vaultUpdateMask` live in
+`internal/provider/update_mask.go`, which is **not** a generated file (absent from
+`gen.lock`'s `generatedFiles`). So patch `06` is really a hand-written helper file plus a
+patch wiring it into two generated files. No annotation makes Speakeasy compute a mask
+from a state/plan diff, so overlay cannot produce either half.
+
+## Suggested next steps
+
+1. Repair the two `.genignore`d files against the current spec, and add a check so a regen
+   that breaks them fails loudly instead of silently.
+2. Answer the `CreateAppEntitlement` / `deprovisionerPolicy` question; if yes, adopt the
+   overlay entry and retire patch `07`.
+3. File the apigw defects behind `03` and `06`.
+4. File the three Speakeasy defects behind `01`, `02`, and `04`.
+5. Add a trailing newline to `overlay.yaml` — appending to it with `cat >>` currently
+   corrupts the last entry.


### PR DESCRIPTION
Squire (claude-opus-5): **Proposal, not a merge candidate for the 1.5.0 release.** This is an audit to be adopted (or rejected) on its own terms, not merged alongside the release regeneration. It changes no generated code and no `overlay.yaml` entry — it adds one document.

## Why

Every patch in `patches/` is a permanent tax: re-cut on every generation drift, and a chain that stops applying blocks a release. This audits all six against a real regen on the pinned Speakeasy 1.762.0 to separate re-cut tax from load-bearing fixes.

## Conclusion

**No patch can be safely deleted today.** Details, evidence, and the per-patch classification are in `patches/AUDIT-2026-08-14.md`.

Each patch is classified by which layer actually owns the defect — spec, server, or generator — because an overlay entry is a genuine fix for one class and a workaround for another, and the two look identical in a diff.

| Patch | Class | Correct layer | Deletable |
|---|---|---|---|
| `01-actorobjectpermissions-boolnull` | CLIENT-LOGIC-WRONG | Speakeasy upstream | No |
| `02-deleted-at-on-nested-resources` | CLIENT-LOGIC-WRONG | Speakeasy upstream | No |
| `03-access-review-template-update-mask` | SERVER-WRONG | apigw | No |
| `04-app-entitlement-empty-search-results` | SPEC-WRONG in origin | Speakeasy upstream | No |
| `06-app-resource-and-vault-update-mask` | SERVER-WRONG | apigw + provider helper | No |
| `07-custom-app-entitlement-deprovisioner-writable` | SPEC-WRONG | overlay / spec | Not yet |

## The finding worth reading first, and it is not about patches

Committed `main` builds clean. A fresh regen against the current spec **does not**:

```
internal/provider/app_entitlement_resource.go:1084:3: unknown field AppEntitlement
    in struct literal of type shared.UpdateAppEntitlementRequest
internal/provider/app_entitlement_resource_sdk.go:118:24: r.ProvisionPolicy.ActionProvision
    undefined (type *types.ProvisionPolicy has no field or method ActionProvision)
```

Both files are in `.genignore` — hand-maintained, never regenerated — while the types they consume are. The spec renamed `UpdateAppEntitlementRequest`'s body field to `entitlement` and reshaped `ProvisionPolicy`'s oneof arms.

This is an unrecorded manual step with the same cost as a patch and none of the visibility. It also blocks the tripwire tests, so `patches/README.md`'s removal procedure ("delete the patch, re-run `make gen`, confirm the tripwire still passes") cannot currently be followed.

## `04` — the plural-read idea holds mechanically, but the fix is not free

The lever exists and is already in the spec: the search operation maps to **both** `App Entitlement#read` (singular, emits `list[0]` and the bad guard) and `App Entitlements#read` (plural, emits a correct range loop, no guard).

Removing the singular mapping regenerates cleanly and the guard disappears — because `app_entitlement_data_source.go` and its `_sdk.go` cease to exist. It deletes the `conductorone_app_entitlement` data source outright.

Rebinding to the real GET-by-id operation is also breaking: the data source is a search-by-filters interface, and GET-by-id would replace those inputs with `app_id` + `id`.

So patch `04` is the least-bad option today; the durable fix is upstream.

## `07` — proven overlay replacement, blocked on one API question

`CreateAppEntitlementRequestInput` omits `deprovisionerPolicy` while the update path accepts it, so Speakeasy generates the field `Computed`-only. Adding it to the create input via overlay regenerates `Computed: true, Optional: true` plus the missing `ConflictsWith` arms — exactly patch `07`'s change class, `Optional:` 75 → 132 and `ConflictsWith` 8 → 14.

**Blocking question for anyone who knows the API: does `CreateAppEntitlement` actually accept `deprovisionerPolicy`?** The overlay also wires the create path to send it, which patch `07` does not. If the API accepts it, the spec is under-describing the endpoint and the overlay is correct. If not, it ships a silently dropped field — worse than the patch.

Separately: patch `07` no longer applies to a fresh regen.

## `03` — the tempting overlay fix is a functional regression

`x-speakeasy-ignore` on `signatureConfig` would stop the 403 by removing the ability to manage signature config in Terraform at all. Not proposed. The real defect is apigw gating on field-mask presence rather than an actual write; computing the mask from what changed retires the class for the provider with no lost functionality.

## Verification

- `speakeasy` 1.762.0, matching the pin; the pin was not edited.
- `TestPaginationUsesAssignment` and `TestPlanOnlyFieldsAreComputed` pass on committed `main`. This PR changes no Go code, so both remain green.
- They could **not** be run against a regenerated tree — the build failure above precedes test execution.

## Not verified

- Whether `CreateAppEntitlement` accepts `deprovisionerPolicy` (blocking, above).
- State compatibility of the `tfTypes.DeprovisionerPolicy` → `CreateAppEntitlementRequestDeprovisionerPolicy` rename.
- Whether patches `01`/`02` still apply to a fresh regen (only `07` was checked).
- Whether upstream Speakeasy issues already exist for the three defects described.
- Any runtime or acceptance testing; all evidence is generated-code diffs.